### PR TITLE
WIP: Add descriptor key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ unstable = []
 default = []
 
 [dependencies]
-bitcoin = "0.23"
+bitcoin = {git = "https://github.com/sgeisler/rust-bitcoin/", branch = "2020-06-bip32-derive-more"}
 
 [dependencies.serde]
 version = "1.0"

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -81,15 +81,15 @@ pub enum Descriptor<Pk: MiniscriptKey> {
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
 pub enum DescriptorKey {
     PukKey(bitcoin::PublicKey),
-    XPub(DescriptorXPub),
+    XPub(DescriptorXKey<ExtendedPubKey>),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
-pub struct DescriptorXPub {
-    source: Option<([u8; 4], DerivationPath)>,
-    xpub: bitcoin::util::bip32::ExtendedPubKey,
-    derivation_path: DerivationPath,
-    is_wildcard: bool,
+pub struct DescriptorXKey<K> {
+    pub source: Option<([u8; 4], DerivationPath)>,
+    pub xpub: K,
+    pub derivation_path: DerivationPath,
+    pub is_wildcard: bool,
 }
 
 #[derive(Debug)]
@@ -168,7 +168,7 @@ impl FromStr for DescriptorKey {
 
             let (xpub, derivation_path, is_wildcard) = Self::parse_xpub_deriv(key_deriv)?;
 
-            Ok(DescriptorKey::XPub(DescriptorXPub {
+            Ok(DescriptorKey::XPub(DescriptorXKey {
                 source: Some((origin_id, origin_path)),
                 xpub,
                 derivation_path,
@@ -180,7 +180,7 @@ impl FromStr for DescriptorKey {
             Ok(DescriptorKey::PukKey(pk))
         } else {
             let (xpub, derivation_path, is_wildcard) = Self::parse_xpub_deriv(s)?;
-            Ok(DescriptorKey::XPub(DescriptorXPub {
+            Ok(DescriptorKey::XPub(DescriptorXKey {
                 source: None,
                 xpub,
                 derivation_path,
@@ -239,7 +239,7 @@ impl DescriptorKey {
             DescriptorKey::PukKey(pk) => DescriptorKey::PukKey(*pk),
             DescriptorKey::XPub(xpub) => {
                 if xpub.is_wildcard {
-                    DescriptorKey::XPub(DescriptorXPub {
+                    DescriptorKey::XPub(DescriptorXKey {
                         source: xpub.source.clone(),
                         xpub: xpub.xpub.clone(),
                         derivation_path: (&xpub.derivation_path)

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -247,6 +247,25 @@ impl MiniscriptKey for DescriptorKey {
     }
 }
 
+impl ToPublicKey for DescriptorKey {
+    fn to_public_key(&self) -> PublicKey {
+        match self {
+            DescriptorKey::PukKey(pk) => *pk,
+            DescriptorKey::XPub(xpub) => {
+                let ctx = Secp256k1::verification_only();
+                xpub.xpub
+                    .derive_pub(&ctx, &xpub.derivation_path)
+                    .expect("Shouldn't fail, only normal derivations")
+                    .public_key
+            }
+        }
+    }
+
+    fn hash_to_hash160(hash: &Self::Hash) -> hash160::Hash {
+        *hash
+    }
+}
+
 impl<Pk: MiniscriptKey> Descriptor<Pk> {
     /// Convert a descriptor using abstract keys to one using specific keys
     /// This will panic if translatefpk returns an uncompressed key when

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -46,6 +46,7 @@ pub use self::satisfied_constraints::Error as InterpreterError;
 pub use self::satisfied_constraints::SatisfiedConstraint;
 pub use self::satisfied_constraints::SatisfiedConstraints;
 pub use self::satisfied_constraints::Stack;
+use bitcoin::util::bip32::DerivationPath;
 
 /// Script descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -66,6 +67,17 @@ pub enum Descriptor<Pk: MiniscriptKey> {
     Wsh(Miniscript<Pk, Segwitv0>),
     /// P2SH-P2WSH with Segwitv0 context
     ShWsh(Miniscript<Pk, Segwitv0>),
+}
+
+pub enum DescriptorKey {
+    PukKey(bitcoin::PublicKey),
+    XPub(DescriptorXPub),
+}
+
+pub struct DescriptorXPub {
+    source: Option<([u8; 4], DerivationPath)>,
+    xpub: bitcoin::util::bip32::ExtendedPubKey,
+    derivation_path: DerivationPath,
 }
 
 impl<Pk: MiniscriptKey> Descriptor<Pk> {


### PR DESCRIPTION
Keys in script descriptors can come in a wide variety of formats:
* simple public or private keys
* xpub, xpriv

all with or without origin information.

The xpub/xpriv variety can also allow further derivations by ending its derivation path with `*`. This PR allows all of theses keys to be represented and `Descriptors` to be derived. Deriving a descriptor leaves all keys as they are _except_ wildcard keys. They are derived using a supplied path resulting in a `Descriptor` without wildcard keys/with the respective derived keys. 

For example to derive the first 5 addresses of a 2-of-3 multisig wallet with one static key (for some reason) and two derived keys the resulting code would look like this:

```rust
et policy = "thresh(2,\
pk(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*),\
pk(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/2/*),\
pk(03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8))";

let descriptor = Descriptor::Wsh(
    policy
        .parse::<Concrete<DescriptorKey>>()
        .unwrap()
        .compile()
        .unwrap(),
);

let base_deriv = DerivationPath::from(Vec::<ChildNumber>::new());

for child in base_deriv.normal_children().take(5) {
    println!(
        "child {}: {}",
        child,
        descriptor
            .derive(child.as_ref())
            .address(Network::Regtest)
            .unwrap()
    );
}
```

This would generate
```
child m/0: bcrt1qyaqn5jangsa8jt92n6evj7fzhwkttsh7prn6vaswhhekmr78a8vqedj0uw
child m/1: bcrt1q2m3lqldudthalkhukt595zv79awvdy2mmvkrnlck030fhccpyd5sqpt0cq
child m/2: bcrt1qjulpj2f0cfftvc3ae4jcfdrdfzvh58tf9vahj4uaqwgl2sfuc49ql0wc9h
child m/3: bcrt1qsvlq87een4pk76jq394j4tuc6058j93zy2nnjqj9m84am82ksw0qc5tjf7
child m/4: bcrt1qnz7346r9u7utq4srct06hrsqkcgy6paglx3qdcy9p8upzl30xt8qsex053
```

As in the title, this is still heavily WIP, I mainly want to get concept feedback.