### PR TITLE
policy: Corrected an inverted documentation for `Older` and `After`

### DIFF
--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -38,9 +38,9 @@ use {Error, MiniscriptKey};
 pub enum Policy<Pk: MiniscriptKey> {
     /// A public key which must sign to satisfy the descriptor
     Key(Pk),
-    /// A relative locktime restriction
-    After(u32),
     /// An absolute locktime restriction
+    After(u32),
+    /// A relative locktime restriction
     Older(u32),
     /// A SHA256 whose preimage must be provided to satisfy the descriptor
     Sha256(sha256::Hash),

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -39,9 +39,9 @@ pub enum Policy<Pk: MiniscriptKey> {
     Trivial,
     /// Signature and public key matching a given hash is required
     KeyHash(Pk::Hash),
-    /// A relative locktime restriction
-    After(u32),
     /// An absolute locktime restriction
+    After(u32),
+    /// A relative locktime restriction
     Older(u32),
     /// A SHA256 whose preimage must be provided to satisfy the descriptor
     Sha256(sha256::Hash),


### PR DESCRIPTION
A small typo I noticed on docs.rs