### PR TITLE
Optimize policy compilation for N-of-N tresholds

### DIFF
--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1153,6 +1153,7 @@ mod tests {
 
     use miniscript::{satisfy, Segwitv0};
     use policy::Liftable;
+    use script_num_size;
     use BitcoinSig;
     use DummyKey;
 
@@ -1376,6 +1377,46 @@ mod tests {
                 vec![],
             ]
         );
+    }
+
+    #[test]
+    fn compile_thresh() {
+        let (keys, _) = pubkeys_and_a_sig(21);
+
+        // Up until 20 keys, thresh should be compiled to a multi no matter the value of k
+        for k in 1..4 {
+            let small_thresh: BPolicy = policy_str!(
+                "thresh({},pk({}),pk({}),pk({}))",
+                k,
+                keys[0],
+                keys[1],
+                keys[2]
+            );
+            let small_thresh_ms: SegwitMiniScript = small_thresh.compile().unwrap();
+            let small_thresh_ms_expected =
+                ms_str!("multi({},{},{},{})", k, keys[0], keys[1], keys[2]);
+            assert_eq!(small_thresh_ms, small_thresh_ms_expected);
+        }
+
+        // Above 20 keys, thresh is compiled to a combination of and()s if it's a N of N,
+        // and to a ms thresh otherwise.
+        // k = 1 (or 2) does not compile, see https://github.com/rust-bitcoin/rust-miniscript/issues/114
+        for k in &[10, 15, 21] {
+            let pubkeys: Vec<Concrete<bitcoin::PublicKey>> =
+                keys.iter().map(|pubkey| Concrete::Key(*pubkey)).collect();
+            let big_thresh = Concrete::Threshold(*k, pubkeys);
+            let big_thresh_ms: SegwitMiniScript = big_thresh.compile().unwrap();
+            // N * (PUSH + pubkey + CHECKSIG + ADD + SWAP) + N EQUAL
+            assert_eq!(
+                big_thresh_ms.script_size(),
+                keys.len() * (1 + 33 + 3) + script_num_size(*k) + 1 - 2 // minus one SWAP and one ADD
+            );
+            let big_thresh_ms_expected = ms_str!(
+                "thresh({},pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}),s:pk({}))",
+                k, keys[0], keys[1], keys[2], keys[3], keys[4], keys[5], keys[6], keys[7], keys[8], keys[9],keys[10], keys[11], keys[12], keys[13], keys[14], keys[15], keys[16], keys[17], keys[18], keys[19], keys[20]
+            );
+            assert_eq!(big_thresh_ms, big_thresh_ms_expected);
+        }
     }
 }
 


### PR DESCRIPTION
This adds a special case to the compilation of the `thresh(k, subs)` policy to
miniscript: when all sub-policies are keys and k == subs.len() this
compiles to a combination of and()s instead of a thresh().


The first commit adds some tests for the policy->miniscript compilation of different combinations of `k` and pubkeys under the `thresh()` policy.

The second commit special cases `k == pubkeys.len()` (when `> 20`) to eventually produce slightly more efficient Bitcoin Script:
```
<pubkey1> CHECKSIGVERIFY <pubkey2> CHECKSIGVERIFY  <pubkey3> CHECKSIGVERIFY ... <pubkeyN> CHECKSIG
```
Instead of
```
<pubkey1> CHECKSIG SWAP <pubkey2> CHECKSIG ADD SWAP  <pubkey3> CHECKSIG ADD SWAP ... <pubkeyN> CHECKSIG ADD N EQUAL
```

As mentioned by sipa on IRC we can also special-case `k==1` to a combination of `or()`s, but I left a `FIXME` as I intend to do this in a follow-up (can also push a commit here, as you prefer).