### PR TITLE
Add missing whitespace to rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub trait MiniscriptKey:
     /// The associated Hash type with the publicKey
     type Hash: Clone + Eq + Ord + str::FromStr + fmt::Display + fmt::Debug + hash::Hash;
 
-    ///Converts an object to PublicHash
+    /// Converts an object to PublicHash
     fn to_pubkeyhash(&self) -> Self::Hash;
 }
 


### PR DESCRIPTION
Super trivial first time PR to `rust-miniscript` :) 

Fix whitspace issue in function rustdoc, add missing whitespace character.