### PR TITLE
Add Trivial and Unsatisfiable types to Concrete Policy

### DIFF
--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -161,8 +161,11 @@ struct CompilerExtData {
 
 impl Property for CompilerExtData {
     fn from_true() -> Self {
-        // only used in casts. should never be computed directly
-        unreachable!();
+        CompilerExtData {
+            branch_prob: None,
+            sat_cost: 0.0,
+            dissat_cost: None,
+        }
     }
 
     fn from_false() -> Self {
@@ -811,6 +814,12 @@ where
     }
 
     match *policy {
+        Concrete::Unsatisfiable => {
+            insert_wrap!(AstElemExt::terminal(Terminal::False));
+        }
+        Concrete::Trivial => {
+            insert_wrap!(AstElemExt::terminal(Terminal::True));
+        }
         Concrete::Key(ref pk) => {
             insert_wrap!(AstElemExt::terminal(Terminal::PkH(
                 pk.to_pubkeyhash().clone()

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -37,6 +37,10 @@ use {Error, MiniscriptKey};
 /// to assist the compiler
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Policy<Pk: MiniscriptKey> {
+    /// Unsatisfiable
+    Unsatisfiable,
+    /// Trivially satisfiable
+    Trivial,
     /// A public key which must sign to satisfy the descriptor
     Key(Pk),
     /// An absolute locktime restriction
@@ -147,6 +151,8 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         Q: MiniscriptKey,
     {
         match *self {
+            Policy::Unsatisfiable => Ok(Policy::Unsatisfiable),
+            Policy::Trivial => Ok(Policy::Trivial),
             Policy::Key(ref pk) => translatefpk(pk).map(Policy::Key),
             Policy::Sha256(ref h) => Ok(Policy::Sha256(h.clone())),
             Policy::Hash256(ref h) => Ok(Policy::Hash256(h.clone())),
@@ -192,7 +198,9 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     fn check_timelocks_helper(&self) -> TimeLockInfo {
         // timelocks[csv_h, csv_t, cltv_h, cltv_t, combination]
         match *self {
-            Policy::Key(_)
+            Policy::Unsatisfiable
+            | Policy::Trivial
+            | Policy::Key(_)
             | Policy::Sha256(_)
             | Policy::Hash256(_)
             | Policy::Ripemd160(_)
@@ -284,6 +292,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     ///
     pub fn is_safe_nonmalleable(&self) -> (bool, bool) {
         match *self {
+            Policy::Unsatisfiable | Policy::Trivial => (true, true),
             Policy::Key(_) => (true, true),
             Policy::Sha256(_)
             | Policy::Hash256(_)
@@ -330,6 +339,8 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
 impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Policy::Unsatisfiable => f.write_str("UNSATISFIABLE()"),
+            Policy::Trivial => f.write_str("TRIVIAL()"),
             Policy::Key(ref pk) => write!(f, "pk({:?})", pk),
             Policy::After(n) => write!(f, "after({})", n),
             Policy::Older(n) => write!(f, "older({})", n),
@@ -371,6 +382,8 @@ impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
 impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Policy::Unsatisfiable => f.write_str("UNSATISFIABLE"),
+            Policy::Trivial => f.write_str("TRIVIAL"),
             Policy::Key(ref pk) => write!(f, "pk({})", pk),
             Policy::After(n) => write!(f, "after({})", n),
             Policy::Older(n) => write!(f, "older({})", n),
@@ -468,6 +481,8 @@ where
             }
         }
         match (frag_name, top.args.len() as u32) {
+            ("UNSATISFIABLE", 0) => Ok(Policy::Unsatisfiable),
+            ("TRIVIAL", 0) => Ok(Policy::Trivial),
             ("pk", 1) => expression::terminal(&top.args[0], |pk| Pk::from_str(pk).map(Policy::Key)),
             ("after", 1) => {
                 let num = expression::terminal(&top.args[0], |x| expression::parse_num(x))?;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -141,6 +141,8 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
         // involving combination of timelocks and heightlocks
         self.check_timelocks()?;
         let ret = match *self {
+            Concrete::Unsatisfiable => Semantic::Unsatisfiable,
+            Concrete::Trivial => Semantic::Trivial,
             Concrete::Key(ref pk) => Semantic::KeyHash(pk.to_pubkeyhash()),
             Concrete::After(t) => Semantic::After(t),
             Concrete::Older(t) => Semantic::Older(t),


### PR DESCRIPTION
It makes sense to have a corresponding type for trivial/unsatisfiable in the concrete compiler as it's quite useful when generating Policy from a higher level. This patch attempts to add these types.

See IRC:

```
[9/30/20 18:00] <jeremyrubin> Would anyone be opposed to adding a Unsatisifiable and Satisfied type to Policy. Context: sometimes when writing generic code to generate conditions, a component want to return "no further condition required" or "we don't want to authorize ever on this path". This is, of course, emulable with a higher order wrapper around the Policy type, but it seems simpler to add the types into Policy itself. There would be some identities, e.g.
[9/30/20 18:00] <jeremyrubin> , Or([A, Unsat]) = A, Or([A, Sat]) = Sat, And([A, Unsat]) = Unsat, And([A, Sat]) = A
[9/30/20 18:07] <jeremyrubin> In particular, it's inconvenient if these types don't exist because it's tricky to propagate an Unsat/Sat type -- e.g., if I construct an And tree, and one branch is Unsat, I should return an Unsat. But if I was expecting to plug the result of that And tree clause into e.g., an Or, I need to always manually handle these identities rather than having them baked in to Policy
[9/30/20 18:14] <jeremyrubin> In theory, you *could* use Sha256(0) to represent an unsatisfiable, and PK(G) to represent satisfiable BTW
[9/30/20 18:14] <jeremyrubin> maybe PK(G) is not good given the miniscript key abstraction
[9/30/20 18:15] <jeremyrubin> perhaps sha256(0) and sha256(H(0)) are better constants
[9/30/20 18:16] <jeremyrubin> My point is then I guess more that it might be nice to define these as constants and add a special compilation pass that simplifies them when detected.



[10/1/20 05:33] <andytoshi> jeremyrubin: i thought we had such a thing
[10/1/20 05:34] <andytoshi> https://docs.rs/miniscript/1.0.0/miniscript/policy/semantic/enum.Policy.html unsatisfiable and trivial
[10/1/20 05:35] <andytoshi> oh they don't exist on the compiler policy type
[10/1/20 05:36] <andytoshi> yeah i think they probably should, it does make composeability hard for those if there is no initial/terminal object
```

