### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,16 @@
 - Added scriptContext(`Legacy` and `Segwitv0`) to Miniscript. 
 - Miscellenous fixes against DoS attacks for heavy nesting.
 - Fixed Satisfier bug that caused flipping of arguments for `and_v` and `and_n` and `and_or`
+
+# 2.0.0 - Oct 1, 2020
+
+- Changes to the miniscript type system to detect an invalid
+  combination of heightlocks and timelocks
+     - Lift miniscripts can now fail. Earlier it always succeded and gave
+       the resulting Semantic Policy
+     - Compiler will not compile policies that contain atleast one
+     unspendable path
+- Added support for Descriptor PublicKeys(xpub)
+- Added a generic psbt finalizer and extractor
+- Updated Satisfaction API for checking time/height before setting satisfaction
+- Added a policy entailment API for more miniscript semantic analysisq

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 repository = "https://github.com/apoelstra/miniscript"
 description = "Miniscript: a subset of Bitcoin Script designed for analysis"


### PR DESCRIPTION


Includes the following commits:

03b94d9 Switch Policy to use BTreeMap instead of HashMap
67ea9e1 Update Psbt satisfier to for timelocks
31810ae Added psbt satisfy for after/older
78a56be Added PsbtInputSatisfier
eae1634 Merge pull request #119 from sanket1729/psbt_fixes
c2b1fa7 Added psbt example
099d68a Implemnented finalizer
a71025f Added pkh lookup for psbt
5c16f2f Rework error types. Complete extractor
0fb11c0 Added from impl interpreter error
8e7410b Decouple satisfaction API
70f5490 Helper for conversion of bitcoinsig from rawsig
e0fc688 Merge pull request #131 from darosior/descriptor_publickey
28158a3 fuzz: add a fuzz target for descriptor parsing
5ac4112 descriptor: allow "raw" pubkeys to have origin
367eda0 Make Descriptors derivable
021880e Implement ToPublicKey for DescriptorKey
35d2ab7 Implement MiniscriptKey for DescriptorKey
71add82 descriptor: Add an abstracted DescriptorPublicKey
7236b57 Merge pull request #138 from JeremyRubin/add-trivial-unsat-concrete
efd971b Merge pull request #127 from darosior/legacy_do_have_scriptcode
cda6b5e Merge pull request #70 from LNP-BP/f-iterators
da6ae53 Add Trivial and Unsatisfiable types to Concrete Policy
c1a54ec Merge pull request #137 from darosior/psbt_satisfy_everyone
f36e4f9 Merge pull request #121 from sanket1729/heightlocks
a662105 Update signer
d0a4f1a Update lift trait
9098986 Added Timelock info
6af9cf7 Merge pull request #136 from darosior/nit_doc
726df9b psbt: generalize the satisfier to all MiniscriptKey s
416f3ff [doc] psbt: bip is bip-0174
3ce5ccc Refactor has_verify_form -> has_free_verify
aac0178 Update README: Remove stability section
b9f61b1 Merge pull request #133 from LNP-BP/fix/instrelem
b836032 Iterator improvements according to review
d241544 Simplification of instruction iterators use by descriptors
3515c6a Merge pull request #130 from rust-bitcoin/2020-09--bitcoin-0.24
7e5d1e8 ci: fix rust 1.22 build
0718263 update rust-bitcoin to 0.24.0
8582c17 descriptors: define script_codefor legacy outputs
deab3c2 Merge pull request #129 from tcharding/whitespace-char
61dab52 Add missing whitespace to rustdoc
b9d7d6a Miniscript iterators: applying PR review suggestions
6edc698 Miniscript iterators
a3370b7 Merge pull request #108 from rust-bitcoin/sanket1729-update_readme
ffdd320 Merge pull request #120 from sanket1729/more_cltv_csv_fixes
b0103a7 More csv ctlv fixes
efd3321 Merge pull request #125 from sanket1729/master
c2cfb12 Merge pull request #113 from darosior/optimize_nofn
1e7fe04 Merge pull request #118 from sanket1729/policy_entail
963305c Support for github actions
f934e73 Update comments for trvial functions
de8e121 Added max recursion depth to policy entailment
eb91472 Added policy entailment
0c69589 Semantic analysis now uses only thresh
51dcc7e Merge pull request #123 from darosior/script_code
283676e method
24fc18b descriptor: add a method to get the scriptCode as per bip-0143
688b0a8 compilation in the case of an N-of-N
b45ac46 policy/compiler: test the different threshpolicy compilation
87a47e2 Merge pull request #112 from darosior/doc_older_interchange
5e5b0b6 miniscript: doc: fix Older/After interchange in doccomments
e98989c Merge pull request #110 from darosior/csv_doc
c41ef95 policy: doc: Older is CSV, After is CLTV
d8b59ce Merge pull request #104 from stevenroose/serde
1b20194 Add serde impls for policy::Semantic and policy::Concrete
fe25f5b Replace serde impl for Miniscript and Descriptor with macro
aa0c092 Add serde_string_impl_pk macro for serde impls
956c5f0 Update README: Remove stability section