### PR TITLE
Add Cargo.toml Flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ trace = []
 unstable = []
 default = []
 use-serde = ["bitcoin/use-serde", "serde"]
+rand = ["bitcoin/rand"]
 
 [dependencies]
 bitcoin = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ compiler = []
 trace = []
 unstable = []
 default = []
+use-serde = ["bitcoin/use-serde", "serde"]
 
 [dependencies]
 bitcoin = "0.24"


### PR DESCRIPTION
This adds pass-through flags for enabling rand on rust-bitcoin and enabling serde on rust-bitcoin.