### PR TITLE
Check for segwit standardness limits

### DIFF
--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -85,7 +85,7 @@ fn main() {
     // Check weight for witness satisfaction cost ahead of time.
     // 4(scriptSig length of 0) + 1(witness stack size) + 106(serialized witnessScript)
     // + 73*2(signature length + signatures + sighash bytes) + 1(dummy byte) = 258
-    assert_eq!(my_descriptor.max_satisfaction_weight(), 258);
+    assert_eq!(my_descriptor.max_satisfaction_weight().unwrap(), 258);
 
     // Observe the script properties, just for fun
     assert_eq!(

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -619,12 +619,12 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
     /// transaction. Assumes all signatures are 73 bytes, including push opcode
     /// and sighash suffix. Includes the weight of the VarInts encoding the
     /// scriptSig and witness stack length.
-    pub fn max_satisfaction_weight(&self) -> usize {
+    pub fn max_satisfaction_weight(&self) -> Option<usize> {
         fn varint_len(n: usize) -> usize {
             bitcoin::VarInt(n as u64).len()
         }
 
-        match *self {
+        Some(match *self {
             Descriptor::Bare(ref ms) => {
                 let scriptsig_len = ms.max_satisfaction_size(1);
                 4 * (varint_len(scriptsig_len) + scriptsig_len)
@@ -653,7 +653,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
                 4 +  // scriptSig length byte
                     varint_len(script_size) +
                     script_size +
-                    varint_len(ms.max_satisfaction_witness_elements()) +
+                    varint_len(ms.max_satisfaction_witness_elements()?) +
                     ms.max_satisfaction_size(2)
             }
             Descriptor::ShWsh(ref ms) => {
@@ -661,10 +661,10 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
                 4 * 36
                     + varint_len(script_size)
                     + script_size
-                    + varint_len(ms.max_satisfaction_witness_elements())
+                    + varint_len(ms.max_satisfaction_witness_elements()?)
                     + ms.max_satisfaction_size(2)
             }
-        }
+        })
     }
 
     /// Get the `scriptCode` of a transaction output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 //!     );
 //!
 //!     // Estimate the satisfaction cost
-//!     assert_eq!(desc.max_satisfaction_weight(), 293);
+//!     assert_eq!(desc.max_satisfaction_weight().unwrap(), 293);
 //! }
 //! ```
 //!

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -848,70 +848,79 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     ///
     /// This number does not include the witness script itself, so 1 needs
     /// to be added to the final result.
-    pub fn max_satisfaction_witness_elements(&self) -> usize {
+    pub fn max_satisfaction_witness_elements(&self) -> Option<usize> {
         match *self {
-            Terminal::PkK(..) => 1,
-            Terminal::PkH(..) => 2,
-            Terminal::After(..) | Terminal::Older(..) => 0,
+            Terminal::PkK(..) => Some(1),
+            Terminal::PkH(..) => Some(2),
+            Terminal::After(..) | Terminal::Older(..) => Some(0),
             Terminal::Sha256(..)
             | Terminal::Hash256(..)
             | Terminal::Ripemd160(..)
-            | Terminal::Hash160(..) => 1,
-            Terminal::True => 0,
-            Terminal::False => 0,
+            | Terminal::Hash160(..) => Some(1),
+            Terminal::True => Some(0),
+            Terminal::False => None,
             Terminal::Alt(ref sub) | Terminal::Swap(ref sub) | Terminal::Check(ref sub) => {
                 sub.node.max_satisfaction_witness_elements()
             }
-            Terminal::DupIf(ref sub) => 1 + sub.node.max_satisfaction_witness_elements(),
+            Terminal::DupIf(ref sub) => sub.node.max_satisfaction_witness_elements().map(|x| x + 1),
             Terminal::Verify(ref sub)
             | Terminal::NonZero(ref sub)
             | Terminal::ZeroNotEqual(ref sub) => sub.node.max_satisfaction_witness_elements(),
-            Terminal::AndV(ref l, ref r) | Terminal::AndB(ref l, ref r) => {
-                l.node.max_satisfaction_witness_elements()
-                    + r.node.max_satisfaction_witness_elements()
-            }
+            Terminal::AndV(ref l, ref r) | Terminal::AndB(ref l, ref r) => l
+                .node
+                .max_satisfaction_witness_elements()
+                .and_then(|l| r.node.max_satisfaction_witness_elements().map(|r| l + r)),
             Terminal::AndOr(ref a, ref b, ref c) => cmp::max(
-                a.node.max_satisfaction_witness_elements()
-                    + c.node.max_satisfaction_witness_elements(),
-                a.node.max_dissatisfaction_witness_elements().unwrap()
-                    + b.node.max_satisfaction_witness_elements(),
+                a.node
+                    .max_satisfaction_witness_elements()
+                    .and_then(|a| c.node.max_satisfaction_witness_elements().map(|c| c + a)),
+                a.node
+                    .max_dissatisfaction_witness_elements()
+                    .and_then(|a| b.node.max_satisfaction_witness_elements().map(|b| a + b)),
             ),
             Terminal::OrB(ref l, ref r) => cmp::max(
-                l.node.max_satisfaction_witness_elements()
-                    + r.node.max_dissatisfaction_witness_elements().unwrap(),
-                l.node.max_dissatisfaction_witness_elements().unwrap()
-                    + r.node.max_satisfaction_witness_elements(),
+                l.node
+                    .max_satisfaction_witness_elements()
+                    .and_then(|l| r.node.max_dissatisfaction_witness_elements().map(|r| l + r)),
+                l.node
+                    .max_dissatisfaction_witness_elements()
+                    .and_then(|l| r.node.max_satisfaction_witness_elements().map(|r| r + l)),
             ),
             Terminal::OrD(ref l, ref r) | Terminal::OrC(ref l, ref r) => cmp::max(
                 l.node.max_satisfaction_witness_elements(),
-                l.node.max_dissatisfaction_witness_elements().unwrap()
-                    + r.node.max_satisfaction_witness_elements(),
+                l.node
+                    .max_dissatisfaction_witness_elements()
+                    .and_then(|l| r.node.max_satisfaction_witness_elements().map(|r| r + l)),
             ),
-            Terminal::OrI(ref l, ref r) => {
-                1 + cmp::max(
-                    l.node.max_satisfaction_witness_elements(),
-                    r.node.max_satisfaction_witness_elements(),
-                )
-            }
+            Terminal::OrI(ref l, ref r) => cmp::max(
+                l.node.max_satisfaction_witness_elements(),
+                r.node.max_satisfaction_witness_elements(),
+            )
+            .map(|x| x + 1),
             Terminal::Thresh(k, ref subs) => {
                 let mut sub_n = subs
                     .iter()
                     .map(|sub| {
                         (
                             sub.node.max_satisfaction_witness_elements(),
-                            sub.node.max_dissatisfaction_witness_elements().unwrap(),
+                            sub.node.max_dissatisfaction_witness_elements(),
                         )
                     })
-                    .collect::<Vec<(usize, usize)>>();
-                sub_n.sort_by_key(|&(x, y)| x - y);
-                sub_n
-                    .iter()
-                    .rev()
-                    .enumerate()
-                    .map(|(n, &(x, y))| if n < k { x } else { y })
-                    .sum::<usize>()
+                    .collect::<Vec<(Option<usize>, Option<usize>)>>();
+                sub_n.sort_by(|a, b| a.cmp(b));
+
+                let mut sum = Some(0);
+                for (i, &(x, y)) in sub_n.iter().rev().enumerate() {
+                    if i < k {
+                        sum = x.and_then(|x| sum.map(|sum| sum + x));
+                    } else {
+                        sum = y.and_then(|y| sum.map(|sum| sum + y));
+                    }
+                }
+
+                sum
             }
-            Terminal::Multi(k, _) => 1 + k,
+            Terminal::Multi(k, _) => Some(1 + k),
         }
     }
 

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -739,7 +739,9 @@ impl<Pk: MiniscriptKey + ToPublicKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             }
         }
     }
+}
 
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     /// Maximum number of witness elements used to dissatisfy the Miniscript
     /// fragment. Used to estimate the weight of the `VarInt` that specifies
     /// this number in a serialized transaction.

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -12,6 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+use miniscript::types::extra_props::MAX_STANDARD_P2WSH_STACK_ITEMS;
 use std::fmt;
 use {Miniscript, MiniscriptKey, Terminal};
 
@@ -31,6 +32,9 @@ pub enum ScriptContextError {
     /// Only Compressed keys allowed under current descriptor
     /// Segwitv0 fragments do not allow uncompressed pubkeys
     CompressedOnly,
+    /// At least one satisfaction path in the Miniscript fragment has more than
+    /// `MAX_STANDARD_P2WSH_STACK_ITEMS` (100) witness elements.
+    MaxWitnessItemssExceeded,
 }
 
 impl fmt::Display for ScriptContextError {
@@ -44,6 +48,11 @@ impl fmt::Display for ScriptContextError {
             ScriptContextError::CompressedOnly => {
                 write!(f, "Uncompressed pubkeys not allowed in segwit context")
             }
+            ScriptContextError::MaxWitnessItemssExceeded => write!(
+                f,
+                "At least one spending path in the Miniscript fragment has more \
+                 witness items than MAX_STANDARD_P2WSH_STACK_ITEMS.",
+            ),
         }
     }
 }
@@ -71,6 +80,14 @@ pub trait ScriptContext:
     fn check_frag_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
         _frag: &Terminal<Pk, Ctx>,
     ) -> Result<(), ScriptContextError>;
+
+    /// Depending on script Context, some of the Miniscripts might not be valid.
+    /// For example, in Segwit Context requiring a too high number of stack elements
+    /// for a satisfaction path is non-standard.
+    /// In both legacy and Segwit contexts using more than 201 OPs is invalid by consensus.
+    fn check_ms_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        ms: &Miniscript<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError>;
 }
 
 /// Legacy ScriptContext
@@ -94,6 +111,12 @@ impl ScriptContext for Legacy {
     ) -> Result<(), ScriptContextError> {
         Ok(())
     }
+
+    fn check_ms_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        _ms: &Miniscript<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
 }
 
 /// Segwitv0 ScriptContext
@@ -111,11 +134,30 @@ impl ScriptContext for Segwitv0 {
         frag: &Terminal<Pk, Ctx>,
     ) -> Result<(), ScriptContextError> {
         match *frag {
-            Terminal::PkK(ref pk) if pk.is_uncompressed() => {
-                Err(ScriptContextError::CompressedOnly)
+            Terminal::PkK(ref pk) => {
+                if pk.is_uncompressed() {
+                    return Err(ScriptContextError::CompressedOnly);
+                }
+
+                Ok(())
             }
             _ => Ok(()),
         }
+    }
+
+    fn check_ms_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        ms: &Miniscript<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        // We don't need to know if this is actually a p2wsh as the standard satisfaction for
+        // other Segwitv0 defined programs all require (much) less than 100 elements.
+        // The witness script item is accounted for in max_satisfaction_witness_elements().
+        if let Some(max_witness_items) = ms.max_satisfaction_witness_elements() {
+            if max_witness_items > MAX_STANDARD_P2WSH_STACK_ITEMS {
+                return Err(ScriptContextError::MaxWitnessItemssExceeded);
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -132,6 +174,12 @@ impl ScriptContext for Any {
 
     fn check_frag_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
         _frag: &Terminal<Pk, Ctx>,
+    ) -> Result<(), ScriptContextError> {
+        unreachable!()
+    }
+
+    fn check_ms_validity<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        _ms: &Miniscript<Pk, Ctx>,
     ) -> Result<(), ScriptContextError> {
         unreachable!()
     }

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -154,16 +154,16 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {
 
     ///reduce, type check and push a 0-arg node
     fn reduce0(&mut self, ms: Terminal<Pk, Ctx>) -> Result<(), Error> {
-        Ctx::check_frag_validity(&ms)?;
-
         let ty = Type::type_check(&ms, return_none)?;
         let ext = ExtData::type_check(&ms, return_none)?;
-        self.0.push(Miniscript {
+        let ms = Miniscript {
             node: ms,
             ty: ty,
             ext: ext,
             phantom: PhantomData,
-        });
+        };
+        Ctx::check_ms_validity(&ms)?;
+        self.0.push(ms);
         Ok(())
     }
 
@@ -173,18 +173,18 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {
         F: FnOnce(Arc<Miniscript<Pk, Ctx>>) -> Terminal<Pk, Ctx>,
     {
         let top = self.pop().unwrap();
-        Ctx::check_ms_validity(&top)?;
         let wrapped_ms = wrap(Arc::new(top));
-        Ctx::check_frag_validity(&wrapped_ms)?;
 
         let ty = Type::type_check(&wrapped_ms, return_none)?;
         let ext = ExtData::type_check(&wrapped_ms, return_none)?;
-        self.0.push(Miniscript {
+        let ms = Miniscript {
             node: wrapped_ms,
             ty: ty,
             ext: ext,
             phantom: PhantomData,
-        });
+        };
+        Ctx::check_ms_validity(&ms)?;
+        self.0.push(ms);
         Ok(())
     }
 
@@ -196,20 +196,18 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {
         let left = self.pop().unwrap();
         let right = self.pop().unwrap();
 
-        Ctx::check_ms_validity(&left)?;
-        Ctx::check_ms_validity(&right)?;
-
         let wrapped_ms = wrap(Arc::new(left), Arc::new(right));
-        Ctx::check_frag_validity(&wrapped_ms)?;
 
         let ty = Type::type_check(&wrapped_ms, return_none)?;
         let ext = ExtData::type_check(&wrapped_ms, return_none)?;
-        self.0.push(Miniscript {
+        let ms = Miniscript {
             node: wrapped_ms,
             ty: ty,
             ext: ext,
             phantom: PhantomData,
-        });
+        };
+        Ctx::check_ms_validity(&ms)?;
+        self.0.push(ms);
         Ok(())
     }
 }

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -173,6 +173,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {
         F: FnOnce(Arc<Miniscript<Pk, Ctx>>) -> Terminal<Pk, Ctx>,
     {
         let top = self.pop().unwrap();
+        Ctx::check_ms_validity(&top)?;
         let wrapped_ms = wrap(Arc::new(top));
         Ctx::check_frag_validity(&wrapped_ms)?;
 
@@ -194,6 +195,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {
     {
         let left = self.pop().unwrap();
         let right = self.pop().unwrap();
+
+        Ctx::check_ms_validity(&left)?;
+        Ctx::check_ms_validity(&right)?;
 
         let wrapped_ms = wrap(Arc::new(left), Arc::new(right));
         Ctx::check_frag_validity(&wrapped_ms)?;

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -186,8 +186,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// This function may panic on misformed `Miniscript` objects which do
     /// not correspond to semantically sane Scripts. (Such scripts should be
     /// rejected at parse time. Any exceptions are bugs.)
-    pub fn max_satisfaction_witness_elements(&self) -> usize {
-        1 + self.node.max_satisfaction_witness_elements()
+    pub fn max_satisfaction_witness_elements(&self) -> Option<usize> {
+        self.node.max_satisfaction_witness_elements().map(|x| x + 1)
     }
 
     /// Maximum size, in bytes, of a satisfying witness. For Segwit outputs

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -146,6 +146,7 @@ impl<Ctx: ScriptContext> Miniscript<bitcoin::PublicKey, Ctx> {
         let mut iter = TokenIter::new(tokens);
 
         let top = decode::parse(&mut iter)?;
+        Ctx::check_ms_validity(&top)?;
         Ctx::check_frag_validity(&top.node)?;
         let type_check = types::Type::type_check(&top.node, |_| None)?;
         if type_check.corr.base != types::Base::B {

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -175,7 +175,9 @@ impl<Pk: MiniscriptKey + ToPublicKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     pub fn script_size(&self) -> usize {
         self.node.script_size()
     }
+}
 
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Maximum number of witness elements used to satisfy the Miniscript
     /// fragment, including the witness script itself. Used to estimate
     /// the weight of the `VarInt` that specifies this number in a serialized

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -147,7 +147,6 @@ impl<Ctx: ScriptContext> Miniscript<bitcoin::PublicKey, Ctx> {
 
         let top = decode::parse(&mut iter)?;
         Ctx::check_ms_validity(&top)?;
-        Ctx::check_frag_validity(&top.node)?;
         let type_check = types::Type::type_check(&top.node, |_| None)?;
         if type_check.corr.base != types::Base::B {
             return Err(Error::NonTopLevel(format!("{:?}", top)));
@@ -227,14 +226,15 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         Q: MiniscriptKey,
     {
         let inner = self.node.translate_pk(translatefpk, translatefpkh)?;
-        Ok(Miniscript {
+        let ms = Miniscript {
             //directly copying the type and ext is safe because translating public
             //key should not change any properties
             ty: self.ty,
             ext: self.ext,
             node: inner,
             phantom: PhantomData,
-        })
+        };
+        Ok(ms)
     }
 }
 

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -12,6 +12,8 @@ use Terminal;
 pub const MAX_OPS_PER_SCRIPT: usize = 201;
 // https://github.com/bitcoin/bitcoin/blob/875e1ccc9fe01e026e564dfd39a64d9a4b332a89/src/policy/policy.h#L40
 pub const MAX_STANDARD_P2WSH_STACK_ITEMS: usize = 100;
+// https://github.com/bitcoin/bitcoin/blob/283a73d7eaea2907a6f7f800f529a0d6db53d7a6/src/policy/policy.h#L44
+pub const MAX_STANDARD_P2WSH_SCRIPT_SIZE: usize = 3600;
 // https://github.com/bitcoin/bitcoin/blob/9ccaee1d5e2e4b79b0a7c29aadb41b97e4741332/src/script/script.h#L39
 pub const HEIGHT_TIME_THRESHOLD: u32 = 500_000_000;
 

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -93,9 +93,8 @@ impl TimeLockInfo {
     }
 }
 
-/// Structure representing the extra type properties of a fragment which are
-/// relevant to legacy(pre-segwit) safety and fee estimation. If a fragment is
-/// used in pre-segwit transactions it will only be malleable but still is
+/// Structure representing the extra type properties of a fragment. If a fragment
+/// is used in pre-segwit transactions it will only be malleable but still is
 /// correct and sound.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct ExtData {

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -507,7 +507,7 @@ impl Property for ExtData {
         let mut ops_count_nsat = Some(0);
         let mut ops_count_sat = Some(0);
         let mut sat_count = 0;
-        let mut timelocks = vec![];
+        let mut timelocks = Vec::with_capacity(n);
         for i in 0..n {
             let sub = sub_ck(i)?;
 

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -8,7 +8,10 @@ use std::iter::once;
 use MiniscriptKey;
 use Terminal;
 
+// https://github.com/bitcoin/bitcoin/blob/875e1ccc9fe01e026e564dfd39a64d9a4b332a89/src/script/script.h#L26
 pub const MAX_OPS_PER_SCRIPT: usize = 201;
+// https://github.com/bitcoin/bitcoin/blob/875e1ccc9fe01e026e564dfd39a64d9a4b332a89/src/policy/policy.h#L40
+pub const MAX_STANDARD_P2WSH_STACK_ITEMS: usize = 100;
 // https://github.com/bitcoin/bitcoin/blob/9ccaee1d5e2e4b79b0a7c29aadb41b97e4741332/src/script/script.h#L39
 pub const HEIGHT_TIME_THRESHOLD: u32 = 500_000_000;
 

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -659,10 +659,6 @@ fn insert_elem<Pk: MiniscriptKey, Ctx: ScriptContext>(
         return false;
     }
 
-    if let Err(_) = Ctx::check_frag_validity(&elem.ms.node) {
-        return false;
-    }
-
     let elem_cost = elem.cost_1d(sat_prob, dissat_prob);
 
     let elem_key = CompilationKey::from_type(elem.ms.ty, elem.ms.ext.has_free_verify, dissat_prob);

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -54,7 +54,7 @@ pub enum CompilerError {
     TopLevelNonSafe,
     /// Non-Malleable compilation  does exists for the given sub-policy.
     ImpossibleNonMalleableCompilation,
-    /// Atleast one satisfaction path in the optimal Miniscript has opcodes
+    /// At least one satisfaction path in the optimal Miniscript has opcodes
     /// more than `MAX_OPS_PER_SCRIPT`(201). However, there may exist other
     /// miniscripts which are under `MAX_OPS_PER_SCRIPT` but the compiler
     /// currently does not find them.
@@ -83,7 +83,7 @@ impl fmt::Display for CompilerError {
                 f.write_str("The compiler could not find any non-malleable compilation")
             }
             CompilerError::MaxOpCountExceeded => f.write_str(
-                "Atleast one spending path has more op codes executed than \
+                "At least one spending path has more op codes executed than \
                  MAX_OPS_PER_SCRIPT",
             ),
             CompilerError::PolicyError(ref e) => fmt::Display::fmt(e, f),
@@ -661,6 +661,14 @@ fn insert_elem<Pk: MiniscriptKey, Ctx: ScriptContext>(
         if op_count > MAX_OPS_PER_SCRIPT {
             return false;
         }
+    }
+
+    if let Err(_) = Ctx::check_ms_validity(&elem.ms) {
+        return false;
+    }
+
+    if let Err(_) = Ctx::check_frag_validity(&elem.ms.node) {
+        return false;
     }
 
     let elem_cost = elem.cost_1d(sat_prob, dissat_prob);

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -22,7 +22,6 @@ use std::convert::From;
 use std::marker::PhantomData;
 use std::{cmp, error, f64, fmt, mem};
 
-use miniscript::types::extra_props::MAX_OPS_PER_SCRIPT;
 use miniscript::types::{self, ErrorKind, ExtData, Property, Type};
 use miniscript::ScriptContext;
 use policy::Concrete;
@@ -54,11 +53,11 @@ pub enum CompilerError {
     TopLevelNonSafe,
     /// Non-Malleable compilation  does exists for the given sub-policy.
     ImpossibleNonMalleableCompilation,
-    /// At least one satisfaction path in the optimal Miniscript has opcodes
-    /// more than `MAX_OPS_PER_SCRIPT`(201). However, there may exist other
-    /// miniscripts which are under `MAX_OPS_PER_SCRIPT` but the compiler
-    /// currently does not find them.
-    MaxOpCountExceeded,
+    /// At least one satisfaction path in the optimal Miniscript has exceeded
+    /// the consensus or standardness limits.
+    /// There may exist other miniscripts which are under these limits but the
+    /// compiler currently does not find them.
+    LimitsExceeded,
     ///Policy related errors
     PolicyError(policy::concrete::PolicyError),
 }
@@ -82,9 +81,8 @@ impl fmt::Display for CompilerError {
             CompilerError::ImpossibleNonMalleableCompilation => {
                 f.write_str("The compiler could not find any non-malleable compilation")
             }
-            CompilerError::MaxOpCountExceeded => f.write_str(
-                "At least one spending path has more op codes executed than \
-                 MAX_OPS_PER_SCRIPT",
+            CompilerError::LimitsExceeded => f.write_str(
+                "At least one spending path has exceeded the standardness or consensus limits",
             ),
             CompilerError::PolicyError(ref e) => fmt::Display::fmt(e, f),
         }
@@ -657,12 +655,6 @@ fn insert_elem<Pk: MiniscriptKey, Ctx: ScriptContext>(
         return false;
     }
 
-    if let Some(op_count) = elem.ms.ext.ops_count_sat {
-        if op_count > MAX_OPS_PER_SCRIPT {
-            return false;
-        }
-    }
-
     if let Err(_) = Ctx::check_ms_validity(&elem.ms) {
         return false;
     }
@@ -1035,12 +1027,12 @@ where
     }
     if ret.len() == 0 {
         // The only reason we are discarding elements out of compiler is because
-        // compilations exceed opcount or are non-malleable . If there no possible
-        // compilations for any policies regardless of dissat probability then it
-        // must have all compilations exceeded the Max Opcount because we already
-        // checked that policy must have non-malleable compilations before calling
-        // this compile function
-        Err(CompilerError::MaxOpCountExceeded)
+        // compilations exceeded consensus and standardness limits or are non-malleable.
+        // If there no possible compilations for any policies regardless of dissat
+        // probability then it must have all compilations exceeded consensus or standardness
+        // limits because we already checked that policy must have non-malleable compilations
+        // before calling this compile function
+        Err(CompilerError::LimitsExceeded)
     } else {
         policy_cache.insert((policy.clone(), ord_sat_prob, ord_dissat_prob), ret.clone());
         Ok(ret)
@@ -1148,7 +1140,7 @@ where
         })
         .map(|(_, val)| val)
         .min_by_key(|ext| OrdF64(ext.cost_1d(sat_prob, dissat_prob)))
-        .ok_or(CompilerError::MaxOpCountExceeded)
+        .ok_or(CompilerError::LimitsExceeded)
 }
 
 /// Obtain the <basic-type>.deu (e.g. W.deu, B.deu) expression with the given sat and dissat
@@ -1173,7 +1165,7 @@ where
         })
         .map(|(_, val)| val)
         .min_by_key(|ext| OrdF64(ext.cost_1d(sat_prob, dissat_prob)))
-        .ok_or(CompilerError::MaxOpCountExceeded)
+        .ok_or(CompilerError::LimitsExceeded)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is the first part of #148, in order to fix #132.

This comports:
- a few drive-by cleanup commits added as i was reading the cost computation internals
- an API break: change max_witness_elements() to return an Option instead of unwrap()ing internally
- an addition of bounds-check for segwit standardness rules under the Segwitv0 context
- a move of the OPs count check to context in order to also check it at parse time (not only compilation) 

The second part is -coming soon :tm: and- storing  the cost in witness elements in the ExtraData struct in order to avoid the suboptimal recursion at each check. 