### PR TITLE
Fixing sighash serialization failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ unstable = []
 default = []
 
 [dependencies]
-bitcoin = "0.24"
+bitcoin = "0.25"
 
 [dependencies.serde]
 version = "1.0"
 optional = true
+
+[patch.crates-io]
+bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "master" }
 
 [[example]]
 name = "htlc"

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -116,7 +116,9 @@ fn main() {
     // 2. Example two: verify the signatures to ensure that invalid
     //    signatures are not treated as having participated in the script
     let secp = secp256k1::Secp256k1::new();
-    let sighash = transaction.signature_hash(0, &desc.witness_script(), 1);
+    let sighash = transaction
+        .signature_hash(0, &desc.witness_script(), 1)
+        .unwrap();
     let message = secp256k1::Message::from_slice(&sighash[..]).expect("32-byte hash");
 
     let iter = miniscript::descriptor::SatisfiedConstraints::from_descriptor(

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,9 @@ afl = { version = "0.3", optional = true }
 regex = { version = "1.3.9"}
 miniscript = { path = "..", features = ["fuzztarget", "compiler"] }
 
+[patch.crates-io]
+bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "master" }
+
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -235,7 +235,8 @@ pub fn interpreter_check(psbt: &Psbt) -> Result<(), Error> {
                 &des.witness_script(),
                 sighash_ty.as_u32(),
             ),
-        };
+        }
+        .map_err(|_| Error::SigHashSerialization)?;
         let secp = secp256k1::Secp256k1::verification_only();
 
         let msg = secp256k1::Message::from_slice(&sighash[..])

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -82,6 +82,7 @@ pub enum InputError {
 pub enum Error {
     InputError(InputError, usize),
     WrongInputCount { in_tx: usize, in_map: usize },
+    SigHashSerialization,
 }
 
 impl fmt::Display for InputError {
@@ -178,6 +179,9 @@ impl fmt::Display for Error {
                 "PSBT had {} inputs in transaction but {} inputs in map",
                 in_tx, in_map
             ),
+            Error::SigHashSerialization => {
+                f.write_str("unable to serialize transaction for computing sighash")
+            }
         }
     }
 }


### PR DESCRIPTION
When upgraded to the latest bitcoin master miniscript fails because of https://github.com/rust-bitcoin/rust-bitcoin/commit/3618d7a41d8aadd1f3c1762969893012cefff899

This PR fixes this and can be applied once 0.26 will be released