### PR TITLE
Descriptor pubkeys fixups

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -23,8 +23,8 @@
 //! these with BIP32 paths, pay-to-contract instructions, etc.
 //!
 
-use std::fmt;
 use std::str::{self, FromStr};
+use std::{error, fmt};
 
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::hash160;
@@ -101,6 +101,16 @@ pub struct DescriptorKeyParseError(&'static str);
 impl fmt::Display for DescriptorKeyParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.0)
+    }
+}
+
+impl error::Error for DescriptorKeyParseError {
+    fn description(&self) -> &str {
+        ""
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        None
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ use std::{error, fmt, hash, str};
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::{hash160, sha256, Hash};
 
-pub use descriptor::{Descriptor, SatisfiedConstraints};
+pub use descriptor::{Descriptor, DescriptorPublicKey, SatisfiedConstraints};
 pub use miniscript::context::{Legacy, ScriptContext, Segwitv0};
 pub use miniscript::decode::Terminal;
 pub use miniscript::satisfy::{BitcoinSig, Satisfier};


### PR DESCRIPTION
Just noticed i didn't implement Error for the descriptor pubkey parsing error (happens to be problematic downstream)...
Also re-exported `DescriptorPublicKey` which [was suggested previously](https://github.com/rust-bitcoin/rust-miniscript/pull/131#issuecomment-699036746) but i overlooked