### PR TITLE
Update ToPublicKey API to take in context param

### DIFF
--- a/examples/htlc.rs
+++ b/examples/htlc.rs
@@ -20,6 +20,7 @@ extern crate miniscript;
 use bitcoin::Network;
 use miniscript::policy::{Concrete, Liftable};
 use miniscript::Descriptor;
+use miniscript::NullCtx;
 use std::str::FromStr;
 
 fn main() {
@@ -44,17 +45,20 @@ fn main() {
     );
 
     assert_eq!(
-        format!("{:x}", htlc_descriptor.script_pubkey()),
+        format!("{:x}", htlc_descriptor.script_pubkey(NullCtx)),
         "00203c0a59874cb570ff3093bcd67e846c967127c9e3fcd30f0a20857b504599e50a"
     );
 
     assert_eq!(
-        format!("{:x}", htlc_descriptor.witness_script()),
+        format!("{:x}", htlc_descriptor.witness_script(NullCtx)),
         "21022222222222222222222222222222222222222222222222222222222222222222ac6476a9144377a5acd66dc5cb67148a24818d1e51fa183bd288ad025c11b26782012088a82011111111111111111111111111111111111111111111111111111111111111118768"
     );
 
     assert_eq!(
-        format!("{}", htlc_descriptor.address(Network::Bitcoin).unwrap()),
+        format!(
+            "{}",
+            htlc_descriptor.address(Network::Bitcoin, NullCtx).unwrap()
+        ),
         "bc1q8s99np6vk4c07vynhnt8aprvjecj0j0rlnfs7z3qs4a4q3veu59q8x3k8x"
     );
 }

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -17,6 +17,7 @@
 extern crate bitcoin;
 extern crate miniscript;
 
+use miniscript::NullCtx;
 use std::str::FromStr;
 
 fn main() {
@@ -25,13 +26,17 @@ fn main() {
     )
     .unwrap();
 
+    // Sometimes it is necesarry to have additional information to get the bitcoin::PublicKey
+    // from the MiniscriptKey which can supplied by `to_pk_ctx` parameter. For example,
+    // when calculating the script pubkey of a descriptor with xpubs, the secp context and
+    // child information maybe required.
     assert_eq!(
-        format!("{:x}", my_descriptor.script_pubkey()),
+        format!("{:x}", my_descriptor.script_pubkey(NullCtx)),
         "0020daef16dd7c946a3e735a6e43310cb2ce33dfd14a04f76bf8241a16654cb2f0f9"
     );
 
     assert_eq!(
-        format!("{:x}", my_descriptor.witness_script()),
+        format!("{:x}", my_descriptor.witness_script(NullCtx)),
         "21020202020202020202020202020202020202020202020202020202020202020202ac"
     );
 }

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -19,7 +19,7 @@ extern crate miniscript;
 
 use bitcoin::consensus::Decodable;
 use bitcoin::secp256k1; // secp256k1 re-exported from rust-bitcoin
-
+use miniscript::NullCtx;
 fn main() {
     // tx `f27eba163c38ad3f34971198687a3f1882b7ec818599ffe469a8440d82261c98`
     #[cfg_attr(feature="cargo-fmt", rustfmt_skip)]
@@ -116,7 +116,11 @@ fn main() {
     // 2. Example two: verify the signatures to ensure that invalid
     //    signatures are not treated as having participated in the script
     let secp = secp256k1::Secp256k1::new();
-    let sighash = transaction.signature_hash(0, &desc.witness_script(), 1);
+    // Sometimes it is necesarry to have additional information to get the bitcoin::PublicKey
+    // from the MiniscriptKey which can supplied by `to_pk_ctx` parameter. For example,
+    // when calculating the script pubkey of a descriptor with xpubs, the secp context and
+    // child information maybe required.
+    let sighash = transaction.signature_hash(0, &desc.witness_script(NullCtx), 1);
     let message = secp256k1::Message::from_slice(&sighash[..]).expect("32-byte hash");
 
     let iter = miniscript::descriptor::SatisfiedConstraints::from_descriptor(

--- a/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
@@ -2,6 +2,7 @@ extern crate miniscript;
 
 use miniscript::bitcoin::blockdata::script;
 use miniscript::Miniscript;
+use miniscript::NullCtx;
 use miniscript::Segwitv0;
 
 fn do_test(data: &[u8]) {
@@ -9,8 +10,8 @@ fn do_test(data: &[u8]) {
     let script = script::Script::from(data.to_owned());
 
     if let Ok(pt) = Miniscript::<_, Segwitv0>::parse(&script) {
-        let output = pt.encode();
-        assert_eq!(pt.script_size(), output.len());
+        let output = pt.encode(NullCtx);
+        assert_eq!(pt.script_size(NullCtx), output.len());
         assert_eq!(output, script);
     }
 }

--- a/src/descriptor/satisfied_constraints.rs
+++ b/src/descriptor/satisfied_constraints.rs
@@ -20,7 +20,7 @@ use miniscript::ScriptContext;
 use Descriptor;
 use Terminal;
 use {error, Miniscript};
-use {BitcoinSig, ToPublicKey};
+use {BitcoinSig, NullCtx, ToPublicKey};
 
 /// Detailed Error type for Interpreter
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -722,7 +722,9 @@ where
                     self.stack.push(StackElement::Satisfied);
                     return Some(Ok(SatisfiedConstraint::PublicKey { key: pk, sig }));
                 } else {
-                    return Some(Err(Error::PkEvaluationError(pk.clone().to_public_key())));
+                    return Some(Err(Error::PkEvaluationError(
+                        pk.clone().to_public_key(NullCtx),
+                    )));
                 }
             } else {
                 return Some(Err(Error::UnexpectedStackEnd));
@@ -823,7 +825,9 @@ impl<'stack> Stack<'stack> {
                     }
                 }
                 StackElement::Satisfied => {
-                    return Some(Err(Error::PkEvaluationError(pk.clone().to_public_key())))
+                    return Some(Err(Error::PkEvaluationError(
+                        pk.clone().to_public_key(NullCtx),
+                    )))
                 }
             }
         } else {
@@ -874,7 +878,7 @@ impl<'stack> Stack<'stack> {
                             }
                             StackElement::Satisfied => {
                                 return Some(Err(Error::PkEvaluationError(
-                                    pk.clone().to_public_key(),
+                                    pk.clone().to_public_key(NullCtx),
                                 )))
                             }
                         }
@@ -1075,6 +1079,7 @@ mod tests {
     use BitcoinSig;
     use Miniscript;
     use MiniscriptKey;
+    use NullCtx;
     use ToPublicKey;
 
     fn setup_keys_sigs(
@@ -1180,7 +1185,7 @@ mod tests {
         assert!(pk_err.is_err());
 
         //Check Pkh
-        let pk_bytes = pks[1].to_public_key().to_bytes();
+        let pk_bytes = pks[1].to_public_key(NullCtx).to_bytes();
         let stack = Stack(vec![
             StackElement::Push(&der_sigs[1]),
             StackElement::Push(&pk_bytes),
@@ -1263,7 +1268,7 @@ mod tests {
         );
 
         //Check AndV
-        let pk_bytes = pks[1].to_public_key().to_bytes();
+        let pk_bytes = pks[1].to_public_key(NullCtx).to_bytes();
         let stack = Stack(vec![
             StackElement::Push(&der_sigs[1]),
             StackElement::Push(&pk_bytes),
@@ -1344,7 +1349,7 @@ mod tests {
         );
 
         //AndOr second satisfaction path
-        let pk_bytes = pks[1].to_public_key().to_bytes();
+        let pk_bytes = pks[1].to_public_key(NullCtx).to_bytes();
         let stack = Stack(vec![
             StackElement::Push(&der_sigs[1]),
             StackElement::Push(&pk_bytes),

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -61,6 +61,7 @@ enum NonTerm {
     EndIfElse,
 }
 /// All AST elements
+#[allow(broken_intra_doc_links)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Terminal<Pk: MiniscriptKey, Ctx: ScriptContext> {
     /// `1`

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -116,7 +116,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// if any. Otherwise returns an empty `Vec`.
     ///
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
-    /// To obtain a list of all public keys within AST use [`iter_pk()`] function, for example
+    /// To obtain a list of all public keys within AST use [fn.iter_pk()] function, for example
     /// `miniscript.iter_pubkeys().collect()`.
     pub fn get_leaf_pk(&self) -> Vec<Pk> {
         match self.node {
@@ -133,7 +133,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// returns its cloned copy.
     ///
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
-    /// To obtain a list of all public key hashes within AST use [`iter_pkh()`] function,
+    /// To obtain a list of all public key hashes within AST use [fn.iter_pkh()] function,
     /// for example `miniscript.iter_pubkey_hashes().collect()`.
     pub fn get_leaf_pkh(&self) -> Vec<Pk::Hash> {
         match self.node {
@@ -149,7 +149,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// keys or hashes, the function returns an empty `Vec`.
     ///
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
-    /// To obtain a list of all public keys or hashes within AST use [`iter_pk_pkh()`]
+    /// To obtain a list of all public keys or hashes within AST use [fn.iter_pk_pkh()]
     /// function, for example `miniscript.iter_pubkeys_and_hashes().collect()`.
     pub fn get_leaf_pk_pkh(&self) -> Vec<PkPkh<Pk>> {
         match self.node {
@@ -364,7 +364,7 @@ pub enum PkPkh<Pk: MiniscriptKey> {
 
 /// Iterator for traversing all [MiniscriptKey]'s and hashes, depending what data are present in AST,
 /// starting from some specific node which constructs the iterator via
-/// [Miniscript::iter_keys_and_hashes] method.
+/// [fn.Miniscript::iter_keys_and_hashes()] method.
 pub struct PkPkhIter<'a, Pk: 'a + MiniscriptKey, Ctx: 'a + ScriptContext> {
     node_iter: Iter<'a, Pk, Ctx>,
     curr_node: Option<&'a Miniscript<Pk, Ctx>>,
@@ -390,7 +390,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> PkPkhIter<'a, Pk, Ctx> {
     /// * Differs from `Miniscript::iter_pubkeys_and_hashes().collect()` in the way that it lists
     ///   only public keys, and not their hashes
     ///
-    /// Unlike these functions, [pk_only()] returns an `Option` value with `Vec`, not an iterator,
+    /// Unlike these functions, [fn.pk_only] returns an `Option` value with `Vec`, not an iterator,
     /// and consumes the iterator object.
     pub fn pk_only(self) -> Option<Vec<Pk>> {
         let mut keys = vec![];

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -225,11 +225,13 @@ impl<'psbt> PsbtInputSatisfier<'psbt> {
     }
 }
 
-impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfier<'psbt> {
-    fn lookup_sig(&self, pk: &Pk) -> Option<BitcoinSig> {
+impl<'psbt, ToPkCtx: Copy, Pk: MiniscriptKey + ToPublicKey<ToPkCtx>> Satisfier<ToPkCtx, Pk>
+    for PsbtInputSatisfier<'psbt>
+{
+    fn lookup_sig(&self, pk: &Pk, to_pk_ctx: ToPkCtx) -> Option<BitcoinSig> {
         if let Some(rawsig) = self.psbt.inputs[self.index]
             .partial_sigs
-            .get(&pk.to_public_key())
+            .get(&pk.to_public_key(to_pk_ctx))
         {
             // We have already previously checked that all signatures have the
             // correct sighash flag.
@@ -239,11 +241,15 @@ impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfie
         }
     }
 
-    fn lookup_pkh_sig(&self, pkh: &Pk::Hash) -> Option<(bitcoin::PublicKey, BitcoinSig)> {
+    fn lookup_pkh_sig(
+        &self,
+        pkh: &Pk::Hash,
+        to_pk_ctx: ToPkCtx,
+    ) -> Option<(bitcoin::PublicKey, BitcoinSig)> {
         if let Some((pk, sig)) = self.psbt.inputs[self.index]
             .partial_sigs
             .iter()
-            .filter(|&(pubkey, _sig)| pubkey.to_pubkeyhash() == Pk::hash_to_hash160(pkh))
+            .filter(|&(pubkey, _sig)| pubkey.to_pubkeyhash() == Pk::hash_to_hash160(pkh, to_pk_ctx))
             .next()
         {
             // If the mapping is incorrect, return None
@@ -264,7 +270,7 @@ impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfie
         if seq == 0xffffffff {
             false
         } else {
-            <Satisfier<Pk>>::check_after(&After(locktime), n)
+            <Satisfier<ToPkCtx, Pk>>::check_after(&After(locktime), n)
         }
     }
 
@@ -280,7 +286,7 @@ impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfie
             // transaction version and sequence check
             false
         } else {
-            <Satisfier<Pk>>::check_after(&Older(seq), n)
+            <Satisfier<ToPkCtx, Pk>>::check_after(&Older(seq), n)
         }
     }
 }


### PR DESCRIPTION
Although the diff is large, most of it just compiler guiding me on how to fix the errors. As can be seen from the diff the change is pretty invasive.  

On the other hand, we can have the user use the translate functions to get a `Miniscript<bitcoin::PublicKey, _>` and then use the API operations on those. Considering the API changes required here, I am leaning toward the other option of not implementing `ToPublicKey` to DescriptorKey at all. Even for tweaked keys where we need cryptographic operations, we should use the translate functions. 

I am starting to think that having additional parameters for address, max_satisfaction_wieght, etc might not be worth it. 
Does not currently build/test for compiler feature. I can fix that depending on what we decide. 

w.r.t #163, I think the best way to not implement `ToPublicKey` at all and have users use the translate function to get a `Miniscript<bitcoin::PublicKey, _>`. We can even provide a simple utility function that does it incase the user finds it hard to use the `traslate_pk` function.  

@apoelstra What do you think?