### PR TITLE
Add malleable signer

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -41,7 +41,7 @@ use bitcoin::{self, Script};
 use expression;
 use miniscript;
 use miniscript::context::{ScriptContext, ScriptContextError};
-use miniscript::{decode::Terminal, satisfy, Legacy, Miniscript, Segwitv0};
+use miniscript::{decode::Terminal, Legacy, Miniscript, Segwitv0};
 use policy;
 use push_opcode_size;
 use script_num_size;
@@ -1566,12 +1566,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
         Pk: ToPublicKey<ToPkCtx>,
         S: Satisfier<ToPkCtx, Pk>,
     {
-        match satisfy::Satisfaction::satisfy(&self.sorted_node(to_pk_ctx), &satisfier, to_pk_ctx)
-            .stack
-        {
-            satisfy::Witness::Stack(stack) => Some(stack),
-            satisfy::Witness::Unavailable => None,
-        }
+        let ms = Miniscript::from_ast(self.sorted_node(to_pk_ctx)).expect("Multi node typecheck");
+        ms.satisfy(satisfier, to_pk_ctx)
     }
 
     /// Size, in bytes of the script-pubkey. If this Miniscript is used outside

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -411,10 +411,17 @@ impl PartialOrd for Witness {
 
 impl Ord for Witness {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
+        fn varint_len(n: usize) -> usize {
+            bitcoin::VarInt(n as u64).len()
+        }
         match (self, other) {
             (&Witness::Stack(_), &Witness::Unavailable) => cmp::Ordering::Less,
             (&Witness::Unavailable, &Witness::Stack(_)) => cmp::Ordering::Greater,
-            (&Witness::Stack(ref v1), &Witness::Stack(ref v2)) => v1.len().cmp(&v2.len()),
+            (&Witness::Stack(ref v1), &Witness::Stack(ref v2)) => {
+                let w1 = v1.iter().map(Vec::len).sum::<usize>() + varint_len(v1.len());
+                let w2 = v2.iter().map(Vec::len).sum::<usize>() + varint_len(v2.len());
+                w1.cmp(&w2)
+            }
             (&Witness::Unavailable, &Witness::Unavailable) => cmp::Ordering::Equal,
         }
     }


### PR DESCRIPTION
Based on the comment: 
https://github.com/rust-bitcoin/rust-miniscript/pull/161#discussion_r517353815

> The attacker only has access to hash preimages that honest users have access to as well. This is a reasonable assumption because hash preimages are revealed once globally, and then available to everyone. On the other hand, making the assumption that attackers may have access to more preimages than honest users makes a large portion of scripts impossible to satisfy in a non-malleable way.

from bitcoin.sipa.be/miniscript