### PR TITLE
lift failure bug fixes

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -268,15 +268,7 @@ impl fmt::Display for DescriptorKeyParseError {
     }
 }
 
-impl error::Error for DescriptorKeyParseError {
-    fn description(&self) -> &str {
-        ""
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
-}
+impl error::Error for DescriptorKeyParseError {}
 
 impl fmt::Display for DescriptorPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -101,9 +101,6 @@ impl From<::Error> for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        ""
-    }
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Secp(ref err) => Some(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,15 +354,17 @@ pub enum Error {
     CouldNotSatisfy,
     /// Typechecking failed
     TypeCheck(String),
-    ///General error in creating descriptor
+    /// General error in creating descriptor
     BadDescriptor,
-    ///Forward-secp related errors
+    /// Forward-secp related errors
     Secp(bitcoin::secp256k1::Error),
     #[cfg(feature = "compiler")]
-    ///Compiler related errors
+    /// Compiler related errors
     CompilerError(policy::compiler::CompilerError),
-    ///Errors related to policy
+    /// Errors related to policy
     PolicyError(policy::concrete::PolicyError),
+    /// Errors related to lifting
+    LiftError(policy::LiftError),
     /// Forward script context related errors
     ContextError(miniscript::context::ScriptContextError),
     /// Recursion depth exceeded when parsing policy/miniscript from string
@@ -384,6 +386,13 @@ where
 {
     fn from(e: miniscript::types::Error<Pk, Ctx>) -> Error {
         Error::TypeCheck(e.to_string())
+    }
+}
+
+#[doc(hidden)]
+impl From<policy::LiftError> for Error {
+    fn from(e: policy::LiftError) -> Error {
+        Error::LiftError(e)
     }
 }
 
@@ -472,6 +481,7 @@ impl fmt::Display for Error {
             #[cfg(feature = "compiler")]
             Error::CompilerError(ref e) => fmt::Display::fmt(e, f),
             Error::PolicyError(ref e) => fmt::Display::fmt(e, f),
+            Error::LiftError(ref e) => fmt::Display::fmt(e, f),
             Error::MaxRecursiveDepthExceeded => write!(
                 f,
                 "Recursive depth over {} not permitted",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,10 +428,6 @@ impl error::Error for Error {
             _ => None,
         }
     }
-
-    fn description(&self) -> &str {
-        ""
-    }
 }
 
 // https://github.com/sipa/miniscript/pull/5 for discussion on this number

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -65,14 +65,7 @@ impl fmt::Display for AnalysisError {
     }
 }
 
-impl error::Error for AnalysisError {
-    fn description(&self) -> &str {
-        ""
-    }
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
-}
+impl error::Error for AnalysisError {}
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Whether all spend paths of miniscript require a signature

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -62,15 +62,7 @@ pub enum CompilerError {
     PolicyError(policy::concrete::PolicyError),
 }
 
-impl error::Error for CompilerError {
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        ""
-    }
-}
+impl error::Error for CompilerError {}
 
 impl fmt::Display for CompilerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -93,14 +93,7 @@ pub enum PolicyError {
     DuplicatePubKeys,
 }
 
-impl error::Error for PolicyError {
-    fn description(&self) -> &str {
-        ""
-    }
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
-}
+impl error::Error for PolicyError {}
 
 impl fmt::Display for PolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -183,15 +183,7 @@ impl From<bitcoin::util::key::Error> for InputError {
     }
 }
 
-impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> {
-        None
-    }
-
-    fn description(&self) -> &str {
-        ""
-    }
-}
+impl error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Lifting should fail for miniscripts/descriptors
- timelock combination
- branch exceeds resource limits

Lifting fails for concrete policies:
- timelock combination
- If there is a branch that can exceed resource limits, our compiler would not create miniscripts anyway. And it general, it is difficult to check the resource limit checks without compiling.