### PR TITLE
Standard sortedmulti

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1425,6 +1425,11 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     ///
     /// Internally checks all the applicable size limits and pubkey types limitations according to the current `Ctx`.
     pub fn new(k: usize, pks: Vec<Pk>) -> Result<Self, Error> {
+        // A sortedmulti() is only defined for <= 20 keys (it maps to CHECKMULTISIG)
+        if pks.len() > 20 {
+            Error::BadDescriptor("Too many public keys".to_string());
+        }
+
         // Check the limits before creating a new SortedMultiVec
         // For example, under p2sh context the scriptlen can only be
         // upto 520 bytes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ pub enum Error {
     /// Typechecking failed
     TypeCheck(String),
     /// General error in creating descriptor
-    BadDescriptor,
+    BadDescriptor(String),
     /// Forward-secp related errors
     Secp(bitcoin::secp256k1::Error),
     #[cfg(feature = "compiler")]
@@ -471,7 +471,7 @@ impl fmt::Display for Error {
             Error::CouldNotSatisfy => f.write_str("could not satisfy"),
             Error::BadPubkey(ref e) => fmt::Display::fmt(e, f),
             Error::TypeCheck(ref e) => write!(f, "typecheck: {}", e),
-            Error::BadDescriptor => f.write_str("could not create a descriptor"),
+            Error::BadDescriptor(ref e) => write!(f, "Invalid descriptor: {}", e),
             Error::Secp(ref e) => fmt::Display::fmt(e, f),
             Error::ContextError(ref e) => fmt::Display::fmt(e, f),
             #[cfg(feature = "compiler")]


### PR DESCRIPTION
We could previously create `sortedmulti()` invalid by consensus.

Stole 79a0e62 from #197 .