### PR TITLE
Remove ToPkCtx from length/satisfaction_weight

### DIFF
--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -83,15 +83,15 @@ fn main() {
     let my_descriptor =
         BitcoinDescriptor::from_str(&descriptor_str[..]).expect("parse descriptor string");
 
-    // Sometimes it is necessary to have additional information to get the bitcoin::PublicKey
-    // from the MiniscriptKey which can supplied by `to_pk_ctx` parameter. For example,
-    // when calculating the script pubkey of a descriptor with xpubs, the secp context and
-    // child information maybe required.
-
     // Check weight for witness satisfaction cost ahead of time.
     // 4(scriptSig length of 0) + 1(witness stack size) + 106(serialized witnessScript)
     // + 73*2(signature length + signatures + sighash bytes) + 1(dummy byte) = 258
     assert_eq!(my_descriptor.max_satisfaction_weight().unwrap(), 258);
+
+    // Sometimes it is necessary to have additional information to get the bitcoin::PublicKey
+    // from the MiniscriptKey which can supplied by `to_pk_ctx` parameter. For example,
+    // when calculating the script pubkey of a descriptor with xpubs, the secp context and
+    // child information maybe required.
 
     // Observe the script properties, just for fun
     assert_eq!(

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -91,7 +91,7 @@ fn main() {
     // Check weight for witness satisfaction cost ahead of time.
     // 4(scriptSig length of 0) + 1(witness stack size) + 106(serialized witnessScript)
     // + 73*2(signature length + signatures + sighash bytes) + 1(dummy byte) = 258
-    assert_eq!(my_descriptor.max_satisfaction_weight(NullCtx).unwrap(), 258);
+    assert_eq!(my_descriptor.max_satisfaction_weight().unwrap(), 258);
 
     // Observe the script properties, just for fun
     assert_eq!(

--- a/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
@@ -11,7 +11,7 @@ fn do_test(data: &[u8]) {
 
     if let Ok(pt) = Miniscript::<_, Segwitv0>::parse(&script) {
         let output = pt.encode(NullCtx);
-        assert_eq!(pt.script_size(NullCtx), output.len());
+        assert_eq!(pt.script_size(), output.len());
         assert_eq!(output, script);
     }
 }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1105,10 +1105,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
     /// transaction. Assumes all signatures are 73 bytes, including push opcode
     /// and sighash suffix. Includes the weight of the VarInts encoding the
     /// scriptSig and witness stack length.
-    pub fn max_satisfaction_weight<ToPkCtx: Copy>(&self, to_pk_ctx: ToPkCtx) -> Option<usize>
-    where
-        Pk: ToPublicKey<ToPkCtx>,
-    {
+    pub fn max_satisfaction_weight(&self) -> Option<usize> {
         fn varint_len(n: usize) -> usize {
             bitcoin::VarInt(n as u64).len()
         }
@@ -1119,17 +1116,17 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
                 4 * (varint_len(scriptsig_len) + scriptsig_len)
             }
             Descriptor::Pk(..) => 4 * (1 + 73),
-            Descriptor::Pkh(ref pk) => 4 * (1 + 73 + pk.serialized_len(to_pk_ctx)),
-            Descriptor::Wpkh(ref pk) => 4 + 1 + 73 + pk.serialized_len(to_pk_ctx),
-            Descriptor::ShWpkh(ref pk) => 4 * 24 + 1 + 73 + pk.serialized_len(to_pk_ctx),
+            Descriptor::Pkh(ref pk) => 4 * (1 + 73 + pk.serialized_len()),
+            Descriptor::Wpkh(ref pk) => 4 + 1 + 73 + pk.serialized_len(),
+            Descriptor::ShWpkh(ref pk) => 4 * 24 + 1 + 73 + pk.serialized_len(),
             Descriptor::Sh(ref ms) => {
-                let ss = ms.script_size(to_pk_ctx);
+                let ss = ms.script_size();
                 let ps = push_opcode_size(ss);
                 let scriptsig_len = ps + ss + ms.max_satisfaction_size()?;
                 4 * (varint_len(scriptsig_len) + scriptsig_len)
             }
             Descriptor::Wsh(ref ms) => {
-                let script_size = ms.script_size(to_pk_ctx);
+                let script_size = ms.script_size();
                 4 +  // scriptSig length byte
                     varint_len(script_size) +
                     script_size +
@@ -1137,7 +1134,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
                     ms.max_satisfaction_size()?
             }
             Descriptor::ShWsh(ref ms) => {
-                let script_size = ms.script_size(to_pk_ctx);
+                let script_size = ms.script_size();
                 4 * 36
                     + varint_len(script_size)
                     + script_size
@@ -1145,13 +1142,13 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
                     + ms.max_satisfaction_size()?
             }
             Descriptor::ShSortedMulti(ref smv) => {
-                let ss = smv.script_size(to_pk_ctx);
+                let ss = smv.script_size();
                 let ps = push_opcode_size(ss);
                 let scriptsig_len = ps + ss + smv.max_satisfaction_size(1);
                 4 * (varint_len(scriptsig_len) + scriptsig_len)
             }
             Descriptor::WshSortedMulti(ref smv) => {
-                let script_size = smv.script_size(to_pk_ctx);
+                let script_size = smv.script_size();
                 4 +  // scriptSig length byte
                     varint_len(script_size) +
                     script_size +
@@ -1159,7 +1156,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
                     smv.max_satisfaction_size(2)
             }
             Descriptor::ShWshSortedMulti(ref smv) => {
-                let script_size = smv.script_size(to_pk_ctx);
+                let script_size = smv.script_size();
                 4 * 36
                     + varint_len(script_size)
                     + script_size
@@ -1546,19 +1543,11 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// In general, it is not recommended to use this function directly, but
     /// to instead call the corresponding function on a `Descriptor`, which
     /// will handle the segwit/non-segwit technicalities for you.
-    pub fn script_size<ToPkCtx>(&self, to_pk_ctx: ToPkCtx) -> usize
-    where
-        ToPkCtx: Copy,
-        Pk: ToPublicKey<ToPkCtx>,
-    {
+    pub fn script_size(&self) -> usize {
         script_num_size(self.k)
             + 1
             + script_num_size(self.pks.len())
-            + self
-                .pks
-                .iter()
-                .map(|pk| ToPublicKey::serialized_len(pk, to_pk_ctx))
-                .sum::<usize>()
+            + self.pks.iter().map(|pk| pk.serialized_len()).sum::<usize>()
     }
 
     /// Maximum number of witness elements used to satisfy the Miniscript

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //!     assert!(desc.sanity_check().is_ok());
 //!
 //!     // Estimate the satisfaction cost
-//!     assert_eq!(desc.max_satisfaction_weight(NullCtx).unwrap(), 293);
+//!     assert_eq!(desc.max_satisfaction_weight().unwrap(), 293);
 //! }
 //! ```
 //!
@@ -149,6 +149,16 @@ pub trait MiniscriptKey:
 
     /// Converts an object to PublicHash
     fn to_pubkeyhash(&self) -> Self::Hash;
+
+    /// Computes the size of a public key when serialized in a script,
+    /// including the length bytes
+    fn serialized_len(&self) -> usize {
+        if self.is_uncompressed() {
+            66
+        } else {
+            34
+        }
+    }
 }
 
 impl MiniscriptKey for bitcoin::PublicKey {
@@ -190,16 +200,6 @@ pub trait ToPublicKey<ToPkCtx: Copy>: MiniscriptKey {
     /// or additional information for substituting the wildcard in
     /// extended pubkeys
     fn to_public_key(&self, to_pk_ctx: ToPkCtx) -> bitcoin::PublicKey;
-
-    /// Computes the size of a public key when serialized in a script,
-    /// including the length bytes
-    fn serialized_len(&self, to_pk_ctx: ToPkCtx) -> usize {
-        if self.to_public_key(to_pk_ctx).compressed {
-            34
-        } else {
-            66
-        }
-    }
 
     /// Converts a hashed version of the public key to a `hash160` hash.
     ///

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -197,11 +197,8 @@ where
     /// In general, it is not recommended to use this function directly, but
     /// to instead call the corresponding function on a `Descriptor`, which
     /// will handle the segwit/non-segwit technicalities for you.
-    pub fn script_size<ToPkCtx: Copy>(&self, to_pk_ctx: ToPkCtx) -> usize
-    where
-        Pk: ToPublicKey<ToPkCtx>,
-    {
-        self.node.script_size(to_pk_ctx)
+    pub fn script_size(&self) -> usize {
+        self.node.script_size()
     }
 }
 
@@ -471,7 +468,7 @@ mod tests {
     fn script_rtt<Str1: Into<Option<&'static str>>>(script: Segwitv0Script, expected_hex: Str1) {
         assert_eq!(script.ty.corr.base, types::Base::B);
         let bitcoin_script = script.encode(NullCtx);
-        assert_eq!(bitcoin_script.len(), script.script_size(NullCtx));
+        assert_eq!(bitcoin_script.len(), script.script_size());
         if let Some(expected) = expected_hex.into() {
             assert_eq!(format!("{:x}", bitcoin_script), expected);
         }
@@ -483,7 +480,7 @@ mod tests {
     fn roundtrip(tree: &Segwitv0Script, s: &str) {
         assert_eq!(tree.ty.corr.base, types::Base::B);
         let ser = tree.encode(NullCtx);
-        assert_eq!(ser.len(), tree.script_size(NullCtx));
+        assert_eq!(ser.len(), tree.script_size());
         assert_eq!(ser.to_string(), s);
         let deser = Segwitv0Script::parse_insane(&ser).expect("deserialize result of serialize");
         assert_eq!(*tree, deser);

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1451,14 +1451,11 @@ mod tests {
             let big_thresh_ms: SegwitMiniScript = big_thresh.compile().unwrap();
             if *k == 21 {
                 // N * (PUSH + pubkey + CHECKSIGVERIFY)
-                assert_eq!(
-                    big_thresh_ms.script_size(NullCtx),
-                    keys.len() * (1 + 33 + 1)
-                );
+                assert_eq!(big_thresh_ms.script_size(), keys.len() * (1 + 33 + 1));
             } else {
                 // N * (PUSH + pubkey + CHECKSIG + ADD + SWAP) + N EQUAL
                 assert_eq!(
-                    big_thresh_ms.script_size(NullCtx),
+                    big_thresh_ms.script_size(),
                     keys.len() * (1 + 33 + 3) + script_num_size(*k) + 1 - 2 // minus one SWAP and one ADD
                 );
                 let big_thresh_ms_expected = ms_str!(
@@ -1490,7 +1487,7 @@ mod tests {
             (1, Concrete::Threshold(keys_b.len(), keys_b)),
         ])
         .compile();
-        let script_size = thresh_res.clone().and_then(|m| Ok(m.script_size(NullCtx)));
+        let script_size = thresh_res.clone().and_then(|m| Ok(m.script_size()));
         assert_eq!(
             thresh_res,
             Err(CompilerError::LimitsExceeded),


### PR DESCRIPTION
To improve ergonomics and efficiency. You don't need to do an ecmult to figure out the length of your public key! Also should be possible on string descriptors now I guess?