### PR TITLE
Replace empty array equality comparison with is_empty()

### DIFF
--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -47,7 +47,7 @@ impl<'txin> From<&'txin [u8]> for Element<'txin> {
     fn from(v: &'txin [u8]) -> Element<'txin> {
         if *v == [1] {
             Element::Satisfied
-        } else if *v == [] {
+        } else if v.is_empty() {
             Element::Dissatisfied
         } else {
             Element::Push(v)


### PR DESCRIPTION
This trivial change actually prevents us from running into a mystifying error [here](https://github.com/comit-network/droplet/pull/29/checks?check_run_id=1557115096#step:7:252) when building to wasm.