### PR TITLE
remove FromStr bound on MiniscriptKey and MiniscriptKey::Hash

### DIFF
--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -78,8 +78,10 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Bare<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> FromTree for Bare<Pk>
+impl<Pk> FromTree for Bare<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -90,8 +92,10 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> FromStr for Bare<Pk>
+impl<Pk> FromStr for Bare<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -104,11 +108,7 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Bare<Pk>
-where
-    <Pk as FromStr>::Err: ToString,
-    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
-{
+impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Bare<Pk> {
     fn sanity_check(&self) -> Result<(), Error> {
         self.ms.sanity_check()?;
         Ok(())
@@ -237,8 +237,10 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Pkh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> FromTree for Pkh<Pk>
+impl<Pk> FromTree for Pkh<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -257,8 +259,10 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> FromStr for Pkh<Pk>
+impl<Pk> FromStr for Pkh<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -271,11 +275,7 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Pkh<Pk>
-where
-    <Pk as FromStr>::Err: ToString,
-    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
-{
+impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Pkh<Pk> {
     fn sanity_check(&self) -> Result<(), Error> {
         Ok(())
     }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -290,11 +290,7 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Descriptor<P> {
     }
 }
 
-impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk>
-where
-    <Pk as FromStr>::Err: ToString,
-    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
-{
+impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
     /// Whether the descriptor is safe
     /// Checks whether all the spend paths in the descriptor are possible
     /// on the bitcoin network under the current standardness and consensus rules
@@ -517,7 +513,8 @@ impl Descriptor<DescriptorPublicKey> {
 
 impl<Pk> expression::FromTree for Descriptor<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -535,7 +532,8 @@ where
 
 impl<Pk> FromStr for Descriptor<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -83,8 +83,10 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Wsh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> FromTree for Wsh<Pk>
+impl<Pk> FromTree for Wsh<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -130,8 +132,10 @@ impl<Pk: MiniscriptKey> fmt::Display for Wsh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> FromStr for Wsh<Pk>
+impl<Pk> FromStr for Wsh<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -144,11 +148,7 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wsh<Pk>
-where
-    <Pk as FromStr>::Err: ToString,
-    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
-{
+impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wsh<Pk> {
     fn sanity_check(&self) -> Result<(), Error> {
         match self.inner {
             WshInner::SortedMulti(ref smv) => smv.sanity_check()?,
@@ -315,8 +315,10 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Wpkh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> FromTree for Wpkh<Pk>
+impl<Pk> FromTree for Wpkh<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -335,8 +337,10 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> FromStr for Wpkh<Pk>
+impl<Pk> FromStr for Wpkh<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -349,11 +353,7 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wpkh<Pk>
-where
-    <Pk as FromStr>::Err: ToString,
-    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
-{
+impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wpkh<Pk> {
     fn sanity_check(&self) -> Result<(), Error> {
         if self.pk.is_uncompressed() {
             Err(Error::ContextError(ScriptContextError::CompressedOnly))

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -97,8 +97,10 @@ impl<Pk: MiniscriptKey> fmt::Display for Sh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> FromTree for Sh<Pk>
+impl<Pk> FromTree for Sh<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -126,8 +128,10 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> FromStr for Sh<Pk>
+impl<Pk> FromStr for Sh<Pk>
 where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
     <Pk as FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
 {
@@ -184,11 +188,7 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Sh<Pk>
-where
-    <Pk as FromStr>::Err: ToString,
-    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
-{
+impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Sh<Pk> {
     fn sanity_check(&self) -> Result<(), Error> {
         match self.inner {
             ShInner::Wsh(ref wsh) => wsh.sanity_check()?,

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -66,6 +66,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// Parse an expression tree into a SortedMultiVec
     pub fn from_tree(tree: &expression::Tree) -> Result<Self, Error>
     where
+        Pk: FromStr,
         <Pk as FromStr>::Err: ToString,
     {
         if tree.args.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,16 +131,14 @@ pub use miniscript::satisfy::{BitcoinSig, Satisfier};
 pub use miniscript::Miniscript;
 
 ///Public key trait which can be converted to Hash type
-pub trait MiniscriptKey:
-    Clone + Eq + Ord + str::FromStr + fmt::Debug + fmt::Display + hash::Hash
-{
+pub trait MiniscriptKey: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash {
     /// Check if the publicKey is uncompressed. The default
     /// implementation returns false
     fn is_uncompressed(&self) -> bool {
         false
     }
     /// The associated Hash type with the publicKey
-    type Hash: Clone + Eq + Ord + str::FromStr + fmt::Display + fmt::Debug + hash::Hash;
+    type Hash: Clone + Eq + Ord + fmt::Display + fmt::Debug + hash::Hash;
 
     /// Converts an object to PublicHash
     fn to_pubkeyhash(&self) -> Self::Hash;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,8 @@ macro_rules! serde_string_impl_pk {
         #[cfg(feature = "serde")]
         impl<'de, Pk $(, $gen)*> $crate::serde::Deserialize<'de> for $name<Pk $(, $gen)*>
         where
-            Pk: $crate::MiniscriptKey,
+            Pk: $crate::MiniscriptKey + $crate::std::str::FromStr,
+            Pk::Hash: $crate::std::str::FromStr,
             <Pk as $crate::std::str::FromStr>::Err: $crate::std::fmt::Display,
             <<Pk as $crate::MiniscriptKey>::Hash as $crate::std::str::FromStr>::Err:
                 $crate::std::fmt::Display,
@@ -41,7 +42,8 @@ macro_rules! serde_string_impl_pk {
                 struct Visitor<Pk $(, $gen)*>(PhantomData<(Pk $(, $gen)*)>);
                 impl<'de, Pk $(, $gen)*> $crate::serde::de::Visitor<'de> for Visitor<Pk $(, $gen)*>
                 where
-                    Pk: $crate::MiniscriptKey,
+                    Pk: $crate::MiniscriptKey + $crate::std::str::FromStr,
+                    Pk::Hash: $crate::std::str::FromStr,
                     <Pk as $crate::std::str::FromStr>::Err: $crate::std::fmt::Display,
                     <<Pk as $crate::MiniscriptKey>::Hash as $crate::std::str::FromStr>::Err:
                         $crate::std::fmt::Display,

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -406,7 +406,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Terminal<Pk, Ctx> {
 
 impl<Pk, Ctx> expression::FromTree for Arc<Terminal<Pk, Ctx>>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     Ctx: ScriptContext,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
@@ -418,7 +419,8 @@ where
 
 impl<Pk, Ctx> expression::FromTree for Terminal<Pk, Ctx>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     Ctx: ScriptContext,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -303,6 +303,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// accept sane scripts.
     pub fn from_str_insane(s: &str) -> Result<Miniscript<Pk, Ctx>, Error>
     where
+        Pk: str::FromStr,
+        Pk::Hash: str::FromStr,
         <Pk as str::FromStr>::Err: ToString,
         <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
     {
@@ -364,7 +366,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 
 impl<Pk, Ctx> expression::FromTree for Arc<Miniscript<Pk, Ctx>>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     Ctx: ScriptContext,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
@@ -376,7 +379,8 @@ where
 
 impl<Pk, Ctx> expression::FromTree for Miniscript<Pk, Ctx>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     Ctx: ScriptContext,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
@@ -399,7 +403,8 @@ where
 /// do not clear the [Miniscript::sanity_check] checks.
 impl<Pk, Ctx> str::FromStr for Miniscript<Pk, Ctx>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     Ctx: ScriptContext,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
@@ -460,7 +465,8 @@ mod tests {
         expected_debug: Str1,
         expected_display: Str2,
     ) where
-        Pk: MiniscriptKey,
+        Pk: MiniscriptKey + str::FromStr,
+        Pk::Hash: str::FromStr,
         Ctx: ScriptContext,
         <Pk as str::FromStr>::Err: ToString,
         <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -483,7 +483,8 @@ impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
 
 impl<Pk> str::FromStr for Policy<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
 {
@@ -507,7 +508,8 @@ serde_string_impl_pk!(Policy, "a miniscript concrete policy");
 
 impl<Pk> Policy<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as str::FromStr>::Err: ToString,
 {
     /// Helper function for `from_tree` to parse subexpressions with
@@ -617,7 +619,8 @@ where
 
 impl<Pk> FromTree for Policy<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as str::FromStr>::Err: ToString,
 {
     fn from_tree(top: &expression::Tree) -> Result<Policy<Pk>, Error> {

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -258,7 +258,8 @@ impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
 
 impl<Pk> str::FromStr for Policy<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
 {
@@ -280,7 +281,8 @@ serde_string_impl_pk!(Policy, "a miniscript semantic policy");
 
 impl<Pk> expression::FromTree for Policy<Pk>
 where
-    Pk: MiniscriptKey,
+    Pk: MiniscriptKey + str::FromStr,
+    Pk::Hash: str::FromStr,
     <Pk as str::FromStr>::Err: ToString,
     <<Pk as MiniscriptKey>::Hash as str::FromStr>::Err: ToString,
 {


### PR DESCRIPTION
Without this bound you can't deserialize, but there are lots of in-memory things you might like to do with weird keytypes (e.g. looking up a bunch of aux data from a database and tagging keys with them, or even attaching an `&'a wallet`) where the requirement to impl `FromStr` is extremely onerous.