### PR TITLE
Fix checksum for nested sh(wpkh())

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1388,4 +1388,15 @@ pk(03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8))";
         // try to turn it back into a string with the secrets
         assert_eq!(descriptor_str, descriptor.to_string_with_secret(&keymap));
     }
+
+    #[test]
+    fn checksum_for_nested_sh() {
+        let descriptor_str = "sh(wpkh(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL))";
+        let descriptor: Descriptor<DescriptorPublicKey> = descriptor_str.parse().unwrap();
+        assert_eq!(descriptor.to_string(), "sh(wpkh(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL))#tjp2zm88");
+
+        let descriptor_str = "sh(wsh(pk(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL)))";
+        let descriptor: Descriptor<DescriptorPublicKey> = descriptor_str.parse().unwrap();
+        assert_eq!(descriptor.to_string(), "sh(wsh(pk(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL)))#6c6hwr22");
+    }
 }

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -63,6 +63,14 @@ impl<Pk: MiniscriptKey> Wsh<Pk> {
     pub fn as_inner(&self) -> &WshInner<Pk> {
         &self.inner
     }
+
+    /// Get the descriptor without the checksum
+    pub fn to_string_no_checksum(&self) -> String {
+        match self.inner {
+            WshInner::SortedMulti(ref smv) => format!("wsh({})", smv),
+            WshInner::Ms(ref ms) => format!("wsh({})", ms),
+        }
+    }
 }
 
 /// Wsh Inner
@@ -123,10 +131,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Wsh<Pk> {
 
 impl<Pk: MiniscriptKey> fmt::Display for Wsh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let desc = match self.inner {
-            WshInner::SortedMulti(ref smv) => format!("wsh({})", smv),
-            WshInner::Ms(ref ms) => format!("wsh({})", ms),
-        };
+        let desc = self.to_string_no_checksum();
         let checksum = desc_checksum(&desc).map_err(|_| fmt::Error)?;
         write!(f, "{}#{}", &desc, &checksum)
     }
@@ -293,6 +298,11 @@ impl<Pk: MiniscriptKey> Wpkh<Pk> {
     pub fn as_inner(&self) -> &Pk {
         &self.pk
     }
+
+    /// Get the descriptor without the checksum
+    pub fn to_string_no_checksum(&self) -> String {
+        format!("wpkh({})", self.pk)
+    }
 }
 
 impl<Pk: MiniscriptKey> fmt::Debug for Wpkh<Pk> {
@@ -303,7 +313,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Wpkh<Pk> {
 
 impl<Pk: MiniscriptKey> fmt::Display for Wpkh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let desc = format!("wpkh({})", self.pk);
+        let desc = self.to_string_no_checksum();
         let checksum = desc_checksum(&desc).map_err(|_| fmt::Error)?;
         write!(f, "{}#{}", &desc, &checksum)
     }

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -82,13 +82,8 @@ impl<Pk: MiniscriptKey> fmt::Debug for Sh<Pk> {
 impl<Pk: MiniscriptKey> fmt::Display for Sh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let desc = match self.inner {
-            // extra nesting because the impl of "{}" returns the checksum
-            // which we don't want
-            ShInner::Wsh(ref wsh) => match wsh.as_inner() {
-                super::segwitv0::WshInner::SortedMulti(ref smv) => format!("sh(wsh({}))", smv),
-                super::segwitv0::WshInner::Ms(ref ms) => format!("sh(wsh({}))", ms),
-            },
-            ShInner::Wpkh(ref pk) => format!("sh({})", pk),
+            ShInner::Wsh(ref wsh) => format!("sh({})", wsh.to_string_no_checksum()),
+            ShInner::Wpkh(ref pk) => format!("sh({})", pk.to_string_no_checksum()),
             ShInner::SortedMulti(ref smv) => format!("sh({})", smv),
             ShInner::Ms(ref ms) => format!("sh({})", ms),
         };


### PR DESCRIPTION
Only include it for the outer descriptor and not for the inner one.

This was already considered for `sh(wsh(..))`, but not for `sh(wpkh(..))`, which resulted in `sh(wpkh(<key>)#<checksum1>)#<checksum2>`.