### PR TITLE
Satisfaction bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 repository = "https://github.com/apoelstra/miniscript"
 description = "Miniscript: a subset of Bitcoin Script designed for analysis"

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -120,7 +120,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for Older {
 
         let mask = SEQUENCE_LOCKTIME_MASK | SEQUENCE_LOCKTIME_TYPE_FLAG;
         let masked_n = n & mask;
-        let masked_seq = n & self.0;
+        let masked_seq = self.0 & mask;
         if masked_n < SEQUENCE_LOCKTIME_TYPE_FLAG && masked_seq >= SEQUENCE_LOCKTIME_TYPE_FLAG {
             false
         } else {


### PR DESCRIPTION
The first one is a serious one which caused incorrect results. 

~~While the second one is a relaxation of rules that allow dissatisfactions to be malleable. Because of this, earlier we were not able to satisfy a miniscript that required ORI dissatisfaction where both of the available dissatisfactions were malleable. (which is almost always the case).~~