### PR TITLE
Explicitly error on non-standard sighash types

### DIFF
--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use bitcoin::hashes::hash160;
+use bitcoin::hashes::{hash160, hex::ToHex};
 use bitcoin::{self, secp256k1};
 use std::{error, fmt};
 
@@ -39,6 +39,8 @@ pub enum Error {
     InsufficientSignaturesMultiSig,
     /// Signature failed to verify
     InvalidSignature(bitcoin::PublicKey),
+    /// Last byte of this signature isn't a standard sighash type
+    NonStandardSigHash(Vec<u8>),
     /// Miniscript error
     Miniscript(::Error),
     /// MultiSig requires 1 extra zero element apart from the `k` signatures
@@ -128,6 +130,13 @@ impl fmt::Display for Error {
             Error::IncorrectWScriptHash => f.write_str("witness script did not match scriptpubkey"),
             Error::InsufficientSignaturesMultiSig => f.write_str("Insufficient signatures for CMS"),
             Error::InvalidSignature(pk) => write!(f, "bad signature with pk {}", pk),
+            Error::NonStandardSigHash(ref sig) => {
+                write!(
+                    f,
+                    "Non standard sighash type for signature '{}'",
+                    sig.to_hex()
+                )
+            }
             Error::NonEmptyWitness => f.write_str("legacy spend had nonempty witness"),
             Error::NonEmptyScriptSig => f.write_str("segwit spend had nonempty scriptsig"),
             Error::Miniscript(ref e) => write!(f, "parse error: {}", e),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -757,7 +757,8 @@ where
     F: FnOnce(&bitcoin::PublicKey, BitcoinSig) -> bool,
 {
     if let Some((sighash_byte, sig)) = sigser.split_last() {
-        let sighashtype = bitcoin::SigHashType::from_u32(*sighash_byte as u32);
+        let sighashtype = bitcoin::SigHashType::from_u32_standard(*sighash_byte as u32)
+            .map_err(|_| Error::NonStandardSigHash([sig, &[*sighash_byte]].concat().to_vec()))?;
         let sig = secp256k1::Signature::from_der(sig)?;
         if verify_sig(pk, (sig, sighashtype)) {
             Ok(sig)

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -262,7 +262,14 @@ pub fn finalize<C: secp256k1::Verification>(
                 ));
             }
             let (flag, sig) = rawsig.split_last().unwrap();
-            let flag = bitcoin::SigHashType::from_u32(*flag as u32);
+            let flag = bitcoin::SigHashType::from_u32_standard(*flag as u32).map_err(|_| {
+                super::Error::InputError(
+                    InputError::Interpreter(interpreter::Error::NonStandardSigHash(
+                        [sig, &[*flag]].concat().to_vec(),
+                    )),
+                    n,
+                )
+            })?;
             if target != flag {
                 return Err(Error::InputError(
                     InputError::WrongSigHashFlag {


### PR DESCRIPTION
I forgot to append the ANYONECANPAY flag with my boutique signer for hand-testing and spent some time before realising we were actually treating the last byte of the sig as a valid SIGHASH_ALL in the finalizer !
I believe it's cleaner to error early on too short signatures.

EDIT (made after the comments below): actually if i was just using SIGHASH_ALL i could have messed up my sighash type and not notifying it. Even though checking this is on the user of the lib, i believe it would be much nicer to not silently accept invalid-by-standardness signatures in rust-miniscript.