### PR TITLE
Thresh bug with equal verify

### DIFF
--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -280,6 +280,13 @@ pub fn parse<Ctx: ScriptContext>(
                                     ))?
                                 },
                             ),
+                            Tk::Num(k) => {
+                                non_term.push(NonTerm::Verify);
+                                non_term.push(NonTerm::ThreshW {
+                                    k: k as usize,
+                                    n: 0
+                                });
+                            },
                         ),
                         x => {
                             tokens.un_next(x);

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -874,6 +874,12 @@ mod tests {
              OP_PUSHNUM_1\
              )"
         );
+
+        // Thresh bug with equal verify roundtrip
+        roundtrip(
+            &ms_str!("tv:thresh(1,pk(02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e))", ),
+            "Script(OP_PUSHBYTES_33 02d7924d4f7d43ea965a465ae3095ff41131e5946f3c85f79e44adbcf8e27e080e OP_CHECKSIG OP_PUSHNUM_1 OP_EQUALVERIFY OP_PUSHNUM_1)",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Parsing an `EQUALVERIFY` ending thresh fragment failed roundtrip. 