### PR TITLE
Exclusive bounds for thresh: 1 < k < n

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,9 @@ pub enum Error {
     Script(script::Error),
     /// A `CHECKMULTISIG` opcode was preceded by a number > 20
     CmsTooManyKeys(u32),
+    /// A threshold with either a single subpolicy or as many subpolicies as the threshold value.
+    /// (threhshold, number of policies)
+    ThreshLaxBound(usize, usize),
     /// Encountered unprintable character in descriptor
     Unprintable(u8),
     /// expected character while parsing descriptor; didn't find one
@@ -588,6 +591,11 @@ impl fmt::Display for Error {
             Error::InvalidPush(ref push) => write!(f, "invalid push {:?}", push), // TODO hexify this
             Error::Script(ref e) => fmt::Display::fmt(e, f),
             Error::CmsTooManyKeys(n) => write!(f, "checkmultisig with {} keys", n),
+            Error::ThreshLaxBound(k, n) => write!(
+                f,
+                "threshold is 1 or equal to the number of subexpressions (k: '{}', n: '{}')",
+                k, n
+            ),
             Error::Unprintable(x) => write!(f, "unprintable character 0x{:02x}", x),
             Error::ExpectedChar(c) => write!(f, "expected {}", c),
             Error::UnexpectedStart => f.write_str("unexpected start of script"),

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -543,6 +543,9 @@ where
                 if k > n - 1 {
                     return Err(errstr("higher threshold than there are subexpressions"));
                 }
+                if k == 1 || k == n - 1 {
+                    return Err(Error::ThreshLaxBound(k, n));
+                }
                 if n == 1 {
                     return Err(errstr("empty thresholds not allowed in descriptors"));
                 }

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -452,6 +452,10 @@ pub fn parse<Ctx: ScriptContext>(
                 });
             }
             Some(NonTerm::ThreshW { n, k }) => {
+                if k == 1 || k == n {
+                    return Err(Error::ThreshLaxBound(k, n));
+                }
+
                 match_token!(
                     tokens,
                     Tk::Add => {
@@ -466,6 +470,10 @@ pub fn parse<Ctx: ScriptContext>(
                 non_term.push(NonTerm::Expression);
             }
             Some(NonTerm::ThreshE { n, k }) => {
+                if k == 1 || k == n {
+                    return Err(Error::ThreshLaxBound(k, n));
+                }
+
                 let mut subs = Vec::with_capacity(n);
                 for _ in 0..n {
                     subs.push(Arc::new(term.pop().unwrap()));

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -690,6 +690,16 @@ mod tests {
     }
 
     #[test]
+    fn verify_parse_err() {
+        let ms = "thresh(4,pkh(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa),a:pkh(027e4bc15e683fe4196a049c9883eb27a5fc83875dde4bb11f6f7f333065bc5b48),a:pkh(035ed174429dd08c052a3d941e341e3737555b635622c446ec209a0957f53fb545),a:pkh(026ebb33dbb36c6723422155bf852fa33ac323763132de5c061526c44397eca95b))";
+        let ms: Result<Segwitv0Script, _> = Miniscript::from_str_insane(ms);
+        assert!(ms
+            .unwrap_err()
+            .to_string()
+            .contains("threshold is 1 or equal to the number of subexpressions"));
+    }
+
+    #[test]
     fn pk_alias() {
         let pubkey = pubkeys(1)[0];
 

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1580,9 +1580,9 @@ mod benches {
     use test::{black_box, Bencher};
 
     use super::{CompilerError, Concrete};
-    use miniscript::Segwitv0;
-    use Miniscript;
+    use miniscript::{Miniscript, Segwitv0};
     type SegwitMsRes = Result<Miniscript<String, Segwitv0>, CompilerError>;
+
     #[bench]
     pub fn compile_basic(bh: &mut Bencher) {
         let h = (0..64).map(|_| "a").collect::<String>();
@@ -1616,6 +1616,17 @@ mod benches {
         ).expect("parsing");
         bh.iter(|| {
             let pt: SegwitMsRes = pol.compile();
+            black_box(pt).unwrap();
+        });
+    }
+
+    // Compile a Policy 'thresh' with 8 sub-policies (and some of them being slightly nested)
+    // that will be compiled to nested Miniscript 'or's
+    #[bench]
+    pub fn compile_thresh_dis(bh: &mut Bencher) {
+        let thresh: Concrete<String> = Concrete::from_str(&format!("thresh(1,pk(A),pk(B),and(pk(C),pk(D)),and(pk(E),pk(F)),and(pk(G),pk(H)),and(pk(I),pk(J)),pk(K),and(pk(N),older(10)))")).expect("parsing");
+        bh.iter(|| {
+            let pt: SegwitMsRes = thresh.compile();
             black_box(pt).unwrap();
         });
     }


### PR DESCRIPTION
~~Currently a draft as i'm unsure how to proceed with the compiler. For `k == n`, we already translate to `and()`s, but for `k == 1` we stepped by because of the exponential behaviour (see https://github.com/rust-bitcoin/rust-miniscript/issues/126).~~

(Credits to @stepansnigirev for finding the inconsistency)
Fixes #241 
Fixes #237
Fixes #126