### PR TITLE
Derive std::hash::Hash for Descriptor et al

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,8 +66,12 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Pin cc if rust 1.29
+      - name: Pin deps if rust 1.29
         if: matrix.rust == '1.29.0'
-        run: cargo generate-lockfile --verbose && cargo update -p cc --precise "1.0.41" --verbose
+        run: |
+            cargo generate-lockfile --verbose && \
+            cargo update --verbose --package "cc" --precise "1.0.41" && \
+            cargo update --verbose --package "serde" --precise "1.0.98" && \
+            cargo update --verbose --package "serde_derive" --precise "1.0.98"
       - name: Running cargo
         run: ./contrib/test.sh

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ coins in a given Bitcoin transaction
 More information can be found in [the documentation](https://docs.rs/miniscript)
 or in [the `examples/` directory](https://github.com/apoelstra/rust-miniscript/tree/master/examples)
 
+
+## Minimum Supported Rust Version (MSRV)
+This library should always compile with any combination of features on **Rust 1.29**.
+
+Because some dependencies have broken the build in minor/patch releases, to
+compile with 1.29.0 you will need to run the following version-pinning command:
+```
+cargo update -p cc --precise "1.0.41" --verbose
+```
+
+In order to use the `use-serde` feature or to build the unit tests with 1.29.0,
+the following version-pinning commands are also needed:
+```
+cargo update --package "serde" --precise "1.0.98"
+cargo update --package "serde_derive" --precise "1.0.98"
+```
+
+
 ## Contributing
 Contributions are generally welcome. If you intend to make larger changes please
 discuss them in an issue before PRing them to avoid duplicate work and

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-FEATURES="compiler serde"
+FEATURES="compiler use-serde rand"
 
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -38,7 +38,7 @@ use super::{
 
 /// Create a Bare Descriptor. That is descriptor that is
 /// not wrapped in sh or wsh. This covers the Pk descriptor
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Bare<Pk: MiniscriptKey> {
     /// underlying miniscript
     ms: Miniscript<Pk, BareCtx>,
@@ -203,7 +203,7 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Bare<P> {
 }
 
 /// A bare PkH descriptor at top level
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Pkh<Pk: MiniscriptKey> {
     /// underlying publickey
     pk: Pk,

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -154,7 +154,7 @@ pub trait DescriptorTrait<Pk: MiniscriptKey> {
 }
 
 /// Script descriptor
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Descriptor<Pk: MiniscriptKey> {
     /// A raw scriptpubkey (including pay-to-pubkey) under Legacy context
     Bare(Bare<Pk>),

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -34,7 +34,7 @@ use super::{
     DescriptorTrait, SortedMultiVec,
 };
 /// A Segwitv0 wsh descriptor
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Wsh<Pk: MiniscriptKey> {
     /// underlying miniscript
     inner: WshInner<Pk>,
@@ -79,7 +79,7 @@ impl<Pk: MiniscriptKey> Wsh<Pk> {
 }
 
 /// Wsh Inner
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum WshInner<Pk: MiniscriptKey> {
     /// Sorted Multi
     SortedMulti(SortedMultiVec<Pk, Segwitv0>),
@@ -282,7 +282,7 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Wsh<P> {
 }
 
 /// A bare Wpkh descriptor at top level
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Wpkh<Pk: MiniscriptKey> {
     /// underlying publickey
     pk: Pk,

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -38,14 +38,14 @@ use super::{
 };
 
 /// A Legacy p2sh Descriptor
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Sh<Pk: MiniscriptKey> {
     /// underlying miniscript
     inner: ShInner<Pk>,
 }
 
 /// Sh Inner
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum ShInner<Pk: MiniscriptKey> {
     /// Nested Wsh
     Wsh(Wsh<Pk>),

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -27,7 +27,7 @@ use script_num_size;
 use {errstr, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey};
 
 /// Contents of a "sortedmulti" descriptor
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SortedMultiVec<Pk: MiniscriptKey, Ctx: ScriptContext> {
     /// signatures required
     pub k: usize,

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -12,15 +12,17 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+use std::{fmt, hash};
+
 use miniscript::limits::{
     MAX_OPS_PER_SCRIPT, MAX_SCRIPTSIG_SIZE, MAX_SCRIPT_ELEMENT_SIZE, MAX_SCRIPT_SIZE,
     MAX_STANDARD_P2WSH_SCRIPT_SIZE, MAX_STANDARD_P2WSH_STACK_ITEMS,
 };
 use miniscript::types;
-use std::fmt;
 use util::witness_to_scriptsig;
 use Error;
 use {Miniscript, MiniscriptKey, Terminal};
+
 /// Error for Script Context
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum ScriptContextError {
@@ -106,7 +108,7 @@ impl fmt::Display for ScriptContextError {
 /// context under which the script is used.
 /// For example, disallowing uncompressed keys in Segwit context
 pub trait ScriptContext:
-    fmt::Debug + Clone + Ord + PartialOrd + Eq + PartialEq + private::Sealed
+    fmt::Debug + Clone + Ord + PartialOrd + Eq + PartialEq + hash::Hash + private::Sealed
 {
     /// Depending on ScriptContext, fragments can be malleable. For Example,
     /// under Legacy context, PkH is malleable because it is possible to


### PR DESCRIPTION
Actually, I'm quite confused by this. The `Miniscript` type derives `Hash` without the `ScriptContext` trait requiring `Hash`, but when I tried for `Descriptor` it would complain about that. Is there some magic that made it work in `Miniscript`? Ideally we wouldn't require the `Hash` on `ScriptContext` there, but it doesn't hurt either.