### PR TITLE
replicate fuzz

### DIFF
--- a/fuzz/fuzz_targets/parse_descriptor.rs
+++ b/fuzz/fuzz_targets/parse_descriptor.rs
@@ -5,8 +5,10 @@ use std::str::FromStr;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
+    println!("{}", data_str);
     if let Ok(dpk) = DescriptorPublicKey::from_str(&data_str) {
         let output = dpk.to_string();
+        println!("{} {}", data_str.to_lowercase(), output.to_lowercase());
         assert_eq!(data_str.to_lowercase(), output.to_lowercase());
     }
 }
@@ -29,5 +31,38 @@ fn main() {
         fuzz!(|data| {
             do_test(data);
         });
+    }
+}
+#[cfg(test)]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'...b'F' => b |= c - b'A' + 10,
+                b'a'...b'f' => b |= c - b'a' + 10,
+                b'0'...b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash2() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("30343935346262626162626262626262626162626262626262623034626262626162626262626262626262626262626262626262626262626262626262626262373562626262626262626262626262626262626262626262626262626262626262626262626262383462626262626242626262626262363735343030326262356262", &mut a);
+        super::do_test(&a);
+    }
+
+    #[test]
+    fn duplicate_crash3() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("30343131393131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131313131", &mut a);
+        super::do_test(&a);
     }
 }


### PR DESCRIPTION
```
303439353462626261626262626262626261626262626262626230346262
626261626262626262626262626262626262626262626262626262626262
626262623735626262626262626262626262626262626262626262626262
626262626262626262626262623834626262626262426262626262623637
35343030326262356262
```
Unable to replicate the crash from https://github.com/rust-bitcoin/rust-miniscript/runs/3041068605 locally. Creating a upstream to retest the same vector on CI