### PR TITLE
Bump bitcoin dependency to 0.26.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ use-serde = ["bitcoin/use-serde", "serde"]
 rand = ["bitcoin/rand"]
 
 [dependencies]
-bitcoin = "0.26"
+bitcoin = "0.26.2"
 
 [dependencies.serde]
 version = "1.0"


### PR DESCRIPTION
Needed because some method from .2 is used now.