### PR TITLE
Bump rust-bitcoin dependency to v0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ use-serde = ["bitcoin/use-serde", "serde"]
 rand = ["bitcoin/rand"]
 
 [dependencies]
-bitcoin = "0.26.2"
+bitcoin = "0.27"
 
 [dependencies.serde]
 version = "1.0"


### PR DESCRIPTION
Needed because `rust-bitcoin v0.27` has added Bech32m address support, see the complete changelog [here](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/CHANGELOG.md#027---2020-07-21).