### PR TITLE
Taproot descriptor

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -45,6 +45,7 @@ mod bare;
 mod segwitv0;
 mod sh;
 mod sortedmulti;
+mod tr;
 // Descriptor Exports
 pub use self::bare::{Bare, Pkh};
 pub use self::segwitv0::{Wpkh, Wsh, WshInner};
@@ -53,6 +54,7 @@ pub use self::sortedmulti::SortedMultiVec;
 
 mod checksum;
 mod key;
+
 pub use self::key::{
     ConversionError, DescriptorKeyParseError, DescriptorPublicKey, DescriptorSecretKey,
     DescriptorSinglePriv, DescriptorSinglePub, DescriptorXKey, InnerXKey, Wildcard,

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -1,0 +1,260 @@
+// Tapscript
+
+use super::checksum::{desc_checksum, verify_checksum};
+use bitcoin::hashes::_export::_core::fmt::Formatter;
+use errstr;
+use expression::{self, FromTree, Tree};
+use miniscript::{limits::TAPROOT_MAX_NODE_COUNT, Miniscript};
+use std::cmp::max;
+use std::sync::Arc;
+use std::{fmt, str::FromStr};
+use Segwitv0;
+use {Error, MiniscriptKey};
+
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum TapTree<Pk: MiniscriptKey> {
+    Tree(Arc<TapTree<Pk>>, Arc<TapTree<Pk>>),
+    Leaf(Arc<Miniscript<Pk, Segwitv0>>),
+}
+
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct Tr<Pk: MiniscriptKey> {
+    internal_key: Pk,
+    tree: Option<TapTree<Pk>>,
+}
+
+impl<Pk: MiniscriptKey> TapTree<Pk> {
+    fn taptree_height(&self) -> usize {
+        match *self {
+            TapTree::Tree(ref left_tree, ref right_tree) => {
+                1 + max(left_tree.taptree_height(), right_tree.taptree_height())
+            }
+            TapTree::Leaf(_) => 1,
+        }
+    }
+
+    pub fn to_string_no_checksum(&self) -> String {
+        match self {
+            TapTree::Tree(ref left, ref right) => {
+                format!("{{{},{}}}", *left, *right)
+            }
+            TapTree::Leaf(ref script) => format!("{}", *script),
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey> fmt::Display for TapTree<Pk> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let desc = self.to_string_no_checksum();
+        write!(f, "{}", &desc)
+    }
+}
+
+impl<Pk: MiniscriptKey> Tr<Pk> {
+    pub fn new(internal_key: Pk, tree: Option<TapTree<Pk>>) -> Result<Self, Error> {
+        let nodes = match tree {
+            Some(ref t) => t.taptree_height(),
+            None => 0,
+        };
+
+        if nodes <= TAPROOT_MAX_NODE_COUNT {
+            Ok(Self { internal_key, tree })
+        } else {
+            Err(Error::MaxRecursiveDepthExceeded)
+        }
+    }
+
+    fn to_string_no_checksum(&self) -> String {
+        let key = &self.internal_key;
+        match self.tree {
+            Some(ref s) => format!("tr({},{})", key, s),
+            None => format!("tr({})", key),
+        }
+    }
+
+    pub fn internal_key(&self) -> &Pk {
+        &self.internal_key
+    }
+
+    pub fn taptree(&self) -> &Option<TapTree<Pk>> {
+        &self.tree
+    }
+}
+
+impl<Pk> Tr<Pk>
+where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
+    <Pk as FromStr>::Err: ToString,
+    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
+{
+    pub fn tr_script_path(tree: &Tree) -> Result<TapTree<Pk>, Error> {
+        match tree {
+            Tree { name, args } if name.len() > 0 && args.len() == 0 => {
+                let script = Miniscript::<Pk, Segwitv0>::from_str(name)?;
+                Ok(TapTree::Leaf(Arc::new(script)))
+            }
+            Tree { name, args } if name.len() == 0 && args.len() == 2 => {
+                let left = Self::tr_script_path(&args[0])?;
+                let right = Self::tr_script_path(&args[1])?;
+                Ok(TapTree::Tree(Arc::new(left), Arc::new(right)))
+            }
+            _ => {
+                return Err(Error::Unexpected(
+                    "unknown format for script spending paths while parsing taproot descriptor"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey> FromTree for Tr<Pk>
+where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
+    <Pk as FromStr>::Err: ToString,
+    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
+{
+    fn from_tree(top: &Tree) -> Result<Self, Error> {
+        if top.name == "tr" {
+            match top.args.len() {
+                1 => {
+                    let key = &top.args[0];
+                    if key.args.len() > 0 {
+                        return Err(Error::Unexpected(format!(
+                            "#{} script associated with `key-path` while parsing taproot descriptor",
+                            key.args.len()
+                        )));
+                    }
+                    Ok(Tr {
+                        internal_key: expression::terminal(key, Pk::from_str)?,
+                        tree: None,
+                    })
+                }
+                2 => {
+                    let ref key = top.args[0];
+                    if key.args.len() > 0 {
+                        return Err(Error::Unexpected(format!(
+                            "#{} script associated with `key-path` while parsing taproot descriptor",
+                            key.args.len()
+                        )));
+                    }
+                    let ref tree = top.args[1];
+                    let ret = Tr::tr_script_path(tree)?;
+                    Ok(Tr {
+                        internal_key: expression::terminal(key, Pk::from_str)?,
+                        tree: Some(ret),
+                    })
+                }
+                _ => {
+                    return Err(Error::Unexpected(format!(
+                        "{}[#{} args] while parsing taproot descriptor",
+                        top.name,
+                        top.args.len()
+                    )));
+                }
+            }
+        } else {
+            return Err(Error::Unexpected(format!(
+                "{}[#{} args] while parsing taproot descriptor",
+                top.name,
+                top.args.len()
+            )));
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey> FromStr for Tr<Pk>
+where
+    Pk: MiniscriptKey + FromStr,
+    Pk::Hash: FromStr,
+    <Pk as FromStr>::Err: ToString,
+    <<Pk as MiniscriptKey>::Hash as FromStr>::Err: ToString,
+{
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let desc_str = verify_checksum(s)?;
+        let top = parse_tr(desc_str)?;
+        Self::from_tree(&top)
+    }
+}
+
+impl<Pk: MiniscriptKey> fmt::Display for Tr<Pk> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let desc = self.to_string_no_checksum();
+        let checksum = desc_checksum(&desc).map_err(|_| fmt::Error)?;
+        write!(f, "{}#{}", &desc, &checksum)
+    }
+}
+
+fn parse_tr(s: &str) -> Result<Tree, Error> {
+    for ch in s.bytes() {
+        if ch > 0x7f {
+            return Err(Error::Unprintable(ch));
+        }
+    }
+
+    let ret = if s.len() > 3 && &s[..3] == "tr(" && s.as_bytes()[s.len() - 1] == b')' {
+        let rest = &s[3..s.len() - 1];
+        if !rest.contains(',') {
+            let internal_key = Tree {
+                name: rest,
+                args: vec![],
+            };
+            return Ok(Tree {
+                name: "tr",
+                args: vec![internal_key],
+            });
+        }
+        // use str::split_once() method to refactor this when compiler version bumps up
+        let (key, script) = split_once(rest, ',')
+            .ok_or_else(|| Error::BadDescriptor("invalid taproot descriptor".to_string()))?;
+
+        let internal_key = Tree {
+            name: key,
+            args: vec![],
+        };
+        if script.is_empty() {
+            return Ok(Tree {
+                name: "tr",
+                args: vec![internal_key],
+            });
+        }
+        let (tree, rest) = expression::Tree::from_slice_helper_curly(script, 1)?;
+        if rest.is_empty() {
+            Ok(Tree {
+                name: "tr",
+                args: vec![internal_key, tree],
+            })
+        } else {
+            Err(errstr(rest))
+        }
+    } else {
+        Err(Error::Unexpected("invalid taproot descriptor".to_string()))
+    };
+
+    return ret;
+}
+
+fn split_once(inp: &str, delim: char) -> Option<(&str, &str)> {
+    let ret = if inp.len() == 0 {
+        None
+    } else {
+        let mut found = inp.len();
+        for (idx, ch) in inp.chars().enumerate() {
+            if ch == delim {
+                found = idx;
+                break;
+            }
+        }
+        // No comma or trailing comma found
+        if found >= inp.len() - 1 {
+            Some((&inp[..], ""))
+        } else {
+            Some((&inp[..found], &inp[found + 1..]))
+        }
+    };
+    return ret;
+}

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -38,11 +38,12 @@ pub trait FromTree: Sized {
 }
 
 impl<'a> Tree<'a> {
-    fn from_slice(sl: &'a str) -> Result<(Tree<'a>, &'a str), Error> {
-        Self::from_slice_helper(sl, 0u32)
+    pub fn from_slice(sl: &'a str) -> Result<(Tree<'a>, &'a str), Error> {
+        // Parsing TapTree or just miniscript
+        Self::from_slice_helper_round(sl, 0u32)
     }
 
-    fn from_slice_helper(mut sl: &'a str, depth: u32) -> Result<(Tree<'a>, &'a str), Error> {
+    fn from_slice_helper_round(mut sl: &'a str, depth: u32) -> Result<(Tree<'a>, &'a str), Error> {
         if depth >= MAX_RECURSION_DEPTH {
             return Err(Error::MaxRecursiveDepthExceeded);
         }
@@ -98,7 +99,7 @@ impl<'a> Tree<'a> {
 
                 sl = &sl[n + 1..];
                 loop {
-                    let (arg, new_sl) = Tree::from_slice_helper(sl, depth + 1)?;
+                    let (arg, new_sl) = Tree::from_slice_helper_round(sl, depth + 1)?;
                     ret.args.push(arg);
 
                     if new_sl.is_empty() {
@@ -109,6 +110,94 @@ impl<'a> Tree<'a> {
                     match new_sl.as_bytes()[0] {
                         b',' => {}
                         b')' => break,
+                        _ => return Err(Error::ExpectedChar(',')),
+                    }
+                }
+                Ok((ret, sl))
+            }
+        }
+    }
+
+    pub fn from_slice_helper_curly(
+        mut sl: &'a str,
+        depth: u32,
+    ) -> Result<(Tree<'a>, &'a str), Error> {
+        // contain the context of brackets
+        if depth >= MAX_RECURSION_DEPTH {
+            return Err(Error::MaxRecursiveDepthExceeded);
+        }
+        enum Found {
+            Nothing,
+            Lbrace(usize),
+            Comma(usize),
+            Rbrace(usize),
+        }
+
+        let mut found = Found::Nothing;
+        let mut new_count = 0;
+        for (n, ch) in sl.char_indices() {
+            match ch {
+                '{' => {
+                    found = Found::Lbrace(n);
+                    break;
+                }
+                '(' => {
+                    new_count += 1;
+                }
+                ',' => {
+                    if new_count == 0 {
+                        found = Found::Comma(n);
+                        break;
+                    }
+                }
+                ')' => {
+                    new_count -= 1;
+                }
+                '}' => {
+                    found = Found::Rbrace(n);
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        match found {
+            // String-ending terminal
+            Found::Nothing => Ok((
+                Tree {
+                    name: &sl[..],
+                    args: vec![],
+                },
+                "",
+            )),
+            // Terminal
+            Found::Comma(n) | Found::Rbrace(n) => Ok((
+                Tree {
+                    name: &sl[..n],
+                    args: vec![],
+                },
+                &sl[n..],
+            )),
+            // Function call
+            Found::Lbrace(n) => {
+                let mut ret = Tree {
+                    name: &sl[..n], // Would be empty for left and right assignments
+                    args: vec![],
+                };
+
+                sl = &sl[n + 1..];
+                loop {
+                    let (arg, new_sl) = Tree::from_slice_helper_curly(sl, depth + 1)?;
+                    ret.args.push(arg);
+
+                    if new_sl.is_empty() {
+                        return Err(Error::ExpectedChar('}'));
+                    }
+
+                    sl = &new_sl[1..];
+                    match new_sl.as_bytes()[0] {
+                        b',' => {}
+                        b'}' => break,
                         _ => return Err(Error::ExpectedChar(',')),
                     }
                 }
@@ -206,4 +295,7 @@ mod tests {
         assert!(parse_num("+6").is_err());
         assert!(parse_num("-6").is_err());
     }
+
+    // Add tests for tapscript parsing
+    // tr(D,{or_i(pk(A),pk(B)),{after(9),pk(C)}})
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,9 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![deny(dead_code)]
+// #![deny(dead_code)]
 #![deny(unused_imports)]
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 
 pub extern crate bitcoin;
 #[cfg(feature = "serde")]

--- a/src/miniscript/limits.rs
+++ b/src/miniscript/limits.rs
@@ -40,3 +40,7 @@ pub const MAX_SCRIPT_ELEMENT_SIZE: usize = 520;
 /// Maximum script sig size allowed by standardness rules
 // https://github.com/bitcoin/bitcoin/blob/42b66a6b814bca130a9ccf0a3f747cf33d628232/src/policy/policy.cpp#L102
 pub const MAX_SCRIPTSIG_SIZE: usize = 1650;
+
+/// Maximum number of scripts allowed by standardness rules in TapTree format
+// https://github.com/bitcoin/bitcoin/blob/81f4a3e84d6f30e7b12a9605dabc3359f614da93/src/script/interpreter.h#L229
+pub const TAPROOT_MAX_NODE_COUNT: usize = 128;


### PR DESCRIPTION
This defines tree structure for *TapTree* and implements parsing of **Taproot Descriptors** as a part of #255 . The purpose is to get basic functionalities for the same and  integrate it with the Miniscript compiler.

Feedback about changes to [tr.rs](https://github.com/SarcasticNastik/rust-miniscript/blob/c0930e623802fafbfacccb8cb062bf16ffb3ee52/src/descriptor/tr.rs) and [expression.rs](https://github.com/SarcasticNastik/rust-miniscript/blob/c0930e623802fafbfacccb8cb062bf16ffb3ee52/src/expression.rs) would be really appreciated. 
- Currently helper functions specific to `Tr` are required to parse taproot descriptor into `Tree` (as defined in [expression.rs](https://github.com/SarcasticNastik/rust-miniscript/blob/c0930e623802fafbfacccb8cb062bf16ffb3ee52/src/expression.rs)).

## TODO

- [ ] Docs for `tr.rs`
- [x] Pass fuzz tests
- [x] Include hex checksum for taproot descriptor.

## Future Work

- [ ] Implement functionalities required to integrate it with `Descriptor` (in [mod.rs](https://github.com/SarcasticNastik/rust-miniscript/blob/c0930e623802fafbfacccb8cb062bf16ffb3ee52/src/descriptor/mod.rs))