### PR TITLE
Miniscript tapscript support (Pr 2 of 3)

### DIFF
--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -61,10 +61,10 @@ fn main() {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ]).expect("key 3"),
     ];
-    let bitcoin_sig = (
+    let bitcoin_sig = bitcoin::EcdsaSig {
         // copied at random off the blockchain; this is not actually a valid
         // signature for this transaction; Miniscript does not verify
-        secp256k1::ecdsa::Signature::from_str(
+        sig: secp256k1::ecdsa::Signature::from_str(
             "3045\
              0221\
              00f7c3648c390d87578cd79c8016940aa8e3511c4104cb78daa8fb8e429375efc1\
@@ -72,8 +72,8 @@ fn main() {
              531d75c136272f127a5dc14acc0722301cbddc222262934151f140da345af177",
         )
         .unwrap(),
-        bitcoin::EcdsaSigHashType::All,
-    );
+        hash_ty: bitcoin::EcdsaSigHashType::All,
+    };
 
     let descriptor_str = format!(
         "wsh(multi(2,{},{},{}))",
@@ -112,7 +112,7 @@ fn main() {
     // Attempt to satisfy at age 0, height 0
     let original_txin = tx.input[0].clone();
 
-    let mut sigs = HashMap::<bitcoin::PublicKey, miniscript::BitcoinSig>::new();
+    let mut sigs = HashMap::<bitcoin::PublicKey, miniscript::bitcoin::EcdsaSig>::new();
 
     // Doesn't work with no signatures
     assert!(my_descriptor.satisfy(&mut tx.input[0], &sigs).is_err());

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -138,8 +138,8 @@ fn main() {
         .expect("Can only fail in sighash single when corresponding output is not present");
     // Restrict to sighash_all just to demonstrate how to add additional filters
     // `&_` needed here because of https://github.com/rust-lang/rust/issues/79187
-    let vfyfn = move |pk: &_, bitcoinsig: miniscript::BitcoinSig| {
-        bitcoinsig.1 == bitcoin::EcdsaSigHashType::All && vfyfn(pk, bitcoinsig)
+    let vfyfn = move |pk: &_, bitcoinsig: miniscript::bitcoin::EcdsaSig| {
+        bitcoinsig.hash_ty == bitcoin::EcdsaSigHashType::All && vfyfn(pk, bitcoinsig)
     };
 
     println!("\nExample two");
@@ -165,9 +165,9 @@ fn main() {
     )
     .unwrap();
 
-    let iter = interpreter.iter(|pk, (sig, sighashtype)| {
-        sighashtype == bitcoin::EcdsaSigHashType::All
-            && secp.verify_ecdsa(&message, &sig, &pk.key).is_ok()
+    let iter = interpreter.iter(|pk, ecdsa_sig| {
+        ecdsa_sig.hash_ty == bitcoin::EcdsaSigHashType::All
+            && secp.verify_ecdsa(&message, &ecdsa_sig.sig, &pk.key).is_ok()
     });
     println!("\nExample three");
     for elem in iter {

--- a/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
@@ -35,3 +35,30 @@ fn main() {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'...b'F' => b |= c - b'A' + 10,
+                b'a'...b'f' => b |= c - b'a' + 10,
+                b'0'...b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash3() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("1479002d00000020323731363342740000004000000000000000000000000000000000000063630004636363639c00000000000000000000", &mut a);
+        super::do_test(&a);
+    }
+}

--- a/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
@@ -38,3 +38,30 @@ fn main() {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'...b'F' => b |= c - b'A' + 10,
+                b'a'...b'f' => b |= c - b'a' + 10,
+                b'0'...b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("1479002d00000020323731363342740000004000000000000000000000000000000000000063630004636363639c00000000000000000000", &mut a);
+        super::do_test(&a);
+    }
+}

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -335,9 +335,8 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Pkh<Pk> {
         Pk: ToPublicKey,
         S: Satisfier<Pk>,
     {
-        if let Some(sig) = satisfier.lookup_sig(&self.pk) {
-            let mut sig_vec = sig.0.serialize_der().to_vec();
-            sig_vec.push(sig.1.as_u32() as u8);
+        if let Some(sig) = satisfier.lookup_ecdsa_sig(&self.pk) {
+            let sig_vec = sig.to_vec();
             let script_sig = script::Builder::new()
                 .push_slice(&sig_vec[..])
                 .push_key(&self.pk.to_public_key())

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -655,13 +655,12 @@ mod tests {
     use bitcoin::hashes::hex::FromHex;
     use bitcoin::hashes::{hash160, sha256};
     use bitcoin::util::bip32;
-    use bitcoin::{self, secp256k1, PublicKey};
+    use bitcoin::{self, secp256k1, EcdsaSigHashType, PublicKey};
     use descriptor::key::Wildcard;
     use descriptor::{
         DescriptorPublicKey, DescriptorSecretKey, DescriptorSinglePub, DescriptorXKey,
     };
     use hex_script;
-    use miniscript::satisfy::BitcoinSig;
     use std::cmp;
     use std::collections::HashMap;
     use std::str::FromStr;
@@ -950,9 +949,12 @@ mod tests {
         }
 
         impl Satisfier<bitcoin::PublicKey> for SimpleSat {
-            fn lookup_sig(&self, pk: &bitcoin::PublicKey) -> Option<BitcoinSig> {
+            fn lookup_ecdsa_sig(&self, pk: &bitcoin::PublicKey) -> Option<bitcoin::EcdsaSig> {
                 if *pk == self.pk {
-                    Some((self.sig, bitcoin::EcdsaSigHashType::All))
+                    Some(bitcoin::EcdsaSig {
+                        sig: self.sig,
+                        hash_ty: bitcoin::EcdsaSigHashType::All,
+                    })
                 } else {
                     None
                 }
@@ -1161,8 +1163,20 @@ mod tests {
         let satisfier = {
             let mut satisfier = HashMap::with_capacity(2);
 
-            satisfier.insert(a, (sig_a.clone(), ::bitcoin::EcdsaSigHashType::All));
-            satisfier.insert(b, (sig_b.clone(), ::bitcoin::EcdsaSigHashType::All));
+            satisfier.insert(
+                a,
+                bitcoin::EcdsaSig {
+                    sig: sig_a,
+                    hash_ty: EcdsaSigHashType::All,
+                },
+            );
+            satisfier.insert(
+                b,
+                bitcoin::EcdsaSig {
+                    sig: sig_b,
+                    hash_ty: EcdsaSigHashType::All,
+                },
+            );
 
             satisfier
         };

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -436,9 +436,8 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wpkh<Pk> {
         Pk: ToPublicKey,
         S: Satisfier<Pk>,
     {
-        if let Some(sig) = satisfier.lookup_sig(&self.pk) {
-            let mut sig_vec = sig.0.serialize_der().to_vec();
-            sig_vec.push(sig.1.as_u32() as u8);
+        if let Some(sig) = satisfier.lookup_ecdsa_sig(&self.pk) {
+            let sig_vec = sig.to_vec();
             let script_sig = Script::new();
             let witness = vec![sig_vec, self.pk.to_public_key().to_bytes()];
             Ok((witness, script_sig))

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -37,6 +37,8 @@ pub enum Error {
     IncorrectWScriptHash,
     /// MultiSig missing at least `1` witness elements out of `k + 1` required
     InsufficientSignaturesMultiSig,
+    /// Invalid Sighash type
+    InvalidSchnorrSigHashType(Vec<u8>),
     /// Signature failed to verify
     InvalidSignature(bitcoin::PublicKey),
     /// Last byte of this signature isn't a standard sighash type
@@ -138,6 +140,13 @@ impl fmt::Display for Error {
             }
             Error::IncorrectWScriptHash => f.write_str("witness script did not match scriptpubkey"),
             Error::InsufficientSignaturesMultiSig => f.write_str("Insufficient signatures for CMS"),
+            Error::InvalidSchnorrSigHashType(ref sig) => {
+                write!(
+                    f,
+                    "Invalid sighash type for schnorr signature '{}'",
+                    sig.to_hex()
+                )
+            }
             Error::InvalidSignature(pk) => write!(f, "bad signature with pk {}", pk),
             Error::NonStandardSigHash(ref sig) => {
                 write!(

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -17,7 +17,7 @@ use bitcoin::blockdata::witness::Witness;
 use bitcoin::hashes::{hash160, sha256, Hash};
 
 use super::{stack, Error, Stack};
-use miniscript::context::NoChecks;
+use miniscript::context::NoChecksEcdsa;
 use {Miniscript, MiniscriptKey};
 
 /// Attempts to parse a slice as a Bitcoin public key, checking compressedness
@@ -48,7 +48,7 @@ fn pk_from_stackelem<'a>(
 
 fn script_from_stackelem<'a>(
     elem: &stack::Element<'a>,
-) -> Result<Miniscript<bitcoin::PublicKey, NoChecks>, Error> {
+) -> Result<Miniscript<bitcoin::PublicKey, NoChecksEcdsa>, Error> {
     match *elem {
         stack::Element::Push(sl) => {
             Miniscript::<bitcoin::PublicKey, _>::parse_insane(&bitcoin::Script::from(sl.to_owned()))
@@ -86,7 +86,7 @@ pub enum Inner {
     /// pay-to-pkhash or pay-to-witness-pkhash)
     PublicKey(bitcoin::PublicKey, PubkeyType),
     /// The script being evaluated is an actual script
-    Script(Miniscript<bitcoin::PublicKey, NoChecks>, ScriptType),
+    Script(Miniscript<bitcoin::PublicKey, NoChecksEcdsa>, ScriptType),
 }
 
 // The `Script` returned by this method is always generated/cloned ... when
@@ -598,7 +598,7 @@ mod tests {
     fn script_bare() {
         let preimage = b"12345678----____12345678----____";
         let hash = hash160::Hash::hash(&preimage[..]);
-        let miniscript: ::Miniscript<bitcoin::PublicKey, NoChecks> =
+        let miniscript: ::Miniscript<bitcoin::PublicKey, NoChecksEcdsa> =
             ::Miniscript::from_str_insane(&format!("hash160({})", hash)).unwrap();
 
         let spk = miniscript.encode();
@@ -625,7 +625,7 @@ mod tests {
     fn script_sh() {
         let preimage = b"12345678----____12345678----____";
         let hash = hash160::Hash::hash(&preimage[..]);
-        let miniscript: ::Miniscript<bitcoin::PublicKey, NoChecks> =
+        let miniscript: ::Miniscript<bitcoin::PublicKey, NoChecksEcdsa> =
             ::Miniscript::from_str_insane(&format!("hash160({})", hash)).unwrap();
 
         let redeem_script = miniscript.encode();
@@ -663,7 +663,7 @@ mod tests {
     fn script_wsh() {
         let preimage = b"12345678----____12345678----____";
         let hash = hash160::Hash::hash(&preimage[..]);
-        let miniscript: ::Miniscript<bitcoin::PublicKey, NoChecks> =
+        let miniscript: ::Miniscript<bitcoin::PublicKey, NoChecksEcdsa> =
             ::Miniscript::from_str_insane(&format!("hash160({})", hash)).unwrap();
 
         let witness_script = miniscript.encode();
@@ -701,7 +701,7 @@ mod tests {
     fn script_sh_wsh() {
         let preimage = b"12345678----____12345678----____";
         let hash = hash160::Hash::hash(&preimage[..]);
-        let miniscript: ::Miniscript<bitcoin::PublicKey, NoChecks> =
+        let miniscript: ::Miniscript<bitcoin::PublicKey, NoChecksEcdsa> =
             ::Miniscript::from_str_insane(&format!("hash160({})", hash)).unwrap();
 
         let witness_script = miniscript.encode();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -27,7 +27,7 @@ use miniscript::context::NoChecks;
 use miniscript::ScriptContext;
 use Miniscript;
 use Terminal;
-use {BitcoinSig, Descriptor, ToPublicKey};
+use {Descriptor, ToPublicKey};
 
 mod error;
 mod inner;
@@ -82,7 +82,7 @@ impl<'txin> Interpreter<'txin> {
     ///
     /// Running the iterator through will consume the internal stack of the
     /// `Iterpreter`, and it should not be used again after this.
-    pub fn iter<'iter, F: FnMut(&bitcoin::PublicKey, BitcoinSig) -> bool>(
+    pub fn iter<'iter, F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool>(
         &'iter mut self,
         verify_sig: F,
     ) -> Iter<'txin, 'iter, F> {
@@ -190,7 +190,7 @@ impl<'txin> Interpreter<'txin> {
         unsigned_tx: &'a bitcoin::Transaction,
         input_idx: usize,
         amount: u64,
-    ) -> Result<impl Fn(&bitcoin::PublicKey, BitcoinSig) -> bool + 'a, Error> {
+    ) -> Result<impl Fn(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool + 'a, Error> {
         // Precompute all sighash types because the borrowck doesn't like us
         // pulling self into the closure
         let sighashes = [
@@ -232,19 +232,21 @@ impl<'txin> Interpreter<'txin> {
             )?,
         ];
 
-        Ok(move |pk: &bitcoin::PublicKey, (sig, sighash_type)| {
-            // This is an awkward way to do this lookup, but it lets us do exhaustiveness
-            // checking in case future rust-bitcoin versions add new sighash types
-            let sighash = match sighash_type {
-                bitcoin::EcdsaSigHashType::All => sighashes[0],
-                bitcoin::EcdsaSigHashType::None => sighashes[1],
-                bitcoin::EcdsaSigHashType::Single => sighashes[2],
-                bitcoin::EcdsaSigHashType::AllPlusAnyoneCanPay => sighashes[3],
-                bitcoin::EcdsaSigHashType::NonePlusAnyoneCanPay => sighashes[4],
-                bitcoin::EcdsaSigHashType::SinglePlusAnyoneCanPay => sighashes[5],
-            };
-            secp.verify_ecdsa(&sighash, &sig, &pk.key).is_ok()
-        })
+        Ok(
+            move |pk: &bitcoin::PublicKey, ecdsa_sig: bitcoin::EcdsaSig| {
+                // This is an awkward way to do this lookup, but it lets us do exhaustiveness
+                // checking in case future rust-bitcoin versions add new sighash types
+                let sighash = match ecdsa_sig.hash_ty {
+                    bitcoin::EcdsaSigHashType::All => sighashes[0],
+                    bitcoin::EcdsaSigHashType::None => sighashes[1],
+                    bitcoin::EcdsaSigHashType::Single => sighashes[2],
+                    bitcoin::EcdsaSigHashType::AllPlusAnyoneCanPay => sighashes[3],
+                    bitcoin::EcdsaSigHashType::NonePlusAnyoneCanPay => sighashes[4],
+                    bitcoin::EcdsaSigHashType::SinglePlusAnyoneCanPay => sighashes[5],
+                };
+                secp.verify_ecdsa(&sighash, &ecdsa_sig.sig, &pk.key).is_ok()
+            },
+        )
     }
 }
 
@@ -327,7 +329,7 @@ struct NodeEvaluationState<'intp> {
 ///
 /// In case the script is actually dissatisfied, this may return several values
 /// before ultimately returning an error.
-pub struct Iter<'intp, 'txin: 'intp, F: FnMut(&bitcoin::PublicKey, BitcoinSig) -> bool> {
+pub struct Iter<'intp, 'txin: 'intp, F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool> {
     verify_sig: F,
     public_key: Option<&'intp bitcoin::PublicKey>,
     state: Vec<NodeEvaluationState<'intp>>,
@@ -341,7 +343,7 @@ pub struct Iter<'intp, 'txin: 'intp, F: FnMut(&bitcoin::PublicKey, BitcoinSig) -
 impl<'intp, 'txin: 'intp, F> Iterator for Iter<'intp, 'txin, F>
 where
     NoChecks: ScriptContext,
-    F: FnMut(&bitcoin::PublicKey, BitcoinSig) -> bool,
+    F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
 {
     type Item = Result<SatisfiedConstraint<'intp, 'txin>, Error>;
 
@@ -362,7 +364,7 @@ where
 impl<'intp, 'txin: 'intp, F> Iter<'intp, 'txin, F>
 where
     NoChecks: ScriptContext,
-    F: FnMut(&bitcoin::PublicKey, BitcoinSig) -> bool,
+    F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
 {
     /// Helper function to push a NodeEvaluationState on state stack
     fn push_evaluation_state(
@@ -770,14 +772,15 @@ fn verify_sersig<'txin, F>(
     sigser: &[u8],
 ) -> Result<secp256k1::ecdsa::Signature, Error>
 where
-    F: FnOnce(&bitcoin::PublicKey, BitcoinSig) -> bool,
+    F: FnOnce(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
 {
     if let Some((sighash_byte, sig)) = sigser.split_last() {
-        let sighashtype = bitcoin::EcdsaSigHashType::from_u32_standard(*sighash_byte as u32)
+        let hash_ty = bitcoin::EcdsaSigHashType::from_u32_standard(*sighash_byte as u32)
             .map_err(|_| Error::NonStandardSigHash([sig, &[*sighash_byte]].concat().to_vec()))?;
         let sig = secp256k1::ecdsa::Signature::from_der(sig)?;
-        if verify_sig(pk, (sig, sighashtype)) {
-            Ok(sig)
+        let ecdsa_sig = bitcoin::EcdsaSig { sig, hash_ty };
+        if verify_sig(pk, ecdsa_sig) {
+            Ok(ecdsa_sig.sig)
         } else {
             Err(Error::InvalidSignature(*pk))
         }
@@ -794,7 +797,6 @@ mod tests {
     use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
     use bitcoin::secp256k1::{self, Secp256k1, VerifyOnly};
     use miniscript::context::NoChecks;
-    use BitcoinSig;
     use Miniscript;
     use MiniscriptKey;
     use ToPublicKey;
@@ -839,8 +841,9 @@ mod tests {
     #[test]
     fn sat_constraints() {
         let (pks, der_sigs, secp_sigs, sighash, secp) = setup_keys_sigs(10);
-        let vfyfn_ =
-            |pk: &bitcoin::PublicKey, (sig, _)| secp.verify_ecdsa(&sighash, &sig, &pk.key).is_ok();
+        let vfyfn_ = |pk: &bitcoin::PublicKey, ecdsa_sig: bitcoin::EcdsaSig| {
+            secp.verify_ecdsa(&sighash, &ecdsa_sig.sig, &pk.key).is_ok()
+        };
 
         fn from_stack<'txin, 'elem, F>(
             verify_fn: F,
@@ -848,7 +851,7 @@ mod tests {
             ms: &'elem Miniscript<bitcoin::PublicKey, NoChecks>,
         ) -> Iter<'elem, 'txin, F>
         where
-            F: FnMut(&bitcoin::PublicKey, BitcoinSig) -> bool,
+            F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
         {
             Iter {
                 verify_sig: verify_fn,

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -23,7 +23,7 @@ use bitcoin::blockdata::witness::Witness;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::util::sighash;
 use bitcoin::{self, secp256k1};
-use miniscript::context::NoChecks;
+use miniscript::context::NoChecksEcdsa;
 use miniscript::ScriptContext;
 use Miniscript;
 use Terminal;
@@ -311,7 +311,7 @@ pub enum SatisfiedConstraint<'intp, 'txin> {
 ///depending on evaluation of the children.
 struct NodeEvaluationState<'intp> {
     ///The node which is being evaluated
-    node: &'intp Miniscript<bitcoin::PublicKey, NoChecks>,
+    node: &'intp Miniscript<bitcoin::PublicKey, NoChecksEcdsa>,
     ///number of children evaluated
     n_evaluated: usize,
     ///number of children satisfied
@@ -342,7 +342,7 @@ pub struct Iter<'intp, 'txin: 'intp, F: FnMut(&bitcoin::PublicKey, bitcoin::Ecds
 ///Iterator for Iter
 impl<'intp, 'txin: 'intp, F> Iterator for Iter<'intp, 'txin, F>
 where
-    NoChecks: ScriptContext,
+    NoChecksEcdsa: ScriptContext,
     F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
 {
     type Item = Result<SatisfiedConstraint<'intp, 'txin>, Error>;
@@ -363,13 +363,13 @@ where
 
 impl<'intp, 'txin: 'intp, F> Iter<'intp, 'txin, F>
 where
-    NoChecks: ScriptContext,
+    NoChecksEcdsa: ScriptContext,
     F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
 {
     /// Helper function to push a NodeEvaluationState on state stack
     fn push_evaluation_state(
         &mut self,
-        node: &'intp Miniscript<bitcoin::PublicKey, NoChecks>,
+        node: &'intp Miniscript<bitcoin::PublicKey, NoChecksEcdsa>,
         n_evaluated: usize,
         n_satisfied: usize,
     ) -> () {
@@ -796,7 +796,7 @@ mod tests {
     use bitcoin;
     use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
     use bitcoin::secp256k1::{self, Secp256k1, VerifyOnly};
-    use miniscript::context::NoChecks;
+    use miniscript::context::NoChecksEcdsa;
     use Miniscript;
     use MiniscriptKey;
     use ToPublicKey;
@@ -848,7 +848,7 @@ mod tests {
         fn from_stack<'txin, 'elem, F>(
             verify_fn: F,
             stack: &'elem mut Stack<'txin>,
-            ms: &'elem Miniscript<bitcoin::PublicKey, NoChecks>,
+            ms: &'elem Miniscript<bitcoin::PublicKey, NoChecksEcdsa>,
         ) -> Iter<'elem, 'txin, F>
         where
             F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -18,7 +18,7 @@ use bitcoin;
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 
-use {BitcoinSig, ToPublicKey};
+use ToPublicKey;
 
 use super::{verify_sersig, Error, HashLockType, SatisfiedConstraint};
 
@@ -132,7 +132,7 @@ impl<'txin> Stack<'txin> {
         pk: &'intp bitcoin::PublicKey,
     ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>>
     where
-        F: FnMut(&bitcoin::PublicKey, BitcoinSig) -> bool,
+        F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
     {
         if let Some(sigser) = self.pop() {
             match sigser {
@@ -171,7 +171,7 @@ impl<'txin> Stack<'txin> {
         pkh: &'intp hash160::Hash,
     ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>>
     where
-        F: FnOnce(&bitcoin::PublicKey, BitcoinSig) -> bool,
+        F: FnOnce(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
     {
         if let Some(Element::Push(pk)) = self.pop() {
             let pk_hash = hash160::Hash::hash(pk);
@@ -367,7 +367,7 @@ impl<'txin> Stack<'txin> {
         pk: &'intp bitcoin::PublicKey,
     ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>>
     where
-        F: FnOnce(&bitcoin::PublicKey, BitcoinSig) -> bool,
+        F: FnOnce(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
     {
         if let Some(witness_sig) = self.pop() {
             if let Element::Push(sigser) = witness_sig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub use descriptor::{Descriptor, DescriptorPublicKey, DescriptorTrait};
 pub use interpreter::Interpreter;
 pub use miniscript::context::{BareCtx, Legacy, ScriptContext, Segwitv0, Tap};
 pub use miniscript::decode::Terminal;
-pub use miniscript::satisfy::{BitcoinSig, Preimage32, Satisfier};
+pub use miniscript::satisfy::{Preimage32, Satisfier};
 pub use miniscript::Miniscript;
 
 ///Public key trait which can be converted to Hash type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,6 +479,8 @@ pub enum Error {
     AddrError(bitcoin::util::address::Error),
     /// A `CHECKMULTISIG` opcode was preceded by a number > 20
     CmsTooManyKeys(u32),
+    /// A tapscript multi_a cannot support more than MAX_BLOCK_WEIGHT/32 keys
+    MultiATooManyKeys(u32),
     /// Encountered unprintable character in descriptor
     Unprintable(u8),
     /// expected character while parsing descriptor; didn't find one
@@ -670,6 +672,9 @@ impl fmt::Display for Error {
             Error::BareDescriptorAddr => write!(f, "Bare descriptors don't have address"),
             Error::PubKeyCtxError(ref pk, ref ctx) => {
                 write!(f, "Pubkey error: {} under {} scriptcontext", pk, ctx)
+            }
+            Error::MultiATooManyKeys(k) => {
+                write!(f, "MultiA too many keys {}", k)
             }
         }
     }

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -29,6 +29,7 @@ use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 
 use errstr;
 use expression;
+use miniscript::context::SigType;
 use miniscript::types::{self, Property};
 use miniscript::ScriptContext;
 use script_num_size;
@@ -761,7 +762,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
                     .push_opcode(opcodes::all::OP_EQUAL)
             }
             Terminal::Multi(k, ref keys) => {
-                debug_assert!(!Ctx::is_tap());
+                debug_assert!(Ctx::sig_type() == SigType::Ecdsa);
                 builder = builder.push_int(k as i64);
                 for pk in keys {
                     builder = builder.push_key(&pk.to_public_key());
@@ -771,7 +772,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
                     .push_opcode(opcodes::all::OP_CHECKMULTISIG)
             }
             Terminal::MultiA(k, ref keys) => {
-                debug_assert!(Ctx::is_tap());
+                debug_assert!(Ctx::sig_type() == SigType::Schnorr);
                 // keys must be atleast len 1 here, guaranteed by typing rules
                 builder = builder.push_ms_key::<_, Ctx>(&keys[0]);
                 builder = builder.push_opcode(opcodes::all::OP_CHECKSIG);

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -74,6 +74,14 @@ pub enum ScriptContextError {
     MultiANotAllowed,
 }
 
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SigType {
+    /// Ecdsa signature
+    Ecdsa,
+    /// Schnorr Signature
+    Schnorr,
+}
+
 impl fmt::Display for ScriptContextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -285,12 +293,10 @@ where
         Self::other_top_level_checks(ms)
     }
 
-    /// Reverse lookup to store whether the context is tapscript.
-    /// pk(33-byte key) is a valid under both tapscript context and segwitv0 context
-    /// We need to context decide whether the serialize pk to 33 byte or 32 bytes.
-    fn is_tap() -> bool {
-        return false;
-    }
+    /// The type of signature required for satisfaction
+    // We need to context decide whether the serialize pk to 33 byte or 32 bytes.
+    // And to decide which type of signatures to look for during satisfaction
+    fn sig_type() -> SigType;
 
     /// Get the len of public key when serialized based on context
     /// Note that this includes the serialization prefix. Returns
@@ -394,6 +400,10 @@ impl ScriptContext for Legacy {
 
     fn name_str() -> &'static str {
         "Legacy/p2sh"
+    }
+
+    fn sig_type() -> SigType {
+        SigType::Ecdsa
     }
 }
 
@@ -503,6 +513,10 @@ impl ScriptContext for Segwitv0 {
     fn name_str() -> &'static str {
         "Segwitv0"
     }
+
+    fn sig_type() -> SigType {
+        SigType::Ecdsa
+    }
 }
 
 /// Tap ScriptContext
@@ -600,8 +614,8 @@ impl ScriptContext for Tap {
         ms.ext.max_sat_size.map(|x| x.0)
     }
 
-    fn is_tap() -> bool {
-        true
+    fn sig_type() -> SigType {
+        SigType::Schnorr
     }
 
     fn pk_len<Pk: MiniscriptKey>(_pk: &Pk) -> usize {
@@ -684,16 +698,20 @@ impl ScriptContext for BareCtx {
     fn name_str() -> &'static str {
         "BareCtx"
     }
+
+    fn sig_type() -> SigType {
+        SigType::Ecdsa
+    }
 }
 
-/// "No Checks" Context
+/// "No Checks Ecdsa" Context
 ///
 /// Used by the "satisified constraints" iterator, which is intended to read
 /// scripts off of the blockchain without doing any sanity checks on them.
-/// This context should not be used unless you know what you are doing.
+/// This context should *NOT* be used unless you know what you are doing.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub enum NoChecks {}
-impl ScriptContext for NoChecks {
+pub enum NoChecksEcdsa {}
+impl ScriptContext for NoChecksEcdsa {
     // todo: When adding support for interpreter, we need a enum with all supported keys here
     type Key = bitcoin::PublicKey;
     fn check_terminal_non_malleable<Pk: MiniscriptKey>(
@@ -727,22 +745,166 @@ impl ScriptContext for NoChecks {
     }
 
     fn max_satisfaction_size<Pk: MiniscriptKey>(_ms: &Miniscript<Pk, Self>) -> Option<usize> {
-        panic!("Tried to compute a satisfaction size bound on a no-checks miniscript")
+        panic!("Tried to compute a satisfaction size bound on a no-checks ecdsa miniscript")
     }
 
     fn pk_len<Pk: MiniscriptKey>(_pk: &Pk) -> usize {
-        panic!("Tried to compute a pk len bound on a no-checks miniscript")
+        panic!("Tried to compute a pk len bound on a no-checks ecdsa miniscript")
     }
 
     fn name_str() -> &'static str {
         // Internally used code
-        "Nochecks"
+        "NochecksEcdsa"
+    }
+
+    fn check_witness<Pk: MiniscriptKey>(_witness: &[Vec<u8>]) -> Result<(), ScriptContextError> {
+        // Only really need to do this for segwitv0 and legacy
+        // Bare is already restrcited by standardness rules
+        // and would reach these limits.
+        Ok(())
+    }
+
+    fn check_global_validity<Pk: MiniscriptKey>(
+        ms: &Miniscript<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Self::check_global_consensus_validity(ms)?;
+        Self::check_global_policy_validity(ms)?;
+        Ok(())
+    }
+
+    fn check_local_validity<Pk: MiniscriptKey>(
+        ms: &Miniscript<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Self::check_global_consensus_validity(ms)?;
+        Self::check_global_policy_validity(ms)?;
+        Self::check_local_consensus_validity(ms)?;
+        Self::check_local_policy_validity(ms)?;
+        Ok(())
+    }
+
+    fn top_level_type_check<Pk: MiniscriptKey>(ms: &Miniscript<Pk, Self>) -> Result<(), Error> {
+        if ms.ty.corr.base != types::Base::B {
+            return Err(Error::NonTopLevel(format!("{:?}", ms)));
+        }
+        Ok(())
+    }
+
+    fn other_top_level_checks<Pk: MiniscriptKey>(_ms: &Miniscript<Pk, Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn top_level_checks<Pk: MiniscriptKey>(ms: &Miniscript<Pk, Self>) -> Result<(), Error> {
+        Self::top_level_type_check(ms)?;
+        Self::other_top_level_checks(ms)
+    }
+
+    fn sig_type() -> SigType {
+        SigType::Ecdsa
+    }
+}
+
+/// "No Checks Schnorr" Context
+///
+/// Used by the "satisified constraints" iterator, which is intended to read
+/// scripts off of the blockchain without doing any sanity checks on them.
+/// This context should *NOT* be used unless you know what you are doing.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum NoChecksSchnorr {}
+impl ScriptContext for NoChecksSchnorr {
+    // todo: When adding support for interpreter, we need a enum with all supported keys here
+    type Key = bitcoin::secp256k1::XOnlyPublicKey;
+    fn check_terminal_non_malleable<Pk: MiniscriptKey>(
+        _frag: &Terminal<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
+
+    fn check_global_policy_validity<Pk: MiniscriptKey>(
+        _ms: &Miniscript<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
+
+    fn check_global_consensus_validity<Pk: MiniscriptKey>(
+        _ms: &Miniscript<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
+
+    fn check_local_policy_validity<Pk: MiniscriptKey>(
+        _ms: &Miniscript<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
+
+    fn check_local_consensus_validity<Pk: MiniscriptKey>(
+        _ms: &Miniscript<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
+
+    fn max_satisfaction_size<Pk: MiniscriptKey>(_ms: &Miniscript<Pk, Self>) -> Option<usize> {
+        panic!("Tried to compute a satisfaction size bound on a no-checks schnorr miniscript")
+    }
+
+    fn pk_len<Pk: MiniscriptKey>(_pk: &Pk) -> usize {
+        panic!("Tried to compute a pk len bound on a no-checks schnorr miniscript")
+    }
+
+    fn name_str() -> &'static str {
+        // Internally used code
+        "NochecksSchnorr"
+    }
+
+    fn check_witness<Pk: MiniscriptKey>(_witness: &[Vec<u8>]) -> Result<(), ScriptContextError> {
+        // Only really need to do this for segwitv0 and legacy
+        // Bare is already restrcited by standardness rules
+        // and would reach these limits.
+        Ok(())
+    }
+
+    fn check_global_validity<Pk: MiniscriptKey>(
+        ms: &Miniscript<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Self::check_global_consensus_validity(ms)?;
+        Self::check_global_policy_validity(ms)?;
+        Ok(())
+    }
+
+    fn check_local_validity<Pk: MiniscriptKey>(
+        ms: &Miniscript<Pk, Self>,
+    ) -> Result<(), ScriptContextError> {
+        Self::check_global_consensus_validity(ms)?;
+        Self::check_global_policy_validity(ms)?;
+        Self::check_local_consensus_validity(ms)?;
+        Self::check_local_policy_validity(ms)?;
+        Ok(())
+    }
+
+    fn top_level_type_check<Pk: MiniscriptKey>(ms: &Miniscript<Pk, Self>) -> Result<(), Error> {
+        if ms.ty.corr.base != types::Base::B {
+            return Err(Error::NonTopLevel(format!("{:?}", ms)));
+        }
+        Ok(())
+    }
+
+    fn other_top_level_checks<Pk: MiniscriptKey>(_ms: &Miniscript<Pk, Self>) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn top_level_checks<Pk: MiniscriptKey>(ms: &Miniscript<Pk, Self>) -> Result<(), Error> {
+        Self::top_level_type_check(ms)?;
+        Self::other_top_level_checks(ms)
+    }
+
+    fn sig_type() -> SigType {
+        SigType::Schnorr
     }
 }
 
 /// Private Mod to prevent downstream from implementing this public trait
 mod private {
-    use super::{BareCtx, Legacy, NoChecks, Segwitv0, Tap};
+    use super::{BareCtx, Legacy, NoChecksEcdsa, NoChecksSchnorr, Segwitv0, Tap};
 
     pub trait Sealed {}
 
@@ -751,5 +913,6 @@ mod private {
     impl Sealed for Legacy {}
     impl Sealed for Segwitv0 {}
     impl Sealed for Tap {}
-    impl Sealed for NoChecks {}
+    impl Sealed for NoChecksEcdsa {}
+    impl Sealed for NoChecksSchnorr {}
 }

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -17,6 +17,7 @@
 //! Functionality to parse a Bitcoin Script into a `Miniscript`
 //!
 
+use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use std::marker::PhantomData;
 use std::{error, fmt};
@@ -491,6 +492,10 @@ pub fn parse<Ctx: ScriptContext>(
                     },
                     // MultiA
                     Tk::NumEqual, Tk::Num(k) => {
+                        // Check size before allocating keys
+                        if k > MAX_BLOCK_WEIGHT/32 {
+                            return Err(Error::MultiATooManyKeys(MAX_BLOCK_WEIGHT/32))
+                        }
                         let mut keys = Vec::with_capacity(k as usize); // atleast k capacity
                         while tokens.peek() == Some(&Tk::CheckSigAdd) {
                             match_token!(

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -121,7 +121,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     pub fn get_leaf_pk(&self) -> Vec<Pk> {
         match self.node {
             Terminal::PkK(ref key) => vec![key.clone()],
-            Terminal::Multi(_, ref keys) => keys.clone(),
+            Terminal::Multi(_, ref keys) | Terminal::MultiA(_, ref keys) => keys.clone(),
             _ => vec![],
         }
     }
@@ -139,7 +139,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         match self.node {
             Terminal::PkH(ref hash) => vec![hash.clone()],
             Terminal::PkK(ref key) => vec![key.to_pubkeyhash()],
-            Terminal::Multi(_, ref keys) => keys.iter().map(Pk::to_pubkeyhash).collect(),
+            Terminal::Multi(_, ref keys) | Terminal::MultiA(_, ref keys) => {
+                keys.iter().map(Pk::to_pubkeyhash).collect()
+            }
             _ => vec![],
         }
     }
@@ -155,7 +157,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         match self.node {
             Terminal::PkH(ref hash) => vec![PkPkh::HashedPubkey(hash.clone())],
             Terminal::PkK(ref key) => vec![PkPkh::PlainPubkey(key.clone())],
-            Terminal::Multi(_, ref keys) => keys
+            Terminal::Multi(_, ref keys) | Terminal::MultiA(_, ref keys) => keys
                 .into_iter()
                 .map(|key| PkPkh::PlainPubkey(key.clone()))
                 .collect(),
@@ -170,7 +172,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     pub fn get_nth_pk(&self, n: usize) -> Option<Pk> {
         match (&self.node, n) {
             (&Terminal::PkK(ref key), 0) => Some(key.clone()),
-            (&Terminal::Multi(_, ref keys), _) => keys.get(n).cloned(),
+            (&Terminal::Multi(_, ref keys), _) | (&Terminal::MultiA(_, ref keys), _) => {
+                keys.get(n).cloned()
+            }
             _ => None,
         }
     }
@@ -186,7 +190,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         match (&self.node, n) {
             (&Terminal::PkH(ref hash), 0) => Some(hash.clone()),
             (&Terminal::PkK(ref key), 0) => Some(key.to_pubkeyhash()),
-            (&Terminal::Multi(_, ref keys), _) => keys.get(n).map(Pk::to_pubkeyhash),
+            (&Terminal::Multi(_, ref keys), _) | (&Terminal::MultiA(_, ref keys), _) => {
+                keys.get(n).map(Pk::to_pubkeyhash)
+            }
             _ => None,
         }
     }
@@ -199,7 +205,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         match (&self.node, n) {
             (&Terminal::PkH(ref hash), 0) => Some(PkPkh::HashedPubkey(hash.clone())),
             (&Terminal::PkK(ref key), 0) => Some(PkPkh::PlainPubkey(key.clone())),
-            (&Terminal::Multi(_, ref keys), _) => {
+            (&Terminal::Multi(_, ref keys), _) | (&Terminal::MultiA(_, ref keys), _) => {
                 keys.get(n).map(|key| PkPkh::PlainPubkey(key.clone()))
             }
             _ => None,

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -31,7 +31,9 @@ pub enum Token<'s> {
     BoolOr,
     Add,
     Equal,
+    NumEqual,
     CheckSig,
+    CheckSigAdd,
     CheckMultiSig,
     CheckSequenceVerify,
     CheckLockTimeVerify,
@@ -129,12 +131,23 @@ pub fn lex<'s>(script: &'s script::Script) -> Result<Vec<Token<'s>>, Error> {
                 ret.push(Token::Equal);
                 ret.push(Token::Verify);
             }
+            script::Instruction::Op(opcodes::all::OP_NUMEQUAL) => {
+                ret.push(Token::NumEqual);
+            }
+            script::Instruction::Op(opcodes::all::OP_NUMEQUALVERIFY) => {
+                ret.push(Token::NumEqual);
+                ret.push(Token::Verify);
+            }
             script::Instruction::Op(opcodes::all::OP_CHECKSIG) => {
                 ret.push(Token::CheckSig);
             }
             script::Instruction::Op(opcodes::all::OP_CHECKSIGVERIFY) => {
                 ret.push(Token::CheckSig);
                 ret.push(Token::Verify);
+            }
+            // Change once the opcode name is updated
+            script::Instruction::Op(opcodes::all::OP_CHECKSIGADD) => {
+                ret.push(Token::CheckSigAdd);
             }
             script::Instruction::Op(opcodes::all::OP_CHECKMULTISIG) => {
                 ret.push(Token::CheckMultiSig);

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -488,11 +488,19 @@ impl Ord for Witness {
 
 impl Witness {
     /// Turn a signature into (part of) a satisfaction
-    fn signature<Pk: ToPublicKey, S: Satisfier<Pk>>(sat: S, pk: &Pk) -> Self {
-        match sat.lookup_ecdsa_sig(pk) {
-            Some(sig) => Witness::Stack(vec![sig.to_vec()]),
-            // Signatures cannot be forged
-            None => Witness::Impossible,
+    fn signature<Pk: ToPublicKey, S: Satisfier<Pk>, Ctx: ScriptContext>(sat: S, pk: &Pk) -> Self {
+        if Ctx::is_tap() {
+            match sat.lookup_schnorr_sig(pk) {
+                Some(sig) => Witness::Stack(vec![sig.to_vec()]),
+                // Signatures cannot be forged
+                None => Witness::Impossible,
+            }
+        } else {
+            match sat.lookup_ecdsa_sig(pk) {
+                Some(sig) => Witness::Stack(vec![sig.to_vec()]),
+                // Signatures cannot be forged
+                None => Witness::Impossible,
+            }
         }
     }
 
@@ -828,7 +836,7 @@ impl Satisfaction {
     {
         match *term {
             Terminal::PkK(ref pk) => Satisfaction {
-                stack: Witness::signature(stfr, pk),
+                stack: Witness::signature::<_, _, Ctx>(stfr, pk),
                 has_sig: true,
             },
             Terminal::PkH(ref pkh) => Satisfaction {
@@ -989,7 +997,7 @@ impl Satisfaction {
                 let mut sig_count = 0;
                 let mut sigs = Vec::with_capacity(k);
                 for pk in keys {
-                    match Witness::signature(stfr, pk) {
+                    match Witness::signature::<_, _, Ctx>(stfr, pk) {
                         Witness::Stack(sig) => {
                             sigs.push(sig);
                             sig_count += 1;
@@ -1031,7 +1039,7 @@ impl Satisfaction {
                 let mut sig_count = 0;
                 let mut sigs = vec![vec![vec![]]; keys.len()];
                 for (i, pk) in keys.iter().rev().enumerate() {
-                    match Witness::signature(stfr, pk) {
+                    match Witness::signature::<_, _, Ctx>(stfr, pk) {
                         Witness::Stack(sig) => {
                             sigs[i] = sig;
                             sig_count += 1;

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -489,18 +489,17 @@ impl Ord for Witness {
 impl Witness {
     /// Turn a signature into (part of) a satisfaction
     fn signature<Pk: ToPublicKey, S: Satisfier<Pk>, Ctx: ScriptContext>(sat: S, pk: &Pk) -> Self {
-        if Ctx::is_tap() {
-            match sat.lookup_schnorr_sig(pk) {
+        match Ctx::sig_type() {
+            super::context::SigType::Ecdsa => match sat.lookup_ecdsa_sig(pk) {
                 Some(sig) => Witness::Stack(vec![sig.to_vec()]),
                 // Signatures cannot be forged
                 None => Witness::Impossible,
-            }
-        } else {
-            match sat.lookup_ecdsa_sig(pk) {
+            },
+            super::context::SigType::Schnorr => match sat.lookup_schnorr_sig(pk) {
                 Some(sig) => Witness::Stack(vec![sig.to_vec()]),
                 // Signatures cannot be forged
                 None => Witness::Impossible,
-            }
+            },
         }
     }
 

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -269,6 +269,12 @@ pub trait Property: Sized {
     /// Type property of a `Multi` fragment
     fn from_multi(k: usize, n: usize) -> Self;
 
+    /// Type property of a `MultiA` fragment
+    fn from_multi_a(k: usize, n: usize) -> Self {
+        // default impl same as multi
+        Self::from_multi(k, n)
+    }
+
     /// Type property of a hash fragment
     fn from_hash() -> Self;
 
@@ -410,7 +416,7 @@ pub trait Property: Sized {
             Terminal::False => Ok(Self::from_false()),
             Terminal::PkK(..) => Ok(Self::from_pk_k()),
             Terminal::PkH(..) => Ok(Self::from_pk_h()),
-            Terminal::Multi(k, ref pks) => {
+            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -423,7 +429,11 @@ pub trait Property: Sized {
                         error: ErrorKind::OverThreshold(k, pks.len()),
                     });
                 }
-                Ok(Self::from_multi(k, pks.len()))
+                match *fragment {
+                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
+                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
+                    _ => unreachable!(),
+                }
             }
             Terminal::After(t) => {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
@@ -789,7 +799,7 @@ impl Property for Type {
             Terminal::False => Ok(Self::from_false()),
             Terminal::PkK(..) => Ok(Self::from_pk_k()),
             Terminal::PkH(..) => Ok(Self::from_pk_h()),
-            Terminal::Multi(k, ref pks) => {
+            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -802,7 +812,11 @@ impl Property for Type {
                         error: ErrorKind::OverThreshold(k, pks.len()),
                     });
                 }
-                Ok(Self::from_multi(k, pks.len()))
+                match *fragment {
+                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
+                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
+                    _ => unreachable!(),
+                }
             }
             Terminal::After(t) => {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1161,7 +1161,7 @@ where
 mod tests {
     use super::*;
     use bitcoin::blockdata::{opcodes, script};
-    use bitcoin::{self, hashes, secp256k1, EcdsaSigHashType};
+    use bitcoin::{self, hashes, secp256k1};
     use std::collections::HashMap;
     use std::str::FromStr;
     use std::string::String;
@@ -1169,7 +1169,6 @@ mod tests {
     use miniscript::{satisfy, Legacy, Segwitv0};
     use policy::Liftable;
     use script_num_size;
-    use BitcoinSig;
 
     type SPolicy = Concrete<String>;
     type BPolicy = Concrete<bitcoin::PublicKey>;
@@ -1364,14 +1363,16 @@ mod tests {
         assert_eq!(abs.n_keys(), 5);
         assert_eq!(abs.minimum_n_keys(), Some(3));
 
-        let bitcoinsig = (sig, EcdsaSigHashType::All);
-        let mut sigvec = sig.serialize_der().to_vec();
-        sigvec.push(1); // sighash all
+        let bitcoinsig = bitcoin::EcdsaSig {
+            sig,
+            hash_ty: bitcoin::EcdsaSigHashType::All,
+        };
+        let sigvec = bitcoinsig.to_vec();
 
-        let no_sat = HashMap::<bitcoin::PublicKey, BitcoinSig>::new();
-        let mut left_sat = HashMap::<bitcoin::PublicKey, BitcoinSig>::new();
+        let no_sat = HashMap::<bitcoin::PublicKey, bitcoin::EcdsaSig>::new();
+        let mut left_sat = HashMap::<bitcoin::PublicKey, bitcoin::EcdsaSig>::new();
         let mut right_sat =
-            HashMap::<hashes::hash160::Hash, (bitcoin::PublicKey, BitcoinSig)>::new();
+            HashMap::<hashes::hash160::Hash, (bitcoin::PublicKey, bitcoin::EcdsaSig)>::new();
 
         for i in 0..5 {
             left_sat.insert(keys[i], bitcoinsig);

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -161,7 +161,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
                     subs.into_iter().map(|s| s.node.lift()).collect();
                 Semantic::Threshold(k, semantic_subs?)
             }
-            Terminal::Multi(k, ref keys) => Semantic::Threshold(
+            Terminal::Multi(k, ref keys) | Terminal::MultiA(k, ref keys) => Semantic::Threshold(
                 k,
                 keys.into_iter()
                     .map(|k| Semantic::KeyHash(k.to_pubkeyhash()))

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 use bitcoin;
 use bitcoin::blockdata::script;
 use bitcoin::Script;
+use miniscript::context;
 
 use {ScriptContext, ToPublicKey};
 pub(crate) fn varint_len(n: usize) -> usize {
@@ -39,10 +40,9 @@ impl MsKeyBuilder for script::Builder {
         Pk: ToPublicKey,
         Ctx: ScriptContext,
     {
-        if Ctx::is_tap() {
-            self.push_slice(&key.to_x_only_pubkey().serialize())
-        } else {
-            self.push_key(&key.to_public_key())
+        match Ctx::sig_type() {
+            context::SigType::Ecdsa => self.push_key(&key.to_public_key()),
+            context::SigType::Schnorr => self.push_slice(&key.to_x_only_pubkey().serialize()),
         }
     }
 }


### PR DESCRIPTION
Adds support for MultiA script fragment. Builds on top of #255 .

Do not merge this until we have a rust-bitcoin release