### PR TITLE
Fix over-generic parameterization of ScriptContext

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -360,7 +360,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     {
         match satisfy::Satisfaction::satisfy(&self.node, &satisfier, self.ty.mall.safe).stack {
             satisfy::Witness::Stack(stack) => {
-                Ctx::check_witness::<Pk, Ctx>(&stack)?;
+                Ctx::check_witness::<Pk>(&stack)?;
                 Ok(stack)
             }
             satisfy::Witness::Unavailable | satisfy::Witness::Impossible => {
@@ -380,7 +380,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     {
         match satisfy::Satisfaction::satisfy_mall(&self.node, &satisfier, self.ty.mall.safe).stack {
             satisfy::Witness::Stack(stack) => {
-                Ctx::check_witness::<Pk, Ctx>(&stack)?;
+                Ctx::check_witness::<Pk>(&stack)?;
                 Ok(stack)
             }
             satisfy::Witness::Unavailable | satisfy::Witness::Impossible => {


### PR DESCRIPTION
The previous genericization of the ScriptContext methods permitted some very surprising behaviors that are certainly not intended. The Ctx Parameters should in all cases be a Self parameter as far as I can tell. This PR fixes this issue.

fixes https://github.com/rust-bitcoin/rust-miniscript/pull/255#discussion_r711772814

Technically, this is a breaking change as the generic paremeter count decreases and it is not generally inferred I think.  It's easy to fix, and any code which could not be fixed trivially would be hopelessly broken/buggy.