### PR TITLE
Allow unknown lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,9 @@
 //!
 //!
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
+// Unknown lint warnings occur when linting with an old version of clippy and
+// hitting code that allows a lint that exists only in newer versions of clippy.
+#![allow(unknown_lints)]
 // Coding conventions
 #![deny(unsafe_code)]
 #![deny(non_upper_case_globals)]


### PR DESCRIPTION
We support many versions of rustc by design, this puts us in the following predicament:

1. Linting with a newer version of clippy throws a warning for a newly introduced default lint.
2. In order to allow the lint we must use the lint by name but this lint does not exist in earlier versions of clippy, so we get a warning `unknown lint` when linting with the earlier version.

We want to have our cake and eat it too, we can do this by allowing unknown lints. Doing so enables (1) while preventing (2).

As demonstration `cargo +1.36 check` emits:
```
warning: unknown lint: `broken_intra_doc_links`
```
With this patch applied there is no such warning emitted.

The change in this PR has also been submitted in `bitcoin_hashes`, for brevity it is likely easier if we discuss the failings/merits of this work in a single place on [that PR](https://github.com/rust-bitcoin/bitcoin_hashes/pull/137). Thanks.