### PR TITLE
Context: check for the maximum number of public keys in a `CHECKMULTISIG`

### DIFF
--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -21,7 +21,9 @@ use std::{fmt, marker::PhantomData, str::FromStr};
 use bitcoin::blockdata::script;
 
 use expression;
-use miniscript::{self, context::ScriptContext, decode::Terminal};
+use miniscript::{
+    self, context::ScriptContext, decode::Terminal, limits::MAX_PUBKEYS_PER_MULTISIG,
+};
 use policy;
 use script_num_size;
 use {errstr, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey};
@@ -43,7 +45,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// Internally checks all the applicable size limits and pubkey types limitations according to the current `Ctx`.
     pub fn new(k: usize, pks: Vec<Pk>) -> Result<Self, Error> {
         // A sortedmulti() is only defined for <= 20 keys (it maps to CHECKMULTISIG)
-        if pks.len() > 20 {
+        if pks.len() > MAX_PUBKEYS_PER_MULTISIG {
             Error::BadDescriptor("Too many public keys".to_string());
         }
 

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -23,6 +23,7 @@ use std::{error, fmt};
 use {bitcoin, Miniscript};
 
 use miniscript::lex::{Token as Tk, TokenIter};
+use miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
 use miniscript::types::extra_props::ExtData;
 use miniscript::types::Property;
 use miniscript::types::Type;
@@ -465,7 +466,7 @@ pub fn parse<Ctx: ScriptContext>(
                     },
                     // CHECKMULTISIG based multisig
                     Tk::CheckMultiSig, Tk::Num(n) => {
-                        if n > 20 {
+                        if n as usize > MAX_PUBKEYS_PER_MULTISIG {
                             return Err(Error::CmsTooManyKeys(n));
                         }
                         let mut keys = Vec::with_capacity(n as usize);

--- a/src/miniscript/limits.rs
+++ b/src/miniscript/limits.rs
@@ -46,3 +46,7 @@ pub const MAX_SCRIPTSIG_SIZE: usize = 1650;
 pub const MAX_STACK_SIZE: usize = 1000;
 /** The maximum allowed weight for a block, see BIP 141 (network rule) */
 pub const MAX_BLOCK_WEIGHT: usize = 4000000;
+
+/// Maximum pubkeys as arguments to CHECKMULTISIG
+// https://github.com/bitcoin/bitcoin/blob/6acda4b00b3fc1bfac02f5de590e1a5386cbc779/src/script/script.h#L30
+pub const MAX_PUBKEYS_PER_MULTISIG: usize = 20;

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -22,6 +22,7 @@ use std::convert::From;
 use std::marker::PhantomData;
 use std::{cmp, error, f64, fmt, mem};
 
+use miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
 use miniscript::types::{self, ErrorKind, ExtData, Property, Type};
 use miniscript::ScriptContext;
 use policy::Concrete;
@@ -993,7 +994,7 @@ where
                 })
                 .collect();
 
-            if key_vec.len() == subs.len() && subs.len() <= 20 {
+            if key_vec.len() == subs.len() && subs.len() <= MAX_PUBKEYS_PER_MULTISIG {
                 insert_wrap!(AstElemExt::terminal(Terminal::Multi(k, key_vec)));
             }
             // Not a threshold, it's always more optimal to translate it to and()s as we save the


### PR DESCRIPTION
We check at parsing time, but we would still allow to create a `Multi` with `> 20` keys and not error on sanity checks! I'd add a test but wanted to push a patch quickly first.

Reported by @danielabrozzoni .