### PR TITLE
Update to a dev version latest bitcoin master 0e2e55971275da64ceb62e8991a0a5fa962cb8b1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Miniscript: a subset of Bitcoin Script designed for analysis"
 license = "CC0-1.0"
 
 [features]
-fuzztarget = ["bitcoin/fuzztarget"]
+fuzztarget = []
 compiler = []
 trace = []
 unstable = []
@@ -16,7 +16,8 @@ use-serde = ["bitcoin/use-serde", "serde"]
 rand = ["bitcoin/rand"]
 
 [dependencies]
-bitcoin = "0.27"
+# bitcoin = "0.27"
+bitcoin = {git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "0e2e55971275da64ceb62e8991a0a5fa962cb8b1"}
 
 [dependencies.serde]
 version = "1.0"

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -17,6 +17,7 @@
 extern crate bitcoin;
 extern crate miniscript;
 
+use bitcoin::blockdata::witness::Witness;
 use bitcoin::secp256k1; // secp256k1 re-exported from rust-bitcoin
 use miniscript::DescriptorTrait;
 use std::collections::HashMap;
@@ -34,7 +35,7 @@ fn main() {
             previous_output: Default::default(),
             script_sig: bitcoin::Script::new(),
             sequence: 0xffffffff,
-            witness: vec![],
+            witness: Witness::default(),
         }],
         output: vec![bitcoin::TxOut {
             script_pubkey: bitcoin::Script::new(),
@@ -63,7 +64,7 @@ fn main() {
     let bitcoin_sig = (
         // copied at random off the blockchain; this is not actually a valid
         // signature for this transaction; Miniscript does not verify
-        secp256k1::Signature::from_str(
+        secp256k1::ecdsa::Signature::from_str(
             "3045\
              0221\
              00f7c3648c390d87578cd79c8016940aa8e3511c4104cb78daa8fb8e429375efc1\
@@ -71,7 +72,7 @@ fn main() {
              531d75c136272f127a5dc14acc0722301cbddc222262934151f140da345af177",
         )
         .unwrap(),
-        bitcoin::SigHashType::All,
+        bitcoin::EcdsaSigHashType::All,
     );
 
     let descriptor_str = format!(

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -83,11 +83,10 @@ fn main() {
         0xa9, 0x14, 0x92, 0x09, 0xa8, 0xf9, 0x0c, 0x58, 0x4b, 0xb5, 0x97, 0x4d, 0x58, 0x68, 0x72,
         0x49, 0xe5, 0x32, 0xde, 0x59, 0xf4, 0xbc, 0x87,
     ]);
-    let wit = transaction.input[0].witness.to_vec();
     let mut interpreter = miniscript::Interpreter::from_txdata(
         &spk_input_1,
         &transaction.input[0].script_sig,
-        &wit,
+        &transaction.input[0].witness,
         0,
         0,
     )
@@ -123,11 +122,10 @@ fn main() {
     // from the MiniscriptKey which can supplied by `to_pk_ctx` parameter. For example,
     // when calculating the script pubkey of a descriptor with xpubs, the secp context and
     // child information maybe required.
-    let wit = transaction.input[0].witness.to_vec();
     let mut interpreter = miniscript::Interpreter::from_txdata(
         &spk_input_1,
         &transaction.input[0].script_sig,
-        &wit,
+        &transaction.input[0].witness,
         0,
         0,
     )
@@ -158,11 +156,10 @@ fn main() {
     //    what happens given an apparently invalid script
     let secp = secp256k1::Secp256k1::new();
     let message = secp256k1::Message::from_slice(&[0x01; 32][..]).expect("32-byte hash");
-    let wit = transaction.input[0].witness.to_vec();
     let mut interpreter = miniscript::Interpreter::from_txdata(
         &spk_input_1,
         &transaction.input[0].script_sig,
-        &wit,
+        &transaction.input[0].witness,
         0,
         0,
     )

--- a/examples/xpub_descriptors.rs
+++ b/examples/xpub_descriptors.rs
@@ -28,7 +28,7 @@ fn main() {
             "wsh(sortedmulti(1,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB,xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH))",
         )
         .unwrap()
-        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx))
+        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx).map(bitcoin::PublicKey::new))
         .unwrap()
         .address(bitcoin::Network::Bitcoin).unwrap();
 
@@ -36,7 +36,7 @@ fn main() {
             "wsh(sortedmulti(1,xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB))",
         )
         .unwrap()
-        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx))
+        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx).map(bitcoin::PublicKey::new))
         .unwrap()
         .address(bitcoin::Network::Bitcoin).unwrap();
     let expected = bitcoin::Address::from_str(
@@ -52,7 +52,7 @@ fn main() {
         )
         .unwrap()
         .derive(5)
-        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx))
+        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx).map(bitcoin::PublicKey::new))
         .unwrap()
         .address(bitcoin::Network::Bitcoin).unwrap();
 
@@ -61,7 +61,7 @@ fn main() {
         )
         .unwrap()
         .derive(5)
-        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx))
+        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx).map(bitcoin::PublicKey::new))
         .unwrap()
         .address(bitcoin::Network::Bitcoin).unwrap();
     let expected = bitcoin::Address::from_str("325zcVBN5o2eqqqtGwPjmtDd8dJRyYP82s").unwrap();

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -7,6 +7,6 @@ authors = ["Steven Roose <steven@stevenroose.org>", "Sanket K <sanket1729@gmail.
 miniscript = {path = "../"}
 
 # Until 0.26 support is released on rust-bitcoincore-rpc
-bitcoincore-rpc = "0.14.0"
-bitcoin = "0.27.1"
+bitcoincore-rpc = {git = "https://github.com/sanket1729/rust-bitcoincore-rpc",rev = "ae3ad6cac0a83454f267cb7d5191f6607bb80297"}
+bitcoin = {git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "0e2e55971275da64ceb62e8991a0a5fa962cb8b1"}
 log = "0.4"

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -168,7 +168,7 @@ impl DescriptorXKey<bip32::ExtendedPrivKey> {
             .xkey
             .derive_priv(&secp, &deriv_on_hardened)
             .map_err(|_| DescriptorKeyParseError("Unable to derive the hardened steps"))?;
-        let xpub = bip32::ExtendedPubKey::from_private(&secp, &derived_xprv);
+        let xpub = bip32::ExtendedPubKey::from_priv(&secp, &derived_xprv);
 
         let origin = match &self.origin {
             &Some((fingerprint, ref origin_path)) => Some((
@@ -439,9 +439,9 @@ impl DescriptorPublicKey {
     pub fn derive_public_key<C: secp256k1::Verification>(
         &self,
         secp: &Secp256k1<C>,
-    ) -> Result<bitcoin::PublicKey, ConversionError> {
+    ) -> Result<secp256k1::PublicKey, ConversionError> {
         match *self {
-            DescriptorPublicKey::SinglePub(ref pk) => Ok(pk.key),
+            DescriptorPublicKey::SinglePub(ref pk) => Ok(pk.key.key),
             DescriptorPublicKey::XPub(ref xpk) => match xpk.wildcard {
                 Wildcard::Unhardened => Err(ConversionError::Wildcard),
                 Wildcard::Hardened => Err(ConversionError::HardenedWildcard),

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -209,10 +209,10 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Sh<Pk> {
         Pk: ToPublicKey,
     {
         match self.inner {
-            ShInner::Wsh(ref wsh) => Ok(bitcoin::Address::p2sh(&wsh.script_pubkey(), network)),
-            ShInner::Wpkh(ref wpkh) => Ok(bitcoin::Address::p2sh(&wpkh.script_pubkey(), network)),
-            ShInner::SortedMulti(ref smv) => Ok(bitcoin::Address::p2sh(&smv.encode(), network)),
-            ShInner::Ms(ref ms) => Ok(bitcoin::Address::p2sh(&ms.encode(), network)),
+            ShInner::Wsh(ref wsh) => Ok(bitcoin::Address::p2sh(&wsh.script_pubkey(), network)?),
+            ShInner::Wpkh(ref wpkh) => Ok(bitcoin::Address::p2sh(&wpkh.script_pubkey(), network)?),
+            ShInner::SortedMulti(ref smv) => Ok(bitcoin::Address::p2sh(&smv.encode(), network)?),
+            ShInner::Ms(ref ms) => Ok(bitcoin::Address::p2sh(&ms.encode(), network)?),
         }
     }
 

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -71,6 +71,8 @@ pub enum Error {
     Secp(secp256k1::Error),
     /// Miniscript requires the entire top level script to be satisfied.
     ScriptSatisfactionError,
+    /// Errors in signature hash calculations
+    SighashError(bitcoin::util::sighash::Error),
     /// An uncompressed public key was encountered in a context where it is
     /// disallowed (e.g. in a Segwit script or p2wpkh output)
     UncompressedPubkey,
@@ -92,6 +94,13 @@ pub enum Error {
 impl From<secp256k1::Error> for Error {
     fn from(e: secp256k1::Error) -> Error {
         Error::Secp(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<bitcoin::util::sighash::Error> for Error {
+    fn from(e: bitcoin::util::sighash::Error) -> Error {
+        Error::SighashError(e)
     }
 }
 
@@ -152,6 +161,7 @@ impl fmt::Display for Error {
             }
             Error::ScriptSatisfactionError => f.write_str("Top level script must be satisfied"),
             Error::Secp(ref e) => fmt::Display::fmt(e, f),
+            Error::SighashError(ref e) => fmt::Display::fmt(e, f),
             Error::UncompressedPubkey => {
                 f.write_str("uncompressed pubkey in non-legacy descriptor")
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -19,6 +19,7 @@
 //! assuming that the spent coin was descriptor controlled.
 //!
 
+use bitcoin::blockdata::witness::Witness;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::util::sighash;
 use bitcoin::{self, secp256k1};
@@ -54,7 +55,7 @@ impl<'txin> Interpreter<'txin> {
     pub fn from_txdata(
         spk: &bitcoin::Script,
         script_sig: &'txin bitcoin::Script,
-        witness: &'txin [Vec<u8>],
+        witness: &'txin Witness,
         age: u32,
         height: u32,
     ) -> Result<Self, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl MiniscriptKey for bitcoin::PublicKey {
     }
 }
 
-impl MiniscriptKey for bitcoin::schnorr::PublicKey {
+impl MiniscriptKey for bitcoin::secp256k1::XOnlyPublicKey {
     type Hash = hash160::Hash;
 
     fn to_pubkeyhash(&self) -> Self::Hash {
@@ -181,9 +181,9 @@ pub trait ToPublicKey: MiniscriptKey {
     fn to_public_key(&self) -> bitcoin::PublicKey;
 
     /// Convert an object to x-only pubkey
-    fn to_x_only_pubkey(&self) -> bitcoin::schnorr::PublicKey {
+    fn to_x_only_pubkey(&self) -> bitcoin::secp256k1::XOnlyPublicKey {
         let pk = self.to_public_key();
-        bitcoin::schnorr::PublicKey::from(pk.key)
+        bitcoin::secp256k1::XOnlyPublicKey::from(pk.key)
     }
 
     /// Converts a hashed version of the public key to a `hash160` hash.
@@ -205,7 +205,7 @@ impl ToPublicKey for bitcoin::PublicKey {
     }
 }
 
-impl ToPublicKey for bitcoin::schnorr::PublicKey {
+impl ToPublicKey for bitcoin::secp256k1::XOnlyPublicKey {
     fn to_public_key(&self) -> bitcoin::PublicKey {
         // This code should never be used.
         // But is implemented for completeness
@@ -215,7 +215,7 @@ impl ToPublicKey for bitcoin::schnorr::PublicKey {
             .expect("Failed to construct 33 Publickey from 0x02 appended x-only key")
     }
 
-    fn to_x_only_pubkey(&self) -> bitcoin::schnorr::PublicKey {
+    fn to_x_only_pubkey(&self) -> bitcoin::secp256k1::XOnlyPublicKey {
         *self
     }
 
@@ -475,6 +475,8 @@ pub enum Error {
     InvalidPush(Vec<u8>),
     /// rust-bitcoin script error
     Script(script::Error),
+    /// rust-bitcoin address error
+    AddrError(bitcoin::util::address::Error),
     /// A `CHECKMULTISIG` opcode was preceded by a number > 20
     CmsTooManyKeys(u32),
     /// Encountered unprintable character in descriptor
@@ -582,6 +584,13 @@ impl From<bitcoin::secp256k1::Error> for Error {
     }
 }
 
+#[doc(hidden)]
+impl From<bitcoin::util::address::Error> for Error {
+    fn from(e: bitcoin::util::address::Error) -> Error {
+        Error::AddrError(e)
+    }
+}
+
 fn errstr(s: &str) -> Error {
     Error::Unexpected(s.to_owned())
 }
@@ -607,6 +616,7 @@ impl fmt::Display for Error {
             Error::NonMinimalVerify(ref tok) => write!(f, "{} VERIFY", tok),
             Error::InvalidPush(ref push) => write!(f, "invalid push {:?}", push), // TODO hexify this
             Error::Script(ref e) => fmt::Display::fmt(e, f),
+            Error::AddrError(ref e) => fmt::Display::fmt(e, f),
             Error::CmsTooManyKeys(n) => write!(f, "checkmultisig with {} keys", n),
             Error::Unprintable(x) => write!(f, "unprintable character 0x{:02x}", x),
             Error::ExpectedChar(c) => write!(f, "expected {}", c),

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -500,7 +500,7 @@ impl ScriptContext for Segwitv0 {
 pub enum Tap {}
 
 impl ScriptContext for Tap {
-    type Key = bitcoin::schnorr::PublicKey;
+    type Key = bitcoin::secp256k1::XOnlyPublicKey;
     fn check_terminal_non_malleable<Pk: MiniscriptKey>(
         _frag: &Terminal<Pk, Self>,
     ) -> Result<(), ScriptContextError> {

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -59,9 +59,10 @@ impl ParseableKey for bitcoin::PublicKey {
     }
 }
 
-impl ParseableKey for bitcoin::schnorr::PublicKey {
+impl ParseableKey for bitcoin::secp256k1::XOnlyPublicKey {
     fn from_slice(sl: &[u8]) -> Result<Self, KeyParseError> {
-        bitcoin::schnorr::PublicKey::from_slice(sl).map_err(KeyParseError::XonlyKeyParseError)
+        bitcoin::secp256k1::XOnlyPublicKey::from_slice(sl)
+            .map_err(KeyParseError::XonlyKeyParseError)
     }
 }
 
@@ -90,7 +91,7 @@ mod private {
 
     // Implement for those same types, but no others.
     impl Sealed for super::bitcoin::PublicKey {}
-    impl Sealed for super::bitcoin::schnorr::PublicKey {}
+    impl Sealed for super::bitcoin::secp256k1::XOnlyPublicKey {}
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -176,9 +176,9 @@ impl<Ctx: ScriptContext> Miniscript<Ctx::Key, Ctx> {
     ///
     /// use miniscript::Miniscript;
     /// use miniscript::{Segwitv0, Tap};
-    /// type XonlyKey = bitcoin::schnorr::PublicKey;
+    /// use miniscript::bitcoin::secp256k1::XOnlyPublicKey;
     /// type Segwitv0Script = Miniscript<bitcoin::PublicKey, Segwitv0>;
-    /// type TapScript = Miniscript<XonlyKey, Tap>;
+    /// type TapScript = Miniscript<XOnlyPublicKey, Tap>;
     /// use bitcoin::hashes::hex::FromHex;
     /// fn main() {
     ///     // parse x-only miniscript in Taproot context
@@ -464,7 +464,7 @@ mod tests {
     use std::sync::Arc;
 
     type Segwitv0Script = Miniscript<bitcoin::PublicKey, Segwitv0>;
-    type Tapscript = Miniscript<bitcoin::schnorr::PublicKey, Tap>;
+    type Tapscript = Miniscript<bitcoin::secp256k1::XOnlyPublicKey, Tap>;
 
     fn pubkeys(n: usize) -> Vec<bitcoin::PublicKey> {
         let mut ret = Vec::with_capacity(n);

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -35,7 +35,7 @@ use ScriptContext;
 use Terminal;
 
 /// Type alias for a signature/hashtype pair
-pub type BitcoinSig = (secp256k1::Signature, bitcoin::SigHashType);
+pub type BitcoinSig = (secp256k1::ecdsa::Signature, bitcoin::EcdsaSigHashType);
 /// Type alias for 32 byte Preimage.
 pub type Preimage32 = [u8; 32];
 
@@ -44,9 +44,9 @@ pub type Preimage32 = [u8; 32];
 /// Returns underlying secp if the Signature is not of correct format
 pub fn bitcoinsig_from_rawsig(rawsig: &[u8]) -> Result<BitcoinSig, ::interpreter::Error> {
     let (flag, sig) = rawsig.split_last().unwrap();
-    let flag = bitcoin::SigHashType::from_u32_standard(*flag as u32)
+    let flag = bitcoin::EcdsaSigHashType::from_u32_standard(*flag as u32)
         .map_err(|_| ::interpreter::Error::NonStandardSigHash([sig, &[*flag]].concat().to_vec()))?;
-    let sig = secp256k1::Signature::from_der(sig)?;
+    let sig = secp256k1::ecdsa::Signature::from_der(sig)?;
     Ok((sig, flag))
 }
 /// Trait describing a lookup table for signatures, hash preimages, etc.

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1161,7 +1161,7 @@ where
 mod tests {
     use super::*;
     use bitcoin::blockdata::{opcodes, script};
-    use bitcoin::{self, hashes, secp256k1, SigHashType};
+    use bitcoin::{self, hashes, secp256k1, EcdsaSigHashType};
     use std::collections::HashMap;
     use std::str::FromStr;
     use std::string::String;
@@ -1176,7 +1176,7 @@ mod tests {
     type DummySegwitAstElemExt = policy::compiler::AstElemExt<String, Segwitv0>;
     type SegwitMiniScript = Miniscript<bitcoin::PublicKey, Segwitv0>;
 
-    fn pubkeys_and_a_sig(n: usize) -> (Vec<bitcoin::PublicKey>, secp256k1::Signature) {
+    fn pubkeys_and_a_sig(n: usize) -> (Vec<bitcoin::PublicKey>, secp256k1::ecdsa::Signature) {
         let mut ret = Vec::with_capacity(n);
         let secp = secp256k1::Secp256k1::new();
         let mut sk = [0; 32];
@@ -1194,7 +1194,7 @@ mod tests {
             };
             ret.push(pk);
         }
-        let sig = secp.sign(
+        let sig = secp.sign_ecdsa(
             &secp256k1::Message::from_slice(&sk[..]).expect("secret key"),
             &secp256k1::SecretKey::from_slice(&sk[..]).expect("secret key"),
         );
@@ -1364,7 +1364,7 @@ mod tests {
         assert_eq!(abs.n_keys(), 5);
         assert_eq!(abs.minimum_n_keys(), Some(3));
 
-        let bitcoinsig = (sig, SigHashType::All);
+        let bitcoinsig = (sig, EcdsaSigHashType::All);
         let mut sigvec = sig.serialize_der().to_vec();
         sigvec.push(1); // sighash all
 

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -35,7 +35,7 @@ fn get_scriptpubkey(psbt: &Psbt, index: usize) -> Result<&Script, InputError> {
     if let Some(ref witness_utxo) = inp.witness_utxo {
         script_pubkey = &witness_utxo.script_pubkey;
     } else if let Some(ref non_witness_utxo) = inp.non_witness_utxo {
-        let vout = psbt.global.unsigned_tx.input[index].previous_output.vout;
+        let vout = psbt.unsigned_tx.input[index].previous_output.vout;
         script_pubkey = &non_witness_utxo.output[vout as usize].script_pubkey;
     } else {
         return Err(InputError::MissingUtxo);
@@ -50,7 +50,7 @@ fn get_amt(psbt: &Psbt, index: usize) -> Result<u64, InputError> {
     if let Some(ref witness_utxo) = inp.witness_utxo {
         amt = witness_utxo.value;
     } else if let Some(ref non_witness_utxo) = inp.non_witness_utxo {
-        let vout = psbt.global.unsigned_tx.input[index].previous_output.vout;
+        let vout = psbt.unsigned_tx.input[index].previous_output.vout;
         amt = non_witness_utxo.output[vout as usize].value;
     } else {
         return Err(InputError::MissingUtxo);
@@ -219,15 +219,17 @@ pub fn interpreter_check<C: secp256k1::Verification>(
         // Now look at all the satisfied constraints. If everything is filled in
         // corrected, there should be no errors
 
-        let cltv = psbt.global.unsigned_tx.lock_time;
-        let csv = psbt.global.unsigned_tx.input[index].sequence;
+        let cltv = psbt.unsigned_tx.lock_time;
+        let csv = psbt.unsigned_tx.input[index].sequence;
         let amt = get_amt(psbt, index).map_err(|e| Error::InputError(e, index))?;
 
         let mut interpreter =
             interpreter::Interpreter::from_txdata(spk, &script_sig, &witness, cltv, csv)
                 .map_err(|e| Error::InputError(InputError::Interpreter(e), index))?;
 
-        let vfyfn = interpreter.sighash_verify(&secp, &psbt.global.unsigned_tx, index, amt);
+        let vfyfn = interpreter
+            .sighash_verify(&secp, &psbt.unsigned_tx, index, amt)
+            .map_err(|e| Error::InputError(InputError::Interpreter(e), index))?;
         if let Some(error) = interpreter.iter(vfyfn).filter_map(Result::err).next() {
             return Err(Error::InputError(InputError::Interpreter(error), index));
         }
@@ -268,26 +270,17 @@ pub fn finalize_helper<C: secp256k1::Verification>(
 
     // Check well-formedness of input data
     for (n, input) in psbt.inputs.iter().enumerate() {
-        let target = input.sighash_type.unwrap_or(bitcoin::SigHashType::All);
-        for (key, rawsig) in &input.partial_sigs {
-            if rawsig.is_empty() {
-                return Err(Error::InputError(
-                    InputError::InvalidSignature {
-                        pubkey: *key,
-                        sig: rawsig.clone(),
-                    },
-                    n,
-                ));
-            }
-            let (flag, sig) = rawsig.split_last().unwrap();
-            let flag = bitcoin::SigHashType::from_u32_standard(*flag as u32).map_err(|_| {
-                super::Error::InputError(
-                    InputError::Interpreter(interpreter::Error::NonStandardSigHash(
-                        [sig, &[*flag]].concat().to_vec(),
-                    )),
-                    n,
-                )
-            })?;
+        let target = input.sighash_type.unwrap_or(bitcoin::EcdsaSigHashType::All);
+        for (key, ecdsa_sig) in &input.partial_sigs {
+            let flag = bitcoin::EcdsaSigHashType::from_u32_standard(ecdsa_sig.hash_ty as u32)
+                .map_err(|_| {
+                    super::Error::InputError(
+                        InputError::Interpreter(interpreter::Error::NonStandardSigHash(
+                            ecdsa_sig.to_vec(),
+                        )),
+                        n,
+                    )
+                })?;
             if target != flag {
                 return Err(Error::InputError(
                     InputError::WrongSigHashFlag {
@@ -298,20 +291,7 @@ pub fn finalize_helper<C: secp256k1::Verification>(
                     n,
                 ));
             }
-            match secp256k1::Signature::from_der(sig) {
-                Err(..) => {
-                    return Err(Error::InputError(
-                        InputError::InvalidSignature {
-                            pubkey: *key,
-                            sig: Vec::from(sig),
-                        },
-                        n,
-                    ));
-                }
-                Ok(_sig) => {
-                    // Interpreter will check all the sigs later.
-                }
-            }
+            // Signatures are well-formed in psbt partial sigs
         }
     }
 


### PR DESCRIPTION
Update to a version of dev rust-bitcoin so that we can prepare for rust-miniscript release. The integration tests are updated to point a personal fork of rust-bitcoincore-rpc to have rust semver type issues. 

After we have this, we can make progress on tapscript while we await finalized rust-bitcoin release. After which, we can remove the git dependencies and have crates.io dependencies instead.