### PR TITLE
Taproot Compiler

### DIFF
--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -36,7 +36,7 @@ type PolicyCache<Pk, Ctx> =
 
 ///Ordered f64 for comparison
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-struct OrdF64(f64);
+pub(crate) struct OrdF64(pub f64);
 
 impl Eq for OrdF64 {}
 impl Ord for OrdF64 {

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -24,6 +24,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{cmp, error, f64, fmt, hash, mem};
 
+use crate::miniscript::context::SigType;
 use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
 use crate::miniscript::types::{self, ErrorKind, ExtData, Property, Type};
 use crate::miniscript::ScriptContext;
@@ -987,18 +988,23 @@ where
                 })
                 .collect();
 
-            if key_vec.len() == subs.len() && subs.len() <= MAX_PUBKEYS_PER_MULTISIG {
-                insert_wrap!(AstElemExt::terminal(Terminal::Multi(k, key_vec)));
-            }
-            // Not a threshold, it's always more optimal to translate it to and()s as we save the
-            // resulting threshold check (N EQUAL) in any case.
-            else if k == subs.len() {
-                let mut policy = subs.first().expect("No sub policy in thresh() ?").clone();
-                for sub in &subs[1..] {
-                    policy = Concrete::And(vec![sub.clone(), policy]);
+            match Ctx::sig_type() {
+                SigType::Schnorr if key_vec.len() == subs.len() => {
+                    insert_wrap!(AstElemExt::terminal(Terminal::MultiA(k, key_vec)))
                 }
+                SigType::Ecdsa
+                    if key_vec.len() == subs.len() && subs.len() <= MAX_PUBKEYS_PER_MULTISIG =>
+                {
+                    insert_wrap!(AstElemExt::terminal(Terminal::Multi(k, key_vec)))
+                }
+                _ if k == subs.len() => {
+                    let mut it = subs.iter();
+                    let mut policy = it.next().expect("No sub policy in thresh() ?").clone();
+                    policy = it.fold(policy, |acc, pol| Concrete::And(vec![acc, pol.clone()]));
 
-                ret = best_compilations(policy_cache, &policy, sat_prob, dissat_prob)?;
+                    ret = best_compilations(policy_cache, &policy, sat_prob, dissat_prob)?;
+                }
+                _ => {}
             }
 
             // FIXME: Should we also optimize thresh(1, subs) ?
@@ -1548,6 +1554,17 @@ mod tests {
                 policy::concrete::PolicyError::DuplicatePubKeys
             ))
         );
+    }
+
+    #[test]
+    fn compile_tr_thresh() {
+        for k in 1..4 {
+            let small_thresh: Concrete<String> =
+                policy_str!("{}", &format!("thresh({},pk(B),pk(C),pk(D))", k));
+            let small_thresh_ms: Miniscript<String, Tap> = small_thresh.compile().unwrap();
+            let small_thresh_ms_expected: Miniscript<String, Tap> = ms_str!("multi_a({},B,C,D)", k);
+            assert_eq!(small_thresh_ms, small_thresh_ms_expected);
+        }
     }
 }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -368,15 +368,35 @@ mod tests {
 
     #[test]
     #[cfg(feature = "compiler")]
-    fn single_leaf_tr_compile() {
-        let unspendable_key: String = "z".to_string();
-        let policy: Concrete<String> = policy_str!("thresh(2,pk(A),pk(B),pk(C),pk(D))");
-        let descriptor = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
+    fn taproot_compile() {
+        // Trivial single-node compilation
+        let unspendable_key: String = "UNSPENDABLE".to_string();
+        {
+            let policy: Concrete<String> = policy_str!("thresh(2,pk(A),pk(B),pk(C),pk(D))");
+            let descriptor = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
 
-        let ms_compilation: Miniscript<String, Tap> = ms_str!("multi_a(2,A,B,C,D)");
-        let tree: TapTree<String> = TapTree::Leaf(Arc::new(ms_compilation));
-        let expected_descriptor = Descriptor::new_tr(unspendable_key, Some(tree)).unwrap();
+            let ms_compilation: Miniscript<String, Tap> = ms_str!("multi_a(2,A,B,C,D)");
+            let tree: TapTree<String> = TapTree::Leaf(Arc::new(ms_compilation));
+            let expected_descriptor =
+                Descriptor::new_tr(unspendable_key.clone(), Some(tree)).unwrap();
+            assert_eq!(descriptor, expected_descriptor);
+        }
 
-        assert_eq!(descriptor, expected_descriptor);
+        // Trivial multi-node compilation
+        {
+            let policy: Concrete<String> = policy_str!("or(and(pk(A),pk(B)),and(pk(C),pk(D)))");
+            let descriptor = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
+
+            let left_ms_compilation: Arc<Miniscript<String, Tap>> =
+                Arc::new(ms_str!("and_v(v:pk(C),pk(D))"));
+            let right_ms_compilation: Arc<Miniscript<String, Tap>> =
+                Arc::new(ms_str!("and_v(v:pk(A),pk(B))"));
+            let left_node: Arc<TapTree<String>> = Arc::from(TapTree::Leaf(left_ms_compilation));
+            let right_node: Arc<TapTree<String>> = Arc::from(TapTree::Leaf(right_ms_compilation));
+            let tree: TapTree<String> = TapTree::Tree(left_node, right_node);
+            let expected_descriptor =
+                Descriptor::new_tr(unspendable_key.clone(), Some(tree)).unwrap();
+            assert_eq!(descriptor, expected_descriptor);
+        }
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -409,5 +409,77 @@ mod tests {
                 "Policy contains duplicate keys"
             );
         }
+
+        // Non-trivial multi-node compilation
+        {
+            let node_policies = [
+                "and(pk(A),pk(B))",
+                "and(pk(C),older(12960))",
+                "pk(D)",
+                "pk(E)",
+                "thresh(3,pk(F),pk(G),pk(H))",
+                "and(and(or(2@pk(I),1@pk(J)),or(1@pk(K),20@pk(L))),pk(M))",
+                "pk(N)",
+            ];
+
+            // Floating-point precision errors cause the minor errors
+            let node_probabilities: [f64; 7] =
+                [0.12000002, 0.28, 0.08, 0.12, 0.19, 0.18999998, 0.02];
+
+            let policy: Concrete<String> = policy_str!(
+                "{}",
+                &format!(
+                    "or(4@or(3@{},7@{}),6@thresh(1,or(4@{},6@{}),{},or(9@{},1@{})))",
+                    node_policies[0],
+                    node_policies[1],
+                    node_policies[2],
+                    node_policies[3],
+                    node_policies[4],
+                    node_policies[5],
+                    node_policies[6]
+                )
+            );
+            let descriptor = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
+
+            let mut sorted_policy_prob = node_policies
+                .into_iter()
+                .zip(node_probabilities.into_iter())
+                .collect::<Vec<_>>();
+            sorted_policy_prob.sort_by(|a, b| (a.1).partial_cmp(&b.1).unwrap());
+            let sorted_policies = sorted_policy_prob
+                .into_iter()
+                .map(|(x, _prob)| x)
+                .collect::<Vec<_>>();
+
+            // Generate TapTree leaves compilations from the given sub-policies
+            let node_compilations = sorted_policies
+                .into_iter()
+                .map(|x| {
+                    let leaf_policy: Concrete<String> = policy_str!("{}", x);
+                    TapTree::Leaf(Arc::from(leaf_policy.compile::<Tap>().unwrap()))
+                })
+                .collect::<Vec<_>>();
+
+            // Arrange leaf compilations (acc. to probabilities) using huffman encoding into a TapTree
+            let tree = TapTree::Tree(
+                Arc::from(TapTree::Tree(
+                    Arc::from(node_compilations[4].clone()),
+                    Arc::from(node_compilations[5].clone()),
+                )),
+                Arc::from(TapTree::Tree(
+                    Arc::from(TapTree::Tree(
+                        Arc::from(TapTree::Tree(
+                            Arc::from(node_compilations[0].clone()),
+                            Arc::from(node_compilations[1].clone()),
+                        )),
+                        Arc::from(node_compilations[3].clone()),
+                    )),
+                    Arc::from(node_compilations[6].clone()),
+                )),
+            );
+
+            let expected_descriptor = Descriptor::new_tr("E".to_string(), Some(tree)).unwrap();
+            assert_eq!(descriptor, expected_descriptor);
+        }
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -398,5 +398,16 @@ mod tests {
                 Descriptor::new_tr(unspendable_key.clone(), Some(tree)).unwrap();
             assert_eq!(descriptor, expected_descriptor);
         }
+
+        {
+            // Invalid policy compilation (Duplicate PubKeys)
+            let policy: Concrete<String> = policy_str!("or(and(pk(A),pk(B)),and(pk(A),pk(D)))");
+            let descriptor = policy.compile_tr(Some(unspendable_key.clone()));
+
+            assert_eq!(
+                descriptor.unwrap_err().to_string(),
+                "Policy contains duplicate keys"
+            );
+        }
     }
 }

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -184,7 +184,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     // policy.
     // Witness is currently encoded as policy. Only accepts leaf fragment and
     // a normalized policy
-    fn satisfy_constraint(self, witness: &Policy<Pk>, available: bool) -> Policy<Pk> {
+    pub(crate) fn satisfy_constraint(self, witness: &Policy<Pk>, available: bool) -> Policy<Pk> {
         debug_assert!(self.clone().normalized() == self);
         match *witness {
             // only for internal purposes, safe to use unreachable!


### PR DESCRIPTION
This PR builds on top of #278. 

This is one in a series of PRs aimed to implement a feature-complete *Pay-to-Taproot* **P2Tr** compiler.
Specifically, this introduces a basic compilation for a given policy by collecting the leaf nodes of the *tree* generated by considering root-level disjunctive `OR`and using this to generate a `TapTree`. 

> Assuming that _duplicate keys_ are **NOT** possible even in different branches of the TapTree.

# Follow Up PRs
 
- #342  - Uses heuristic for tree-generation/ _merging_ algorithm while buillding `TapTree` to optimize over the *expected average total cost*. 
- #352 
- A future PR implementing enumerative strategies for optimizing `thresh` `k`-of-`n` and similar structures.