### PR TITLE
miniscript: allow up to 2^32 timelocks for after()

### DIFF
--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -1033,10 +1033,7 @@ impl Property for ExtData {
                 }
             }
             Terminal::After(t) => {
-                // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
-                // number on the stack would be a 5 bytes signed integer but Miniscript's B type
-                // only consumes 4 bytes from the stack.
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) == 1 {
+                if t == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -436,10 +436,7 @@ pub trait Property: Sized {
                 }
             }
             Terminal::After(t) => {
-                // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
-                // number on the stack would be a 5 bytes signed integer but Miniscript's B type
-                // only consumes 4 bytes from the stack.
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) == 1 {
+                if t == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,
@@ -819,10 +816,7 @@ impl Property for Type {
                 }
             }
             Terminal::After(t) => {
-                // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
-                // number on the stack would be a 5 bytes signed integer but Miniscript's B type
-                // only consumes 4 bytes from the stack.
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) == 1 {
+                if t == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,


### PR DESCRIPTION
See https://github.com/sipa/miniscript/pull/97 and the discussion at https://gnusha.org/miniscript/2022-02-06.log.

I still need to:
- [ ] Check the size computation with 5-bytes pushes
- [ ] Add sanity checks for the maximum values inside `after()` and `older()`