### PR TITLE
Allow constructing Sh descriptors wrapping an existing Wsh/Wpkh

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -277,6 +277,18 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
         Ok(Descriptor::Bare(Bare::new(ms)?))
     }
 
+    // Wrap with sh
+
+    /// Create a new sh wrapper for the given wpkh descriptor
+    pub fn new_sh_with_wpkh(wpkh: Wpkh<Pk>) -> Self {
+        Descriptor::Sh(Sh::new_with_wpkh(wpkh))
+    }
+
+    /// Create a new sh wrapper for the given wsh descriptor
+    pub fn new_sh_with_wsh(wsh: Wsh<Pk>) -> Self {
+        Descriptor::Sh(Sh::new_with_wsh(wsh))
+    }
+
     // sorted multi
 
     /// Create a new sh sortedmulti descriptor with threshold `k`

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -175,6 +175,13 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
         })
     }
 
+    /// Create a new p2sh wrapper for the given wsh descriptor
+    pub fn new_with_wsh(wsh: Wsh<Pk>) -> Self {
+        Self {
+            inner: ShInner::Wsh(wsh),
+        }
+    }
+
     /// Create a new p2sh wrapped wsh sortedmulti descriptor from threshold
     /// `k` and Vec of `pks`
     pub fn new_wsh_sortedmulti(k: usize, pks: Vec<Pk>) -> Result<Self, Error> {
@@ -190,6 +197,13 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
         Ok(Self {
             inner: ShInner::Wpkh(Wpkh::new(pk)?),
         })
+    }
+
+    /// Create a new p2sh wrapper for the given wpkh descriptor
+    pub fn new_with_wpkh(wpkh: Wpkh<Pk>) -> Self {
+        Self {
+            inner: ShInner::Wpkh(wpkh),
+        }
     }
 }
 


### PR DESCRIPTION
Useful if you already have an `W{s,pk}h` descriptor and wish to wrap it with P2SH.

This used to be [possible](https://github.com/shesek/minsc/blob/33433462e84e3903a70a9aac6f47e591df094127/src/stdlib/miniscript.rs#L149-L153) before the new inner types for the Descriptor enum variants, which has private fields that cannot be initialized externally.