### PR TITLE
Taproot interpreter support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,9 @@ name = "parse"
 [[example]]
 name = "sign_multisig"
 
-[[example]]
-name = "verify_tx"
+# TODO: Re-enable in future commit after API re-design
+# [[example]]
+# name = "verify_tx"
 
 [[example]]
 name = "psbt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,8 @@ name = "parse"
 [[example]]
 name = "sign_multisig"
 
-# TODO: Re-enable in future commit after API re-design
-# [[example]]
-# name = "verify_tx"
+[[example]]
+name = "verify_tx"
 
 [[example]]
 name = "psbt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rand = ["bitcoin/rand"]
 
 [dependencies]
 # bitcoin = "0.27"
-bitcoin = {git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "0e2e55971275da64ceb62e8991a0a5fa962cb8b1"}
+bitcoin = "0.28.0-rc.1"
 
 [dependencies.serde]
 version = "1.0"

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -167,7 +167,9 @@ fn main() {
 
     let iter = interpreter.iter(|pk, ecdsa_sig| {
         ecdsa_sig.hash_ty == bitcoin::EcdsaSigHashType::All
-            && secp.verify_ecdsa(&message, &ecdsa_sig.sig, &pk.key).is_ok()
+            && secp
+                .verify_ecdsa(&message, &ecdsa_sig.sig, &pk.inner)
+                .is_ok()
     });
     println!("\nExample three");
     for elem in iter {

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -7,6 +7,6 @@ authors = ["Steven Roose <steven@stevenroose.org>", "Sanket K <sanket1729@gmail.
 miniscript = {path = "../"}
 
 # Until 0.26 support is released on rust-bitcoincore-rpc
-bitcoincore-rpc = {git = "https://github.com/sanket1729/rust-bitcoincore-rpc",rev = "ae3ad6cac0a83454f267cb7d5191f6607bb80297"}
-bitcoin = {git = "https://github.com/rust-bitcoin/rust-bitcoin", rev = "0e2e55971275da64ceb62e8991a0a5fa962cb8b1"}
+bitcoincore-rpc = {git = "https://github.com/sanket1729/rust-bitcoincore-rpc",rev = "bcc35944b3dd636cdff9710f90f8e0cfcab28f27"}
+bitcoin = "0.28.0-rc.1"
 log = "0.4"

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -207,7 +207,7 @@ fn main() {
         for sk in sks_reqd {
             let sig = secp.sign_ecdsa(&msg, &sk);
             let pk = pks[sks.iter().position(|&x| x == sk).unwrap()];
-            psbts[i].inputs[0].partial_sigs.insert(pk, bitcoin::EcdsaSig { sig, hash_ty: sighash_ty });
+            psbts[i].inputs[0].partial_sigs.insert(pk.inner, bitcoin::EcdsaSig { sig, hash_ty: sighash_ty });
         }
         // Add the hash preimages to the psbt
         psbts[i].inputs[0].sha256_preimages.insert(

--- a/integration_test/src/read_file.rs
+++ b/integration_test/src/read_file.rs
@@ -60,7 +60,7 @@ fn setup_keys(
 
         let sk = secp256k1::SecretKey::from_slice(&sk[..]).expect("secret key");
         let pk = miniscript::bitcoin::PublicKey {
-            key: secp256k1::PublicKey::from_secret_key(&secp_sign, &sk),
+            inner: secp256k1::PublicKey::from_secret_key(&secp_sign, &sk),
             compressed: true,
         };
         pks.push(pk);

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -4,11 +4,10 @@ use bitcoin::{
     self,
     hashes::Hash,
     hashes::{hex::FromHex, HashEngine},
-    schnorr::XOnlyPublicKey,
     secp256k1,
     secp256k1::{Secp256k1, Signing},
     util::bip32,
-    XpubIdentifier,
+    XOnlyPublicKey, XpubIdentifier,
 };
 
 use {MiniscriptKey, ToPublicKey};

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1011,10 +1011,7 @@ mod tests {
         let secp = secp256k1::Secp256k1::new();
         let sk =
             secp256k1::SecretKey::from_slice(&b"sally was a secret key, she said"[..]).unwrap();
-        let pk = bitcoin::PublicKey {
-            key: secp256k1::PublicKey::from_secret_key(&secp, &sk),
-            compressed: true,
-        };
+        let pk = bitcoin::PublicKey::new(secp256k1::PublicKey::from_secret_key(&secp, &sk));
         let msg = secp256k1::Message::from_slice(&b"michael was a message, amusingly"[..])
             .expect("32 bytes");
         let sig = secp.sign_ecdsa(&msg, &sk);

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -140,9 +140,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
         // Sort pubkeys lexicographically according to BIP 67
         pks.sort_by(|a, b| {
             a.to_public_key()
-                .key
+                .inner
                 .serialize()
-                .partial_cmp(&b.to_public_key().key.serialize())
+                .partial_cmp(&b.to_public_key().inner.serialize())
                 .unwrap()
         });
         Terminal::Multi(self.k, pks)

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -246,7 +246,7 @@ impl fmt::Display for Error {
             Error::Secp(ref e) => fmt::Display::fmt(e, f),
             Error::SchnorrSig(ref s) => write!(f, "Schnorr sig error: {}", s),
             Error::SighashError(ref e) => fmt::Display::fmt(e, f),
-            Error::TapAnnexUnsupported => f.write_str("Encounter Annex element"),
+            Error::TapAnnexUnsupported => f.write_str("Encountered annex element"),
             Error::UncompressedPubkey => {
                 f.write_str("uncompressed pubkey in non-legacy descriptor")
             }

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -376,7 +376,6 @@ pub(super) fn pre_taproot_to_no_checks<Ctx: ScriptContext>(
 }
 
 // Convert a miniscript from a specified context into an insane miniscript
-#[allow(dead_code)]
 pub(super) fn taproot_to_no_checks<Ctx: ScriptContext>(
     ms: &Miniscript<bitcoin::XOnlyPublicKey, Ctx>,
 ) -> Miniscript<BitcoinKey, NoChecks> {

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -154,7 +154,7 @@ pub fn from_txdata<'txin>(
             match wit_stack.pop() {
                 Some(elem) => {
                     let pk = pk_from_stackelem(&elem, true)?;
-                    if *spk == bitcoin::Script::new_v0_wpkh(&pk.to_pubkeyhash().into()) {
+                    if *spk == bitcoin::Script::new_v0_p2wpkh(&pk.to_pubkeyhash().into()) {
                         Ok((
                             Inner::PublicKey(pk, PubkeyType::Wpkh),
                             wit_stack,
@@ -177,7 +177,7 @@ pub fn from_txdata<'txin>(
                     let miniscript = script_from_stackelem(&elem)?;
                     let script = miniscript.encode();
                     let scripthash = sha256::Hash::hash(&script[..]);
-                    if *spk == bitcoin::Script::new_v0_wsh(&scripthash.into()) {
+                    if *spk == bitcoin::Script::new_v0_p2wsh(&scripthash.into()) {
                         Ok((
                             Inner::Script(miniscript, ScriptType::Wsh),
                             wit_stack,
@@ -208,8 +208,9 @@ pub fn from_txdata<'txin>(
                                 } else {
                                     let pk = pk_from_stackelem(&elem, true)?;
                                     if slice
-                                        == &bitcoin::Script::new_v0_wpkh(&pk.to_pubkeyhash().into())
-                                            [..]
+                                        == &bitcoin::Script::new_v0_p2wpkh(
+                                            &pk.to_pubkeyhash().into(),
+                                        )[..]
                                     {
                                         Ok((
                                             Inner::PublicKey(pk, PubkeyType::ShWpkh),
@@ -233,7 +234,8 @@ pub fn from_txdata<'txin>(
                                     let miniscript = script_from_stackelem(&elem)?;
                                     let script = miniscript.encode();
                                     let scripthash = sha256::Hash::hash(&script[..]);
-                                    if slice == &bitcoin::Script::new_v0_wsh(&scripthash.into())[..]
+                                    if slice
+                                        == &bitcoin::Script::new_v0_p2wsh(&scripthash.into())[..]
                                     {
                                         Ok((
                                             Inner::Script(miniscript, ScriptType::ShWsh),
@@ -322,7 +324,7 @@ mod tests {
 
             let pkhash = key.to_pubkeyhash().into();
             let wpkhash = key.to_pubkeyhash().into();
-            let wpkh_spk = bitcoin::Script::new_v0_wpkh(&wpkhash);
+            let wpkh_spk = bitcoin::Script::new_v0_p2wpkh(&wpkhash);
             let wpkh_scripthash = hash160::Hash::hash(&wpkh_spk[..]).into();
 
             KeyTestData {
@@ -670,7 +672,7 @@ mod tests {
         let wit_hash = sha256::Hash::hash(&witness_script[..]).into();
         let wit_stack = Witness::from_vec(vec![witness_script.to_bytes()]);
 
-        let spk = Script::new_v0_wsh(&wit_hash);
+        let spk = Script::new_v0_p2wsh(&wit_hash);
         let blank_script = bitcoin::Script::new();
 
         // wsh without witness
@@ -708,7 +710,7 @@ mod tests {
         let wit_hash = sha256::Hash::hash(&witness_script[..]).into();
         let wit_stack = Witness::from_vec(vec![witness_script.to_bytes()]);
 
-        let redeem_script = Script::new_v0_wsh(&wit_hash);
+        let redeem_script = Script::new_v0_p2wsh(&wit_hash);
         let script_sig = script::Builder::new()
             .push_slice(&redeem_script[..])
             .into_script();

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -244,11 +244,12 @@ pub(super) fn from_txdata<'txin>(
                         Ok((
                             Inner::Script(ms, ScriptType::Tr),
                             wit_stack,
-                            // Tr script spend code is stored in script spend. This is an internal hack to store the
-                            // encoded script instead yet another tagged enum for saving tap_script
-                            // We can recompute the script again by translating from nochecks to tap and re-encoding it
-                            // Having this hack seems simple because this is not exposed publicly and the internal code is
-                            // easy to audit
+                            // Tapscript is returned as a "scriptcode". This is a hack, but avoids adding yet
+                            // another enum just for taproot, and this function is not a publicly exposed API,
+                            // so it's easy enough to keep track of all uses.
+                            //
+                            // In particular, this return value will be put into the `script_code` member of
+                            // the `Interpreter` script; the iterpreter logic does the right thing with it.
                             Some(tap_script),
                         ))
                     } else {

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -211,7 +211,7 @@ pub(super) fn from_txdata<'txin>(
                 // Key spend
                 // let sig =
                 // Tr inference to be done in future commit
-                todo!();
+                panic!("TODO");
             }
             Ok((
                 Inner::PublicKey(output_key.into(), PubkeyType::Tr),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -46,7 +46,9 @@ use self::stack::Stack;
 pub struct Interpreter<'txin> {
     inner: inner::Inner,
     stack: Stack<'txin>,
-    script_code: Option<bitcoin::Script>, // taproot transactions don't have script code
+    /// For non-Taproot spends, the scriptCode; for Taproot script-spends, this
+    /// is the leaf script; for key-spends it is `None`.
+    script_code: Option<bitcoin::Script>,
     age: u32,
     height: u32,
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -244,7 +244,8 @@ impl<'txin> Interpreter<'txin> {
                     bitcoin::EcdsaSigHashType::NonePlusAnyoneCanPay => sighashes[4],
                     bitcoin::EcdsaSigHashType::SinglePlusAnyoneCanPay => sighashes[5],
                 };
-                secp.verify_ecdsa(&sighash, &ecdsa_sig.sig, &pk.key).is_ok()
+                secp.verify_ecdsa(&sighash, &ecdsa_sig.sig, &pk.inner)
+                    .is_ok()
             },
         )
     }
@@ -825,7 +826,7 @@ mod tests {
 
             let sk = secp256k1::SecretKey::from_slice(&sk[..]).expect("secret key");
             let pk = bitcoin::PublicKey {
-                key: secp256k1::PublicKey::from_secret_key(&secp_sign, &sk),
+                inner: secp256k1::PublicKey::from_secret_key(&secp_sign, &sk),
                 compressed: true,
             };
             let sig = secp_sign.sign_ecdsa(&msg, &sk);
@@ -842,7 +843,8 @@ mod tests {
     fn sat_constraints() {
         let (pks, der_sigs, secp_sigs, sighash, secp) = setup_keys_sigs(10);
         let vfyfn_ = |pk: &bitcoin::PublicKey, ecdsa_sig: bitcoin::EcdsaSig| {
-            secp.verify_ecdsa(&sighash, &ecdsa_sig.sig, &pk.key).is_ok()
+            secp.verify_ecdsa(&sighash, &ecdsa_sig.sig, &pk.inner)
+                .is_ok()
         };
 
         fn from_stack<'txin, 'elem, F>(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -28,7 +28,7 @@ use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 // use bitcoin::util::sighash;
 #[allow(unused_imports)]
 use bitcoin::{self, secp256k1};
-use miniscript::context::NoChecksEcdsa;
+use miniscript::context::NoChecks;
 use miniscript::ScriptContext;
 use Miniscript;
 use Terminal;
@@ -486,7 +486,7 @@ pub enum SatisfiedConstraint {
 ///depending on evaluation of the children.
 struct NodeEvaluationState<'intp> {
     ///The node which is being evaluated
-    node: &'intp Miniscript<BitcoinKey, NoChecksEcdsa>,
+    node: &'intp Miniscript<BitcoinKey, NoChecks>,
     ///number of children evaluated
     n_evaluated: usize,
     ///number of children satisfied
@@ -517,7 +517,7 @@ pub struct Iter<'intp, 'txin: 'intp> {
 ///Iterator for Iter
 impl<'intp, 'txin: 'intp> Iterator for Iter<'intp, 'txin>
 where
-    NoChecksEcdsa: ScriptContext,
+    NoChecks: ScriptContext,
 {
     type Item = Result<SatisfiedConstraint, Error>;
 
@@ -537,12 +537,12 @@ where
 
 impl<'intp, 'txin: 'intp> Iter<'intp, 'txin>
 where
-    NoChecksEcdsa: ScriptContext,
+    NoChecks: ScriptContext,
 {
     /// Helper function to push a NodeEvaluationState on state stack
     fn push_evaluation_state(
         &mut self,
-        node: &'intp Miniscript<BitcoinKey, NoChecksEcdsa>,
+        node: &'intp Miniscript<BitcoinKey, NoChecks>,
         n_evaluated: usize,
         n_satisfied: usize,
     ) -> () {
@@ -973,7 +973,7 @@ mod tests {
     use bitcoin;
     use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
     use bitcoin::secp256k1::{self, Secp256k1, VerifyOnly};
-    use miniscript::context::NoChecksEcdsa;
+    use miniscript::context::NoChecks;
     use Miniscript;
     use MiniscriptKey;
     use ToPublicKey;
@@ -1034,7 +1034,7 @@ mod tests {
         fn from_stack<'txin, 'elem>(
             verify_fn: Box<dyn FnMut(&KeySigPair) -> bool + 'elem>,
             stack: Stack<'txin>,
-            ms: &'elem Miniscript<BitcoinKey, NoChecksEcdsa>,
+            ms: &'elem Miniscript<BitcoinKey, NoChecks>,
         ) -> Iter<'elem, 'txin> {
             Iter {
                 verify_sig: verify_fn,
@@ -1438,8 +1438,8 @@ mod tests {
 
     // By design there is no support for parse a miniscript with BitcoinKey
     // because it does not implement FromStr
-    fn no_checks_ms(ms: &str) -> Miniscript<BitcoinKey, NoChecksEcdsa> {
-        let elem: Miniscript<bitcoin::PublicKey, NoChecksEcdsa> =
+    fn no_checks_ms(ms: &str) -> Miniscript<BitcoinKey, NoChecks> {
+        let elem: Miniscript<bitcoin::PublicKey, NoChecks> =
             Miniscript::from_str_insane(ms).unwrap();
         inner::pre_taproot_to_no_checks(&elem)
     }

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -127,14 +127,11 @@ impl<'txin> Stack<'txin> {
     /// Unsat: For empty witness a 0 is pushed
     /// Err: All of other witness result in errors.
     /// `pk` CHECKSIG
-    pub(super) fn evaluate_pk<'intp, F>(
+    pub(super) fn evaluate_pk<'intp>(
         &mut self,
-        verify_sig: F,
+        verify_sig: &mut Box<dyn FnMut(&KeySigPair) -> bool + 'intp>,
         pk: &'intp BitcoinKey,
-    ) -> Option<Result<SatisfiedConstraint, Error>>
-    where
-        F: FnMut(&KeySigPair) -> bool,
-    {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         if let Some(sigser) = self.pop() {
             match sigser {
                 Element::Dissatisfied => {
@@ -166,14 +163,11 @@ impl<'txin> Stack<'txin> {
     /// Unsat: For an empty witness
     /// Err: All of other witness result in errors.
     /// `DUP HASH160 <keyhash> EQUALVERIY CHECKSIG`
-    pub(super) fn evaluate_pkh<'intp, F>(
+    pub(super) fn evaluate_pkh<'intp>(
         &mut self,
-        verify_sig: F,
+        verify_sig: &mut Box<dyn FnMut(&KeySigPair) -> bool + 'intp>,
         pkh: &'intp TaggedHash160,
-    ) -> Option<Result<SatisfiedConstraint, Error>>
-    where
-        F: FnOnce(&KeySigPair) -> bool,
-    {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         // Parse a bitcoin key from witness data slice depending on hash context
         // when we encounter a pkh(hash)
         // Depending on the tag of hash, we parse the as full key or x-only-key
@@ -371,14 +365,11 @@ impl<'txin> Stack<'txin> {
     /// other signatures are not checked against the first pubkey.
     /// `multi(2,pk1,pk2)` would be satisfied by `[0 sig2 sig1]` and Err on
     /// `[0 sig2 sig1]`
-    pub(super) fn evaluate_multi<'intp, F>(
+    pub(super) fn evaluate_multi<'intp>(
         &mut self,
-        verify_sig: F,
+        verify_sig: &mut Box<dyn FnMut(&KeySigPair) -> bool + 'intp>,
         pk: &'intp BitcoinKey,
-    ) -> Option<Result<SatisfiedConstraint, Error>>
-    where
-        F: FnOnce(&KeySigPair) -> bool,
-    {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         if let Some(witness_sig) = self.pop() {
             if let Element::Push(sigser) = witness_sig {
                 let key_sig = verify_sersig(verify_sig, pk, sigser);

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -18,9 +18,10 @@ use bitcoin;
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 
-use ToPublicKey;
-
-use super::{verify_sersig, Error, HashLockType, SatisfiedConstraint};
+use super::error::PkEvalErrInner;
+use super::{
+    verify_sersig, BitcoinKey, Error, HashLockType, KeySigPair, SatisfiedConstraint, TaggedHash160,
+};
 
 /// Definition of Stack Element of the Stack used for interpretation of Miniscript.
 /// All stack elements with vec![] go to Dissatisfied and vec![1] are marked to Satisfied.
@@ -126,13 +127,13 @@ impl<'txin> Stack<'txin> {
     /// Unsat: For empty witness a 0 is pushed
     /// Err: All of other witness result in errors.
     /// `pk` CHECKSIG
-    pub fn evaluate_pk<'intp, F>(
+    pub(super) fn evaluate_pk<'intp, F>(
         &mut self,
         verify_sig: F,
-        pk: &'intp bitcoin::PublicKey,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>>
+        pk: &'intp BitcoinKey,
+    ) -> Option<Result<SatisfiedConstraint, Error>>
     where
-        F: FnMut(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
+        F: FnMut(&KeySigPair) -> bool,
     {
         if let Some(sigser) = self.pop() {
             match sigser {
@@ -140,18 +141,18 @@ impl<'txin> Stack<'txin> {
                     self.push(Element::Dissatisfied);
                     None
                 }
-                Element::Push(ref sigser) => {
-                    let sig = verify_sersig(verify_sig, pk, sigser);
-                    match sig {
-                        Ok(sig) => {
+                Element::Push(sigser) => {
+                    let key_sig = verify_sersig(verify_sig, pk, sigser);
+                    match key_sig {
+                        Ok(key_sig) => {
                             self.push(Element::Satisfied);
-                            Some(Ok(SatisfiedConstraint::PublicKey { key: pk, sig }))
+                            Some(Ok(SatisfiedConstraint::PublicKey { key_sig }))
                         }
                         Err(e) => return Some(Err(e)),
                     }
                 }
                 Element::Satisfied => {
-                    return Some(Err(Error::PkEvaluationError(pk.clone().to_public_key())))
+                    return Some(Err(Error::PkEvaluationError(PkEvalErrInner::from(*pk))));
                 }
             }
         } else {
@@ -165,21 +166,33 @@ impl<'txin> Stack<'txin> {
     /// Unsat: For an empty witness
     /// Err: All of other witness result in errors.
     /// `DUP HASH160 <keyhash> EQUALVERIY CHECKSIG`
-    pub fn evaluate_pkh<'intp, F>(
+    pub(super) fn evaluate_pkh<'intp, F>(
         &mut self,
         verify_sig: F,
-        pkh: &'intp hash160::Hash,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>>
+        pkh: &'intp TaggedHash160,
+    ) -> Option<Result<SatisfiedConstraint, Error>>
     where
-        F: FnOnce(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
+        F: FnOnce(&KeySigPair) -> bool,
     {
+        // Parse a bitcoin key from witness data slice depending on hash context
+        // when we encounter a pkh(hash)
+        // Depending on the tag of hash, we parse the as full key or x-only-key
+        // TODO: All keys parse errors are currently captured in a single BadPubErr
+        // We don't really store information about which key error.
+        fn bitcoin_key_from_slice(sl: &[u8], tag: TaggedHash160) -> Option<BitcoinKey> {
+            let key: BitcoinKey = match tag {
+                TaggedHash160::XonlyKey(_) => bitcoin::XOnlyPublicKey::from_slice(sl).ok()?.into(),
+                TaggedHash160::FullKey(_) => bitcoin::PublicKey::from_slice(sl).ok()?.into(),
+            };
+            Some(key)
+        }
         if let Some(Element::Push(pk)) = self.pop() {
             let pk_hash = hash160::Hash::hash(pk);
-            if pk_hash != *pkh {
-                return Some(Err(Error::PkHashVerifyFail(*pkh)));
+            if pk_hash != pkh.hash160() {
+                return Some(Err(Error::PkHashVerifyFail(pkh.hash160())));
             }
-            match bitcoin::PublicKey::from_slice(pk) {
-                Ok(pk) => {
+            match bitcoin_key_from_slice(pk, *pkh) {
+                Some(pk) => {
                     if let Some(sigser) = self.pop() {
                         match sigser {
                             Element::Dissatisfied => {
@@ -187,30 +200,27 @@ impl<'txin> Stack<'txin> {
                                 None
                             }
                             Element::Push(sigser) => {
-                                let sig = verify_sersig(verify_sig, &pk, sigser);
-                                match sig {
-                                    Ok(sig) => {
+                                let key_sig = verify_sersig(verify_sig, &pk, sigser);
+                                match key_sig {
+                                    Ok(key_sig) => {
                                         self.push(Element::Satisfied);
                                         Some(Ok(SatisfiedConstraint::PublicKeyHash {
-                                            keyhash: pkh,
-                                            key: pk,
-                                            sig,
+                                            keyhash: pkh.hash160(),
+                                            key_sig: key_sig,
                                         }))
                                     }
                                     Err(e) => return Some(Err(e)),
                                 }
                             }
                             Element::Satisfied => {
-                                return Some(Err(Error::PkEvaluationError(
-                                    pk.clone().to_public_key(),
-                                )))
+                                return Some(Err(Error::PkEvaluationError(pk.into())))
                             }
                         }
                     } else {
                         Some(Err(Error::UnexpectedStackEnd))
                     }
                 }
-                Err(..) => Some(Err(Error::PubkeyParseError)),
+                None => Some(Err(Error::PubkeyParseError)),
             }
         } else {
             Some(Err(Error::UnexpectedStackEnd))
@@ -223,14 +233,14 @@ impl<'txin> Stack<'txin> {
     /// The reason we don't need to copy the Script semantics is that
     /// Miniscript never evaluates integers and it is safe to treat them as
     /// booleans
-    pub fn evaluate_after<'intp>(
+    pub(super) fn evaluate_after<'intp>(
         &mut self,
         n: &'intp u32,
         age: u32,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>> {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         if age >= *n {
             self.push(Element::Satisfied);
-            Some(Ok(SatisfiedConstraint::AbsoluteTimeLock { time: n }))
+            Some(Ok(SatisfiedConstraint::AbsoluteTimeLock { time: *n }))
         } else {
             Some(Err(Error::AbsoluteLocktimeNotMet(*n)))
         }
@@ -242,14 +252,14 @@ impl<'txin> Stack<'txin> {
     /// The reason we don't need to copy the Script semantics is that
     /// Miniscript never evaluates integers and it is safe to treat them as
     /// booleans
-    pub fn evaluate_older<'intp>(
+    pub(super) fn evaluate_older<'intp>(
         &mut self,
         n: &'intp u32,
         height: u32,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>> {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         if height >= *n {
             self.push(Element::Satisfied);
-            Some(Ok(SatisfiedConstraint::RelativeTimeLock { time: n }))
+            Some(Ok(SatisfiedConstraint::RelativeTimeLock { time: *n }))
         } else {
             Some(Err(Error::RelativeLocktimeNotMet(*n)))
         }
@@ -257,10 +267,10 @@ impl<'txin> Stack<'txin> {
 
     /// Helper function to evaluate a Sha256 Node.
     /// `SIZE 32 EQUALVERIFY SHA256 h EQUAL`
-    pub fn evaluate_sha256<'intp>(
+    pub(super) fn evaluate_sha256<'intp>(
         &mut self,
         hash: &'intp sha256::Hash,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>> {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         if let Some(Element::Push(preimage)) = self.pop() {
             if preimage.len() != 32 {
                 return Some(Err(Error::HashPreimageLengthMismatch));
@@ -268,8 +278,8 @@ impl<'txin> Stack<'txin> {
             if sha256::Hash::hash(preimage) == *hash {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
-                    hash: HashLockType::Sha256(hash),
-                    preimage,
+                    hash: HashLockType::Sha256(*hash),
+                    preimage: preimage_from_sl(preimage),
                 }))
             } else {
                 self.push(Element::Dissatisfied);
@@ -282,10 +292,10 @@ impl<'txin> Stack<'txin> {
 
     /// Helper function to evaluate a Hash256 Node.
     /// `SIZE 32 EQUALVERIFY HASH256 h EQUAL`
-    pub fn evaluate_hash256<'intp>(
+    pub(super) fn evaluate_hash256<'intp>(
         &mut self,
         hash: &'intp sha256d::Hash,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>> {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         if let Some(Element::Push(preimage)) = self.pop() {
             if preimage.len() != 32 {
                 return Some(Err(Error::HashPreimageLengthMismatch));
@@ -293,8 +303,8 @@ impl<'txin> Stack<'txin> {
             if sha256d::Hash::hash(preimage) == *hash {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
-                    hash: HashLockType::Hash256(hash),
-                    preimage,
+                    hash: HashLockType::Hash256(*hash),
+                    preimage: preimage_from_sl(preimage),
                 }))
             } else {
                 self.push(Element::Dissatisfied);
@@ -307,10 +317,10 @@ impl<'txin> Stack<'txin> {
 
     /// Helper function to evaluate a Hash160 Node.
     /// `SIZE 32 EQUALVERIFY HASH160 h EQUAL`
-    pub fn evaluate_hash160<'intp>(
+    pub(super) fn evaluate_hash160<'intp>(
         &mut self,
         hash: &'intp hash160::Hash,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>> {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         if let Some(Element::Push(preimage)) = self.pop() {
             if preimage.len() != 32 {
                 return Some(Err(Error::HashPreimageLengthMismatch));
@@ -318,8 +328,8 @@ impl<'txin> Stack<'txin> {
             if hash160::Hash::hash(preimage) == *hash {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
-                    hash: HashLockType::Hash160(hash),
-                    preimage,
+                    hash: HashLockType::Hash160(*hash),
+                    preimage: preimage_from_sl(preimage),
                 }))
             } else {
                 self.push(Element::Dissatisfied);
@@ -332,10 +342,10 @@ impl<'txin> Stack<'txin> {
 
     /// Helper function to evaluate a RipeMd160 Node.
     /// `SIZE 32 EQUALVERIFY RIPEMD160 h EQUAL`
-    pub fn evaluate_ripemd160<'intp>(
+    pub(super) fn evaluate_ripemd160<'intp>(
         &mut self,
         hash: &'intp ripemd160::Hash,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>> {
+    ) -> Option<Result<SatisfiedConstraint, Error>> {
         if let Some(Element::Push(preimage)) = self.pop() {
             if preimage.len() != 32 {
                 return Some(Err(Error::HashPreimageLengthMismatch));
@@ -343,8 +353,8 @@ impl<'txin> Stack<'txin> {
             if ripemd160::Hash::hash(preimage) == *hash {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
-                    hash: HashLockType::Ripemd160(hash),
-                    preimage,
+                    hash: HashLockType::Ripemd160(*hash),
+                    preimage: preimage_from_sl(preimage),
                 }))
             } else {
                 self.push(Element::Dissatisfied);
@@ -361,19 +371,19 @@ impl<'txin> Stack<'txin> {
     /// other signatures are not checked against the first pubkey.
     /// `multi(2,pk1,pk2)` would be satisfied by `[0 sig2 sig1]` and Err on
     /// `[0 sig2 sig1]`
-    pub fn evaluate_multi<'intp, F>(
+    pub(super) fn evaluate_multi<'intp, F>(
         &mut self,
         verify_sig: F,
-        pk: &'intp bitcoin::PublicKey,
-    ) -> Option<Result<SatisfiedConstraint<'intp, 'txin>, Error>>
+        pk: &'intp BitcoinKey,
+    ) -> Option<Result<SatisfiedConstraint, Error>>
     where
-        F: FnOnce(&bitcoin::PublicKey, bitcoin::EcdsaSig) -> bool,
+        F: FnOnce(&KeySigPair) -> bool,
     {
         if let Some(witness_sig) = self.pop() {
             if let Element::Push(sigser) = witness_sig {
-                let sig = verify_sersig(verify_sig, pk, sigser);
-                match sig {
-                    Ok(sig) => return Some(Ok(SatisfiedConstraint::PublicKey { key: pk, sig })),
+                let key_sig = verify_sersig(verify_sig, pk, sigser);
+                match key_sig {
+                    Ok(key_sig) => return Some(Ok(SatisfiedConstraint::PublicKey { key_sig })),
                     Err(..) => {
                         self.push(witness_sig);
                         return None;
@@ -385,5 +395,16 @@ impl<'txin> Stack<'txin> {
         } else {
             Some(Err(Error::UnexpectedStackEnd))
         }
+    }
+}
+
+// Helper function to compute preimage from slice
+fn preimage_from_sl(sl: &[u8]) -> [u8; 32] {
+    if sl.len() != 32 {
+        unreachable!("Internal: Preimage length checked to be 32")
+    } else {
+        let mut preimage = [0u8; 32];
+        preimage.copy_from_slice(sl);
+        preimage
     }
 }

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -70,6 +70,15 @@ impl<'txin> Element<'txin> {
             _ => Err(Error::ExpectedPush),
         }
     }
+
+    // Get push element as slice, returning UnexpectedBool otherwise
+    pub(super) fn as_push(&self) -> Result<&[u8], Error> {
+        if let Element::Push(sl) = *self {
+            Ok(sl)
+        } else {
+            Err(Error::UnexpectedStackBoolean)
+        }
+    }
 }
 
 /// Stack Data structure representing the stack input to Miniscript. This Stack

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -20,7 +20,7 @@ use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 
 use super::error::PkEvalErrInner;
 use super::{
-    verify_sersig, BitcoinKey, Error, HashLockType, KeySigPair, SatisfiedConstraint, TaggedHash160,
+    verify_sersig, BitcoinKey, Error, HashLockType, KeySigPair, SatisfiedConstraint, TypedHash160,
 };
 
 /// Definition of Stack Element of the Stack used for interpretation of Miniscript.
@@ -175,17 +175,17 @@ impl<'txin> Stack<'txin> {
     pub(super) fn evaluate_pkh<'intp>(
         &mut self,
         verify_sig: &mut Box<dyn FnMut(&KeySigPair) -> bool + 'intp>,
-        pkh: &'intp TaggedHash160,
+        pkh: &'intp TypedHash160,
     ) -> Option<Result<SatisfiedConstraint, Error>> {
         // Parse a bitcoin key from witness data slice depending on hash context
         // when we encounter a pkh(hash)
         // Depending on the tag of hash, we parse the as full key or x-only-key
         // TODO: All keys parse errors are currently captured in a single BadPubErr
         // We don't really store information about which key error.
-        fn bitcoin_key_from_slice(sl: &[u8], tag: TaggedHash160) -> Option<BitcoinKey> {
+        fn bitcoin_key_from_slice(sl: &[u8], tag: TypedHash160) -> Option<BitcoinKey> {
             let key: BitcoinKey = match tag {
-                TaggedHash160::XonlyKey(_) => bitcoin::XOnlyPublicKey::from_slice(sl).ok()?.into(),
-                TaggedHash160::FullKey(_) => bitcoin::PublicKey::from_slice(sl).ok()?.into(),
+                TypedHash160::XonlyKey(_) => bitcoin::XOnlyPublicKey::from_slice(sl).ok()?.into(),
+                TypedHash160::FullKey(_) => bitcoin::PublicKey::from_slice(sl).ok()?.into(),
             };
             Some(key)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ pub trait ToPublicKey: MiniscriptKey {
     /// Convert an object to x-only pubkey
     fn to_x_only_pubkey(&self) -> bitcoin::secp256k1::XOnlyPublicKey {
         let pk = self.to_public_key();
-        bitcoin::secp256k1::XOnlyPublicKey::from(pk.key)
+        bitcoin::secp256k1::XOnlyPublicKey::from(pk.inner)
     }
 
     /// Converts a hashed version of the public key to a `hash160` hash.

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -125,17 +125,18 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             }
         }
     }
-    pub(super) fn real_translate_pk<FPk, FPkh, Q, Error>(
+    pub(super) fn real_translate_pk<FPk, FPkh, Q, Error, CtxQ>(
         &self,
         translatefpk: &mut FPk,
         translatefpkh: &mut FPkh,
-    ) -> Result<Terminal<Q, Ctx>, Error>
+    ) -> Result<Terminal<Q, CtxQ>, Error>
     where
         FPk: FnMut(&Pk) -> Result<Q, Error>,
         FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, Error>,
         Q: MiniscriptKey,
+        CtxQ: ScriptContext,
     {
-        let frag = match *self {
+        let frag: Terminal<Q, CtxQ> = match *self {
             Terminal::PkK(ref p) => Terminal::PkK(translatefpk(p)?),
             Terminal::PkH(ref p) => Terminal::PkH(translatefpkh(p)?),
             Terminal::After(n) => Terminal::After(n),

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -473,7 +473,7 @@ pub mod test {
     pub fn gen_bitcoin_pubkeys(n: usize, compressed: bool) -> Vec<bitcoin::PublicKey> {
         gen_secp_pubkeys(n)
             .into_iter()
-            .map(|key| bitcoin::PublicKey { key, compressed })
+            .map(|inner| bitcoin::PublicKey { inner, compressed })
             .collect()
     }
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -495,7 +495,7 @@ mod tests {
             sk[2] = (i >> 16) as u8;
 
             let pk = bitcoin::PublicKey {
-                key: secp256k1::PublicKey::from_secret_key(
+                inner: secp256k1::PublicKey::from_secret_key(
                     &secp,
                     &secp256k1::SecretKey::from_slice(&sk[..]).expect("secret key"),
                 ),
@@ -743,7 +743,7 @@ mod tests {
 
         string_rtt(
             script,
-            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, key: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "pk(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)"
         );
 
@@ -751,7 +751,7 @@ mod tests {
 
         string_rtt(
             script,
-            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, key: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "pk(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)"
         );
 
@@ -759,7 +759,7 @@ mod tests {
 
         string_rtt(
             script,
-            "[B/onufsm]t[V/onfsm]v[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, key: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/onufsm]t[V/onfsm]v[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "tv:pk(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)"
         );
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -304,15 +304,16 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         self.node.real_for_each_key(pred)
     }
 
-    fn real_translate_pk<FPk, FPkh, Q, FuncError>(
+    pub(crate) fn real_translate_pk<FPk, FPkh, Q, FuncError, CtxQ>(
         &self,
         translatefpk: &mut FPk,
         translatefpkh: &mut FPkh,
-    ) -> Result<Miniscript<Q, Ctx>, FuncError>
+    ) -> Result<Miniscript<Q, CtxQ>, FuncError>
     where
         FPk: FnMut(&Pk) -> Result<Q, FuncError>,
         FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, FuncError>,
         Q: MiniscriptKey,
+        CtxQ: ScriptContext,
     {
         let inner = self.node.real_translate_pk(translatefpk, translatefpkh)?;
         let ms = Miniscript {

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1185,7 +1185,7 @@ mod tests {
             sk[2] = (i >> 16) as u8;
 
             let pk = bitcoin::PublicKey {
-                key: secp256k1::PublicKey::from_secret_key(
+                inner: secp256k1::PublicKey::from_secret_key(
                     &secp,
                     &secp256k1::SecretKey::from_slice(&sk[..]).expect("sk"),
                 ),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -343,7 +343,7 @@ mod tests {
 
         let ms_str: Miniscript<bitcoin::PublicKey, Segwitv0> = format!(
             "andor(multi(1,{}),older(42),c:pk_k({}))",
-            key_a.key, key_b.key
+            key_a.inner, key_b.inner
         )
         .parse()
         .unwrap();

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -313,7 +313,7 @@ pub fn interpreter_check<C: secp256k1::Verification>(
                 secp.ctx();
                 true
             };
-            let iter = interpreter.iter(Box::new(y));
+            let iter = interpreter.iter_custom(Box::new(y));
             if let Some(error) = iter.filter_map(Result::err).next() {
                 return Err(Error::InputError(InputError::Interpreter(error), index));
             };

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -304,10 +304,11 @@ pub fn interpreter_check<C: secp256k1::Verification>(
             interpreter::Interpreter::from_txdata(spk, &script_sig, &witness, cltv, csv)
                 .map_err(|e| Error::InputError(InputError::Interpreter(e), index))?;
 
-        let vfyfn = interpreter
-            .sighash_verify(&secp, &psbt.unsigned_tx, index, amt)
-            .map_err(|e| Error::InputError(InputError::Interpreter(e), index))?;
-        if let Some(error) = interpreter.iter(vfyfn).filter_map(Result::err).next() {
+        // let vfyfn = interpreter
+        //     .sighash_verify(&secp, &psbt.unsigned_tx, index, amt)
+        //     .map_err(|e| Error::InputError(InputError::Interpreter(e), index))?;
+        // Will change in later commmit
+        if let Some(error) = interpreter.iter(|_| true).filter_map(Result::err).next() {
             return Err(Error::InputError(InputError::Interpreter(error), index));
         }
     }

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -300,7 +300,7 @@ pub fn interpreter_check<C: secp256k1::Verification>(
         let csv = psbt.unsigned_tx.input[index].sequence;
         let amt = get_amt(psbt, index).map_err(|e| Error::InputError(e, index))?;
 
-        let mut interpreter =
+        let interpreter =
             interpreter::Interpreter::from_txdata(spk, &script_sig, &witness, cltv, csv)
                 .map_err(|e| Error::InputError(InputError::Interpreter(e), index))?;
 


### PR DESCRIPTION
Add taproot interpreter support. This is the second to last PR for taproot miniscript support. The last PR will add some more high-level APIs for taproot psbt and integration tests.