### PR TITLE
Update derived_descriptor signature and related examples

### DIFF
--- a/examples/xpub_descriptors.rs
+++ b/examples/xpub_descriptors.rs
@@ -51,8 +51,7 @@ fn main() {
             "sh(wsh(sortedmulti(1,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1/0/*,xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/0/0/*)))",
         )
         .unwrap()
-        .derive(5)
-        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx))
+        .derived_descriptor(&secp_ctx, 5)
         .unwrap()
         .address(bitcoin::Network::Bitcoin).unwrap();
 
@@ -60,8 +59,7 @@ fn main() {
             "sh(wsh(sortedmulti(1,xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/0/0/*,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1/0/*)))",
         )
         .unwrap()
-        .derive(5)
-        .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx))
+        .derived_descriptor(&secp_ctx, 5)
         .unwrap()
         .address(bitcoin::Network::Bitcoin).unwrap();
     let expected = bitcoin::Address::from_str("325zcVBN5o2eqqqtGwPjmtDd8dJRyYP82s").unwrap();

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -581,7 +581,7 @@ impl Descriptor<DescriptorPublicKey> {
     /// let secp = secp256k1::Secp256k1::verification_only();
     /// let descriptor = Descriptor::<DescriptorPublicKey>::from_str("tr(xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ/0/*)")
     ///     .expect("Valid ranged descriptor");
-    /// let result = descriptor.derived_descriptor(0, &secp).expect("Non-hardened derivation");
+    /// let result = descriptor.derived_descriptor(&secp, 0).expect("Non-hardened derivation");
     /// assert_eq!(result.to_string(), "tr(03cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115)#6qm9h8ym");
     /// ```
     ///
@@ -590,8 +590,8 @@ impl Descriptor<DescriptorPublicKey> {
     /// This function will return an error if hardened derivation is attempted.
     pub fn derived_descriptor<C: secp256k1::Verification>(
         &self,
-        index: u32,
         secp: &secp256k1::Secp256k1<C>,
+        index: u32,
     ) -> Result<Descriptor<bitcoin::PublicKey>, ConversionError> {
         let derived = self
             .derive(index)


### PR DESCRIPTION
## Description
Resolves #302.  

- Updates the order of parameters in `derived_descriptor` function signature.
- Updates the P2WSH-P2SH and ranged xpub examples to call `derived_descriptor` function.