### PR TITLE
Fix the length of the taproot output to 34 bytes in script_is_v1_tr

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -52,11 +52,14 @@ impl MsKeyBuilder for script::Builder {
 // This belongs in rust-bitcoin, make this upstream later
 pub(crate) fn script_is_v1_tr(s: &Script) -> bool {
     let mut iter = s.instructions_minimal();
-    if s.len() != 32
-        || iter.next() != Some(Ok(Instruction::Op(opcodes::all::OP_PUSHNUM_1)))
-        || iter.next() != Some(Ok(Instruction::Op(opcodes::all::OP_PUSHBYTES_32)))
-    {
+    if s.len() != 34 {
         return false;
     }
-    return true;
+    if iter.next() != Some(Ok(Instruction::Op(opcodes::all::OP_PUSHNUM_1))) {
+        return false;
+    }
+    if let Some(Ok(Instruction::PushBytes(p))) = iter.next() {
+        return p.len() == 32;
+    }
+    return false;
 }


### PR DESCRIPTION
It's impossible to finalize a taproot PSBT with this line not fixed because the finalizer thinks the output is not TR and then tries to parse it as a legacy script.