### PR TITLE
Make Tr::spend_info public

### DIFF
--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -211,10 +211,12 @@ impl<Pk: MiniscriptKey> Tr<Pk> {
         }
     }
 
-    // Compute the [`TaprootSpendInfo`] associated with this descriptor if spend data is [None]
-    // If spend data is already computed (i.e it is not None), this does not recompute it
-    // TaprootSpendInfo is only required for spending via the script paths.
-    fn spend_info(&self) -> Arc<TaprootSpendInfo>
+    /// Compute the [`TaprootSpendInfo`] associated with this descriptor if spend data is `None`.
+    ///
+    /// If spend data is already computed (i.e it is not `None`), this does not recompute it.
+    ///
+    /// [`TaprootSpendInfo`] is only required for spending via the script paths.
+    pub fn spend_info(&self) -> Arc<TaprootSpendInfo>
     where
         Pk: ToPublicKey,
     {


### PR DESCRIPTION
This is needed for wallet libraries downstream to access for instance merkle root of the script.