### PR TITLE
SigType check for cost-analysis in SegwitV1 scripts

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -654,12 +654,12 @@ mod tests {
         let pkk_ms: Miniscript<DummyKey, Segwitv0> = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
                 node: Terminal::PkK(DummyKey),
-                ty: Type::from_pk_k(),
-                ext: types::extra_props::ExtData::from_pk_k(),
+                ty: Type::from_pk_k::<Segwitv0>(),
+                ext: types::extra_props::ExtData::from_pk_k::<Segwitv0>(),
                 phantom: PhantomData,
             })),
-            ty: Type::cast_check(Type::from_pk_k()).unwrap(),
-            ext: ExtData::cast_check(ExtData::from_pk_k()).unwrap(),
+            ty: Type::cast_check(Type::from_pk_k::<Segwitv0>()).unwrap(),
+            ext: ExtData::cast_check(ExtData::from_pk_k::<Segwitv0>()).unwrap(),
             phantom: PhantomData,
         };
         string_rtt(pkk_ms, "[B/onduesm]c:[K/onduesm]pk_k(DummyKey)", "pk()");
@@ -667,12 +667,12 @@ mod tests {
         let pkh_ms: Miniscript<DummyKey, Segwitv0> = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
                 node: Terminal::PkH(DummyKeyHash),
-                ty: Type::from_pk_h(),
-                ext: types::extra_props::ExtData::from_pk_h(),
+                ty: Type::from_pk_h::<Segwitv0>(),
+                ext: types::extra_props::ExtData::from_pk_h::<Segwitv0>(),
                 phantom: PhantomData,
             })),
-            ty: Type::cast_check(Type::from_pk_h()).unwrap(),
-            ext: ExtData::cast_check(ExtData::from_pk_h()).unwrap(),
+            ty: Type::cast_check(Type::from_pk_h::<Segwitv0>()).unwrap(),
+            ext: ExtData::cast_check(ExtData::from_pk_h::<Segwitv0>()).unwrap(),
             phantom: PhantomData,
         };
         string_rtt(pkh_ms, "[B/nduesm]c:[K/nduesm]pk_h(DummyKeyHash)", "pkh()");
@@ -680,12 +680,12 @@ mod tests {
         let pkk_ms: Segwitv0Script = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
                 node: Terminal::PkK(pk),
-                ty: Type::from_pk_k(),
-                ext: types::extra_props::ExtData::from_pk_k(),
+                ty: Type::from_pk_k::<Segwitv0>(),
+                ext: types::extra_props::ExtData::from_pk_k::<Segwitv0>(),
                 phantom: PhantomData,
             })),
-            ty: Type::cast_check(Type::from_pk_k()).unwrap(),
-            ext: ExtData::cast_check(ExtData::from_pk_k()).unwrap(),
+            ty: Type::cast_check(Type::from_pk_k::<Segwitv0>()).unwrap(),
+            ext: ExtData::cast_check(ExtData::from_pk_k::<Segwitv0>()).unwrap(),
             phantom: PhantomData,
         };
 
@@ -698,12 +698,12 @@ mod tests {
         let pkh_ms: Segwitv0Script = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
                 node: Terminal::PkH(hash),
-                ty: Type::from_pk_h(),
-                ext: types::extra_props::ExtData::from_pk_h(),
+                ty: Type::from_pk_h::<Segwitv0>(),
+                ext: types::extra_props::ExtData::from_pk_h::<Segwitv0>(),
                 phantom: PhantomData,
             })),
-            ty: Type::cast_check(Type::from_pk_h()).unwrap(),
-            ext: ExtData::cast_check(ExtData::from_pk_h()).unwrap(),
+            ty: Type::cast_check(Type::from_pk_h::<Segwitv0>()).unwrap(),
+            ext: ExtData::cast_check(ExtData::from_pk_h::<Segwitv0>()).unwrap(),
             phantom: PhantomData,
         };
 

--- a/src/miniscript/types/correctness.rs
+++ b/src/miniscript/types/correctness.rs
@@ -15,6 +15,7 @@
 //! Correctness/Soundness type properties
 
 use super::{ErrorKind, Property};
+use crate::ScriptContext;
 
 /// Basic type representing where the fragment can go
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
@@ -142,7 +143,7 @@ impl Property for Correctness {
         }
     }
 
-    fn from_pk_k() -> Self {
+    fn from_pk_k<Ctx: ScriptContext>() -> Self {
         Correctness {
             base: Base::K,
             input: Input::OneNonZero,
@@ -151,7 +152,7 @@ impl Property for Correctness {
         }
     }
 
-    fn from_pk_h() -> Self {
+    fn from_pk_h<Ctx: ScriptContext>() -> Self {
         Correctness {
             base: Base::K,
             input: Input::AnyNonZero,

--- a/src/miniscript/types/malleability.rs
+++ b/src/miniscript/types/malleability.rs
@@ -15,6 +15,7 @@
 //! Malleability-related Type properties
 
 use super::{ErrorKind, Property};
+use crate::ScriptContext;
 
 /// Whether the fragment has a dissatisfaction, and if so, whether
 /// it is unique. Affects both correctness and malleability-freeness,
@@ -94,7 +95,7 @@ impl Property for Malleability {
         }
     }
 
-    fn from_pk_k() -> Self {
+    fn from_pk_k<Ctx: ScriptContext>() -> Self {
         Malleability {
             dissat: Dissat::Unique,
             safe: true,
@@ -102,7 +103,7 @@ impl Property for Malleability {
         }
     }
 
-    fn from_pk_h() -> Self {
+    fn from_pk_h<Ctx: ScriptContext>() -> Self {
         Malleability {
             dissat: Dissat::Unique,
             safe: true,

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -258,10 +258,10 @@ pub trait Property: Sized {
     fn from_false() -> Self;
 
     /// Type property of the `PkK` fragment
-    fn from_pk_k() -> Self;
+    fn from_pk_k<Ctx: ScriptContext>() -> Self;
 
     /// Type property of the `PkH` fragment
-    fn from_pk_h() -> Self;
+    fn from_pk_h<Ctx: ScriptContext>() -> Self;
 
     /// Type property of a `Multi` fragment
     fn from_multi(k: usize, n: usize) -> Self;
@@ -413,8 +413,8 @@ pub trait Property: Sized {
         let ret = match *fragment {
             Terminal::True => Ok(Self::from_true()),
             Terminal::False => Ok(Self::from_false()),
-            Terminal::PkK(..) => Ok(Self::from_pk_k()),
-            Terminal::PkH(..) => Ok(Self::from_pk_h()),
+            Terminal::PkK(..) => Ok(Self::from_pk_k::<Ctx>()),
+            Terminal::PkH(..) => Ok(Self::from_pk_h::<Ctx>()),
             Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
@@ -562,17 +562,17 @@ impl Property for Type {
         }
     }
 
-    fn from_pk_k() -> Self {
+    fn from_pk_k<Ctx: ScriptContext>() -> Self {
         Type {
-            corr: Property::from_pk_k(),
-            mall: Property::from_pk_k(),
+            corr: Property::from_pk_k::<Ctx>(),
+            mall: Property::from_pk_k::<Ctx>(),
         }
     }
 
-    fn from_pk_h() -> Self {
+    fn from_pk_h<Ctx: ScriptContext>() -> Self {
         Type {
-            corr: Property::from_pk_h(),
-            mall: Property::from_pk_h(),
+            corr: Property::from_pk_h::<Ctx>(),
+            mall: Property::from_pk_h::<Ctx>(),
         }
     }
 
@@ -796,8 +796,8 @@ impl Property for Type {
         let ret = match *fragment {
             Terminal::True => Ok(Self::from_true()),
             Terminal::False => Ok(Self::from_false()),
-            Terminal::PkK(..) => Ok(Self::from_pk_k()),
-            Terminal::PkH(..) => Ok(Self::from_pk_h()),
+            Terminal::PkK(..) => Ok(Self::from_pk_k::<Ctx>()),
+            Terminal::PkH(..) => Ok(Self::from_pk_h::<Ctx>()),
             Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {


### PR DESCRIPTION
Previously, the struct `CompilerExtData` provided cost analysis for a given script considering the **SegwitV0** standards. This PR aims to track the type/ (context) of the script and provide the respective cost analysis.