### PR TITLE
Rectify `from_multi_a` max satisfaction size

### DIFF
--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -249,7 +249,7 @@ impl Property for ExtData {
             ops_count_nsat: Some(n + 1),
             stack_elem_count_sat: Some(n),
             stack_elem_count_dissat: Some(n),
-            max_sat_size: Some(((n - k) + 64 * k, (n - k) + 64 * k)),
+            max_sat_size: Some(((n - k) + 66 * k, (n - k) + 66 * k)),
             max_dissat_size: Some((n, n)),
             timelock_info: TimeLockInfo::default(),
             exec_stack_elem_count_sat: Some(2), // the two nums before num equal verify


### PR DESCRIPTION
Cost incurred for a single Schnorr signature in the witness stack := `<var_int><64-byte signature><sig_type>` = 1 + 64 + 1 (as clarified by @sanket1729 in #340 ).