### PR TITLE
lib: implement PartialEq for miniscript::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,7 +508,7 @@ pub trait ForEachKey<Pk: MiniscriptKey> {
 
 /// Miniscript
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Opcode appeared which is not part of the script subset
     InvalidOpcode(opcodes::All),

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -31,7 +31,7 @@ use {Miniscript, MiniscriptKey, ScriptContext};
 /// 3. The script is malleable and thereby some of satisfaction weight
 ///    guarantees are not satisfied.
 /// 4. It has repeated publickeys
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum AnalysisError {
     /// Top level is not safe.
     SiglessBranch,


### PR DESCRIPTION
This helps a lot downstream, and we can do that now that rust-bitcoin derives `PartialEq` everywhere.