### PR TITLE
Hacky Fix for int CI failure

### DIFF
--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Steven Roose <steven@stevenroose.org>", "Sanket K <sanket1729@gmail.
 miniscript = {path = "../"}
 
 # Until 0.26 support is released on rust-bitcoincore-rpc
-bitcoincore-rpc = {git = "https://github.com/sanket1729/rust-bitcoincore-rpc",rev = "bcc35944b3dd636cdff9710f90f8e0cfcab28f27"}
+bitcoincore-rpc = {git = "https://github.com/sanket1729/rust-bitcoincore-rpc",rev = "1ee9a3e808815702ac1a4b974689fcb33b5648c3"}
 bitcoin = {ver = "0.28.0-rc.1", features = ["rand"]}
 log = "0.4"
 rand = "0.8.4"


### PR DESCRIPTION
While we await rust-bitcoincore-rpc release, let's have this to make
sure that integrationt tests run and we get a nice green checkmark.
I really don't like seeing a red cross on all PRs :)