### PR TITLE
Enable edition 2018

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.29.0
+          - 1.41.1
           - beta
     steps:
       - name: Checkout Crate
@@ -65,13 +65,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Pin deps if rust 1.29
-        if: matrix.rust == '1.29.0'
-        run: |
-            cargo generate-lockfile --verbose && \
-            cargo update --verbose --package "cc" --precise "1.0.41" && \
-            cargo update --verbose --package "serde" --precise "1.0.98" && \
-            cargo update --verbose --package "serde_derive" --precise "1.0.98"
       - name: Running cargo
         run: ./contrib/test.sh
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/rust-bitcoin/rust-miniscript/"
 description = "Miniscript: a subset of Bitcoin Script designed for analysis"
 keywords = [ "crypto", "bitcoin"]
 readme = "README.md"
+edition = "2018"
 
 [features]
 compiler = []

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 ![Build](https://github.com/rust-bitcoin/rust-miniscript/workflows/Continuous%20integration/badge.svg)
 
-**Minimum Supported Rust Version:** 1.29.0
-
-*This crate uses "2015" edition and won't be ported over "2018" edition
-in the near future as this will change the MSRV to 1.31.*
+**Minimum Supported Rust Version:** 1.41.1
 
 # Miniscript
 
@@ -36,22 +33,7 @@ or in [the `examples/` directory](https://github.com/apoelstra/rust-miniscript/t
 
 
 ## Minimum Supported Rust Version (MSRV)
-This library should always compile with any combination of features on **Rust 1.29**.
-
-Because some dependencies have broken the build in minor/patch releases, to compile with 1.29.0 you will need to
-generate the lockfile and run the following version-pinning command:
-```
-cargo generate-lockfile --verbose
-cargo update -p cc --precise "1.0.41" --verbose
-```
-
-In order to use the `use-serde` feature or to build the unit tests with 1.29.0,
-the following version-pinning commands are also needed:
-```
-cargo update --package "serde" --precise "1.0.98"
-cargo update --package "serde_derive" --precise "1.0.98"
-```
-
+This library should always compile with any combination of features on **Rust 1.41.1**.
 
 ## Contributing
 Contributions are generally welcome. If you intend to make larger changes please

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -14,8 +14,8 @@
 
 //! Example: Parsing a descriptor from a string
 
-extern crate bitcoin;
-extern crate miniscript;
+use bitcoin;
+use miniscript;
 
 use miniscript::{descriptor::DescriptorType, Descriptor, DescriptorTrait};
 use std::str::FromStr;

--- a/examples/psbt.rs
+++ b/examples/psbt.rs
@@ -1,5 +1,4 @@
-extern crate bitcoin;
-extern crate miniscript;
+use bitcoin;
 
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::hex::FromHex;

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -14,8 +14,8 @@
 
 //! Example: Signing a 2-of-3 multisignature
 
-extern crate bitcoin;
-extern crate miniscript;
+use bitcoin;
+use miniscript;
 
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::secp256k1; // secp256k1 re-exported from rust-bitcoin

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -14,8 +14,8 @@
 
 //! Example: Verifying a signed transaction
 
-extern crate bitcoin;
-extern crate miniscript;
+use bitcoin;
+use miniscript;
 
 use bitcoin::consensus::Decodable;
 use bitcoin::util::sighash;

--- a/examples/xpub_descriptors.rs
+++ b/examples/xpub_descriptors.rs
@@ -14,8 +14,6 @@
 
 //! Example: Parsing a xpub and getting address
 
-extern crate miniscript;
-
 use miniscript::bitcoin::{self, secp256k1};
 use miniscript::{Descriptor, DescriptorPublicKey, DescriptorTrait, TranslatePk2};
 

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -8,6 +8,6 @@ miniscript = {path = "../"}
 
 # Until 0.26 support is released on rust-bitcoincore-rpc
 bitcoincore-rpc = {git = "https://github.com/sanket1729/rust-bitcoincore-rpc",rev = "1ee9a3e808815702ac1a4b974689fcb33b5648c3"}
-bitcoin = {ver = "0.28.0-rc.1", features = ["rand"]}
+bitcoin = { version = "0.28", features = ["rand"]}
 log = "0.4"
 rand = "0.8.4"

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -13,7 +13,7 @@ use bitcoincore_rpc::{Auth, Client, RpcApi};
 mod test_cpp;
 mod test_desc;
 mod test_util;
-use test_util::TestData;
+use crate::test_util::TestData;
 
 struct StdLogger;
 

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -22,11 +22,11 @@ use std::{fmt, str::FromStr};
 
 use bitcoin::{self, blockdata::script, Script};
 
-use expression::{self, FromTree};
-use miniscript::context::ScriptContext;
-use policy::{semantic, Liftable};
-use util::{varint_len, witness_to_scriptsig};
-use {
+use crate::expression::{self, FromTree};
+use crate::miniscript::context::ScriptContext;
+use crate::policy::{semantic, Liftable};
+use crate::util::{varint_len, witness_to_scriptsig};
+use crate::{
     BareCtx, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey,
     TranslatePk,
 };

--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -5,7 +5,7 @@
 
 use std::iter::FromIterator;
 
-use Error;
+use crate::Error;
 
 const INPUT_CHARSET: &str =  "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ ";
 const CHECKSUM_CHARSET: &str = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -10,7 +10,7 @@ use bitcoin::{
     XOnlyPublicKey, XpubIdentifier,
 };
 
-use {MiniscriptKey, ToPublicKey};
+use crate::{MiniscriptKey, ToPublicKey};
 
 /// The descriptor pubkey, either a single pubkey or an xpub.
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -35,10 +35,10 @@ use bitcoin::util::address::WitnessVersion;
 use bitcoin::{self, secp256k1, Script};
 
 use self::checksum::verify_checksum;
-use expression;
-use miniscript;
-use miniscript::{Legacy, Miniscript, Segwitv0};
-use {
+use crate::expression;
+use crate::miniscript;
+use crate::miniscript::{Legacy, Miniscript, Segwitv0};
+use crate::{
     BareCtx, Error, ForEach, ForEachKey, MiniscriptKey, Satisfier, ToPublicKey, TranslatePk,
     TranslatePk2,
 };
@@ -870,6 +870,10 @@ mod tests {
     use super::checksum::desc_checksum;
     use super::tr::Tr;
     use super::*;
+    use crate::descriptor::key::Wildcard;
+    use crate::descriptor::{DescriptorPublicKey, DescriptorSecretKey, DescriptorXKey, SinglePub};
+    use crate::hex_script;
+    use crate::{Descriptor, DummyKey, Error, Miniscript, Satisfier, TranslatePk2};
     use bitcoin::blockdata::opcodes::all::{OP_CLTV, OP_CSV};
     use bitcoin::blockdata::script::Instruction;
     use bitcoin::blockdata::{opcodes, script};
@@ -877,16 +881,12 @@ mod tests {
     use bitcoin::hashes::{hash160, sha256};
     use bitcoin::util::bip32;
     use bitcoin::{self, secp256k1, EcdsaSighashType, PublicKey};
-    use descriptor::key::Wildcard;
-    use descriptor::{DescriptorPublicKey, DescriptorSecretKey, DescriptorXKey, SinglePub};
-    use hex_script;
     use std::cmp;
     use std::collections::HashMap;
     use std::str::FromStr;
-    use {Descriptor, DummyKey, Error, Miniscript, Satisfier, TranslatePk2};
 
     #[cfg(feature = "compiler")]
-    use policy;
+    use crate::policy;
 
     type StdDescriptor = Descriptor<PublicKey>;
     const TEST_PK: &'static str =

--- a/src/descriptor/pretaproot.rs
+++ b/src/descriptor/pretaproot.rs
@@ -6,7 +6,7 @@ use std::{
 use bitcoin::{self, Script};
 
 use super::{checksum::verify_checksum, Bare, Pkh, Sh, Wpkh, Wsh};
-use {expression, DescriptorTrait, Error, MiniscriptKey, Satisfier, ToPublicKey};
+use crate::{expression, DescriptorTrait, Error, MiniscriptKey, Satisfier, ToPublicKey};
 
 /// Script descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -241,7 +241,7 @@ serde_string_impl_pk!(PreTaprootDescriptor, "a pre-taproot script descriptor");
 pub(crate) mod traits {
     use bitcoin::Script;
 
-    use {
+    use crate::{
         descriptor::{Pkh, Sh, Wpkh, Wsh},
         DescriptorTrait, MiniscriptKey, ToPublicKey,
     };

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -20,11 +20,11 @@ use std::{fmt, str::FromStr};
 
 use bitcoin::{self, Script};
 
-use expression::{self, FromTree};
-use miniscript::context::{ScriptContext, ScriptContextError};
-use policy::{semantic, Liftable};
-use util::varint_len;
-use {
+use crate::expression::{self, FromTree};
+use crate::miniscript::context::{ScriptContext, ScriptContextError};
+use crate::policy::{semantic, Liftable};
+use crate::util::varint_len;
+use crate::{
     Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, Segwitv0, ToPublicKey,
     TranslatePk,
 };

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -22,12 +22,12 @@ use std::{fmt, str::FromStr};
 
 use bitcoin::{self, blockdata::script, Script};
 
-use expression::{self, FromTree};
-use miniscript::context::ScriptContext;
-use policy::{semantic, Liftable};
-use push_opcode_size;
-use util::{varint_len, witness_to_scriptsig};
-use {
+use crate::expression::{self, FromTree};
+use crate::miniscript::context::ScriptContext;
+use crate::policy::{semantic, Liftable};
+use crate::push_opcode_size;
+use crate::util::{varint_len, witness_to_scriptsig};
+use crate::{
     Error, ForEach, ForEachKey, Legacy, Miniscript, MiniscriptKey, Satisfier, Segwitv0,
     ToPublicKey, TranslatePk,
 };

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -20,13 +20,15 @@ use std::{fmt, marker::PhantomData, str::FromStr};
 
 use bitcoin::blockdata::script;
 
-use expression;
-use miniscript::{
+use crate::expression;
+use crate::miniscript::{
     self, context::ScriptContext, decode::Terminal, limits::MAX_PUBKEYS_PER_MULTISIG,
 };
-use policy;
-use script_num_size;
-use {errstr, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey};
+use crate::policy;
+use crate::script_num_size;
+use crate::{
+    errstr, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey,
+};
 
 /// Contents of a "sortedmulti" descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -1,26 +1,26 @@
 // Tapscript
 
-use policy::semantic::Policy;
-use policy::Liftable;
-use util::{varint_len, witness_size};
-use {DescriptorTrait, ForEach, ForEachKey, Satisfier, ToPublicKey, TranslatePk};
+use crate::policy::semantic::Policy;
+use crate::policy::Liftable;
+use crate::util::{varint_len, witness_size};
+use crate::{DescriptorTrait, ForEach, ForEachKey, Satisfier, ToPublicKey, TranslatePk};
 
 use super::checksum::{desc_checksum, verify_checksum};
+use crate::errstr;
+use crate::expression::{self, FromTree};
+use crate::miniscript::Miniscript;
+use crate::Tap;
+use crate::{Error, MiniscriptKey};
 use bitcoin::blockdata::opcodes;
 use bitcoin::util::taproot::{
     LeafVersion, TaprootBuilder, TaprootBuilderError, TaprootSpendInfo, TAPROOT_CONTROL_BASE_SIZE,
     TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_NODE_SIZE,
 };
 use bitcoin::{self, secp256k1, Script};
-use errstr;
-use expression::{self, FromTree};
-use miniscript::Miniscript;
 use std::cmp::{self, max};
 use std::hash;
 use std::sync::{Arc, Mutex};
 use std::{fmt, str::FromStr};
-use Tap;
-use {Error, MiniscriptKey};
 
 /// A Taproot Tree representation.
 // Hidden leaves are not yet supported in descriptor spec. Conceptually, it should
@@ -749,7 +749,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ForEachKey;
+    use crate::ForEachKey;
 
     #[test]
     fn test_for_each() {

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -309,10 +309,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Tr<Pk> {
 /// would yield (2, A), (2, B), (2,C), (3, D), (3, E).
 ///
 #[derive(Debug, Clone)]
-pub struct TapTreeIter<'a, Pk: MiniscriptKey>
-where
-    Pk: 'a,
-{
+pub struct TapTreeIter<'a, Pk: MiniscriptKey> {
     stack: Vec<(u8, &'a TapTree<Pk>)>,
 }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -17,10 +17,10 @@
 
 use std::str::FromStr;
 
-use errstr;
-use Error;
+use crate::errstr;
+use crate::Error;
 
-use MAX_RECURSION_DEPTH;
+use crate::MAX_RECURSION_DEPTH;
 
 #[derive(Debug)]
 /// A token of the form `x(...)` or `x`

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -60,7 +60,7 @@ pub enum Error {
     /// Last byte of this signature isn't a standard sighash type
     NonStandardSighash(Vec<u8>),
     /// Miniscript error
-    Miniscript(::Error),
+    Miniscript(crate::Error),
     /// MultiSig requires 1 extra zero element apart from the `k` signatures
     MissingExtraZeroMultiSig,
     /// Script abortion because of incorrect dissatisfaction for multisig.
@@ -173,8 +173,8 @@ impl From<bitcoin::SchnorrSigError> for Error {
 }
 
 #[doc(hidden)]
-impl From<::Error> for Error {
-    fn from(e: ::Error) -> Error {
+impl From<crate::Error> for Error {
+    fn from(e: crate::Error) -> Error {
         Error::Miniscript(e)
     }
 }

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -17,11 +17,11 @@ use bitcoin::blockdata::witness::Witness;
 use bitcoin::hashes::{hash160, sha256, Hash};
 use bitcoin::util::taproot::{ControlBlock, TAPROOT_ANNEX_PREFIX};
 
-use {BareCtx, Legacy, Segwitv0, Tap};
+use crate::{BareCtx, Legacy, Segwitv0, Tap};
 
 use super::{stack, BitcoinKey, Error, Stack, TypedHash160};
-use miniscript::context::{NoChecks, ScriptContext};
-use {Miniscript, MiniscriptKey};
+use crate::miniscript::context::{NoChecks, ScriptContext};
+use crate::{Miniscript, MiniscriptKey};
 
 /// Attempts to parse a slice as a Bitcoin public key, checking compressedness
 /// if asked to, but otherwise dropping it
@@ -58,9 +58,11 @@ fn script_from_stackelem<'a, Ctx: ScriptContext>(
         stack::Element::Push(sl) => {
             Miniscript::parse_insane(&bitcoin::Script::from(sl.to_owned())).map_err(Error::from)
         }
-        stack::Element::Satisfied => Miniscript::from_ast(::Terminal::True).map_err(Error::from),
+        stack::Element::Satisfied => {
+            Miniscript::from_ast(crate::Terminal::True).map_err(Error::from)
+        }
         stack::Element::Dissatisfied => {
-            Miniscript::from_ast(::Terminal::False).map_err(Error::from)
+            Miniscript::from_ast(crate::Terminal::False).map_err(Error::from)
         }
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -25,19 +25,19 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::str::FromStr;
 
+use crate::miniscript::context::NoChecks;
+use crate::miniscript::ScriptContext;
+use crate::Miniscript;
+use crate::Terminal;
+use crate::{Descriptor, ToPublicKey};
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::{self, secp256k1, TxOut};
-use miniscript::context::NoChecks;
-use miniscript::ScriptContext;
-use Miniscript;
-use Terminal;
-use {Descriptor, ToPublicKey};
 
 mod error;
 mod inner;
 mod stack;
 
-use MiniscriptKey;
+use crate::MiniscriptKey;
 
 pub use self::error::Error;
 use self::error::PkEvalErrInner;
@@ -444,7 +444,7 @@ impl<'txin> Interpreter<'txin> {
     /// since it cannot distinguish between sorted and unsorted multisigs (and anyway
     /// it can only see the final keys, keyorigin info is lost in serializing to Bitcoin).
     /// x-only keys are translated to [`bitcoin::PublicKey`] with 0x02 prefix.
-    pub fn inferred_descriptor(&self) -> Result<Descriptor<bitcoin::PublicKey>, ::Error> {
+    pub fn inferred_descriptor(&self) -> Result<Descriptor<bitcoin::PublicKey>, crate::Error> {
         Descriptor::from_str(&self.inferred_descriptor_string())
     }
 }
@@ -1032,13 +1032,13 @@ mod tests {
 
     use super::inner::ToNoChecks;
     use super::*;
+    use crate::miniscript::context::NoChecks;
+    use crate::Miniscript;
+    use crate::MiniscriptKey;
+    use crate::ToPublicKey;
     use bitcoin;
     use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
     use bitcoin::secp256k1::{self, Secp256k1};
-    use miniscript::context::NoChecks;
-    use Miniscript;
-    use MiniscriptKey;
-    use ToPublicKey;
 
     fn setup_keys_sigs(
         n: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,14 +122,14 @@ use std::{error, fmt, hash, str};
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::{hash160, sha256, Hash};
 
-pub use descriptor::{Descriptor, DescriptorPublicKey, DescriptorTrait};
-pub use interpreter::Interpreter;
-pub use miniscript::context::{BareCtx, Legacy, ScriptContext, Segwitv0, Tap};
-pub use miniscript::decode::Terminal;
-pub use miniscript::satisfy::{Preimage32, Satisfier};
-pub use miniscript::Miniscript;
+pub use crate::descriptor::{Descriptor, DescriptorPublicKey, DescriptorTrait};
+pub use crate::interpreter::Interpreter;
+pub use crate::miniscript::context::{BareCtx, Legacy, ScriptContext, Segwitv0, Tap};
+pub use crate::miniscript::decode::Terminal;
+pub use crate::miniscript::satisfy::{Preimage32, Satisfier};
+pub use crate::miniscript::Miniscript;
 
-pub use descriptor::pretaproot::{traits::PreTaprootDescriptorTrait, PreTaprootDescriptor};
+pub use crate::descriptor::pretaproot::{traits::PreTaprootDescriptorTrait, PreTaprootDescriptor};
 
 ///Public key trait which can be converted to Hash type
 pub trait MiniscriptKey: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash {
@@ -556,7 +556,7 @@ pub enum Error {
     Secp(bitcoin::secp256k1::Error),
     #[cfg(feature = "compiler")]
     /// Compiler related errors
-    CompilerError(policy::compiler::CompilerError),
+    CompilerError(crate::policy::compiler::CompilerError),
     /// Errors related to policy
     PolicyError(policy::concrete::PolicyError),
     /// Errors related to lifting
@@ -730,8 +730,8 @@ impl fmt::Display for Error {
 
 #[doc(hidden)]
 #[cfg(feature = "compiler")]
-impl From<policy::compiler::CompilerError> for Error {
-    fn from(e: policy::compiler::CompilerError) -> Error {
+impl From<crate::policy::compiler::CompilerError> for Error {
+    fn from(e: crate::policy::compiler::CompilerError) -> Error {
         Error::CompilerError(e)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 
-pub extern crate bitcoin;
+pub use bitcoin;
 #[cfg(feature = "serde")]
 pub extern crate serde;
 #[cfg(all(test, feature = "unstable"))]
@@ -458,7 +458,7 @@ where
 }
 
 /// Either a key or a keyhash
-pub enum ForEach<'a, Pk: MiniscriptKey + 'a> {
+pub enum ForEach<'a, Pk: MiniscriptKey> {
     /// A key
     Key(&'a Pk),
     /// A keyhash

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,7 +13,7 @@ macro_rules! ms_str {
 /// `policy_str!("wsh(c:or_i(pk({}),pk({})))", pk1, pk2)`
 #[cfg(all(feature = "compiler", test))]
 macro_rules! policy_str {
-    ($($arg:tt)*) => (::policy::Concrete::from_str(&format!($($arg)*)).unwrap())
+    ($($arg:tt)*) => ($crate::policy::Concrete::from_str(&format!($($arg)*)).unwrap())
 }
 
 /// A macro that implements serde serialization and deserialization using the
@@ -23,30 +23,30 @@ macro_rules! serde_string_impl_pk {
         #[cfg(feature = "serde")]
         impl<'de, Pk $(, $gen)*> $crate::serde::Deserialize<'de> for $name<Pk $(, $gen)*>
         where
-            Pk: $crate::MiniscriptKey + $crate::std::str::FromStr,
-            Pk::Hash: $crate::std::str::FromStr,
-            <Pk as $crate::std::str::FromStr>::Err: $crate::std::fmt::Display,
-            <<Pk as $crate::MiniscriptKey>::Hash as $crate::std::str::FromStr>::Err:
-                $crate::std::fmt::Display,
+            Pk: $crate::MiniscriptKey + std::str::FromStr,
+            Pk::Hash: std::str::FromStr,
+            <Pk as std::str::FromStr>::Err: std::fmt::Display,
+            <<Pk as $crate::MiniscriptKey>::Hash as std::str::FromStr>::Err:
+                std::fmt::Display,
             $($gen : $gen_con,)*
         {
             fn deserialize<D>(deserializer: D) -> Result<$name<Pk $(, $gen)*>, D::Error>
             where
                 D: $crate::serde::de::Deserializer<'de>,
             {
-                use $crate::std::fmt::{self, Formatter};
-                use $crate::std::marker::PhantomData;
-                use $crate::std::str::FromStr;
+                use std::fmt::{self, Formatter};
+                use std::marker::PhantomData;
+                use std::str::FromStr;
 
                 #[allow(unused_parens)]
                 struct Visitor<Pk $(, $gen)*>(PhantomData<(Pk $(, $gen)*)>);
                 impl<'de, Pk $(, $gen)*> $crate::serde::de::Visitor<'de> for Visitor<Pk $(, $gen)*>
                 where
-                    Pk: $crate::MiniscriptKey + $crate::std::str::FromStr,
-                    Pk::Hash: $crate::std::str::FromStr,
-                    <Pk as $crate::std::str::FromStr>::Err: $crate::std::fmt::Display,
-                    <<Pk as $crate::MiniscriptKey>::Hash as $crate::std::str::FromStr>::Err:
-                        $crate::std::fmt::Display,
+                    Pk: $crate::MiniscriptKey + std::str::FromStr,
+                    Pk::Hash: std::str::FromStr,
+                    <Pk as std::str::FromStr>::Err: std::fmt::Display,
+                    <<Pk as $crate::MiniscriptKey>::Hash as std::str::FromStr>::Err:
+                        std::fmt::Display,
                     $($gen: $gen_con,)*
                 {
                     type Value = $name<Pk $(, $gen)*>;

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -17,11 +17,11 @@
 //! Tools for determining whether the guarantees offered by the library
 //! actually hold.
 
-use error;
-use miniscript::iter::PkPkh;
+use crate::error;
+use crate::miniscript::iter::PkPkh;
+use crate::{Miniscript, MiniscriptKey, ScriptContext};
 use std::collections::HashSet;
 use std::fmt;
-use {Miniscript, MiniscriptKey, ScriptContext};
 /// Possible reasons Miniscript guarantees can fail
 /// We currently mark Miniscript as Non-Analyzable if
 /// 1. It is unsafe(does not require a digital signature to spend it)

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -27,15 +27,17 @@ use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 
-use errstr;
-use expression;
-use miniscript::context::SigType;
-use miniscript::types::{self, Property};
-use miniscript::ScriptContext;
-use script_num_size;
+use crate::errstr;
+use crate::expression;
+use crate::miniscript::context::SigType;
+use crate::miniscript::types::{self, Property};
+use crate::miniscript::ScriptContext;
+use crate::script_num_size;
 
-use util::MsKeyBuilder;
-use {Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Terminal, ToPublicKey, TranslatePk};
+use crate::util::MsKeyBuilder;
+use crate::{
+    Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Terminal, ToPublicKey, TranslatePk,
+};
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     /// Internal helper function for displaying wrapper types; returns

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -14,20 +14,20 @@
 
 use std::{fmt, hash};
 
-use bitcoin;
-use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
-use miniscript::limits::{
+use crate::miniscript::limits::{
     MAX_OPS_PER_SCRIPT, MAX_PUBKEYS_PER_MULTISIG, MAX_SCRIPTSIG_SIZE, MAX_SCRIPT_ELEMENT_SIZE,
     MAX_SCRIPT_SIZE, MAX_STACK_SIZE, MAX_STANDARD_P2WSH_SCRIPT_SIZE,
     MAX_STANDARD_P2WSH_STACK_ITEMS,
 };
-use miniscript::types;
-use util::witness_to_scriptsig;
-use Error;
+use crate::miniscript::types;
+use crate::util::witness_to_scriptsig;
+use crate::Error;
+use bitcoin;
+use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
 
 use super::decode::ParseableKey;
 
-use {Miniscript, MiniscriptKey, Terminal};
+use crate::{Miniscript, MiniscriptKey, Terminal};
 
 /// Error for Script Context
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -17,23 +17,23 @@
 //! Functionality to parse a Bitcoin Script into a `Miniscript`
 //!
 
+use crate::{bitcoin, Miniscript};
 use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
 use std::marker::PhantomData;
 use std::{error, fmt};
-use {bitcoin, Miniscript};
 
-use miniscript::lex::{Token as Tk, TokenIter};
-use miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
-use miniscript::types::extra_props::ExtData;
-use miniscript::types::Property;
-use miniscript::types::Type;
-use miniscript::ScriptContext;
+use crate::miniscript::lex::{Token as Tk, TokenIter};
+use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
+use crate::miniscript::types::extra_props::ExtData;
+use crate::miniscript::types::Property;
+use crate::miniscript::types::Type;
+use crate::miniscript::ScriptContext;
+use crate::Error;
+use crate::MiniscriptKey;
 use std::sync::Arc;
-use Error;
-use MiniscriptKey;
 
-use ToPublicKey;
+use crate::ToPublicKey;
 
 fn return_none<T>(_: usize) -> Option<T> {
     None

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -215,7 +215,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 
 /// Iterator for traversing all [Miniscript] miniscript AST references starting from some specific
 /// node which constructs the iterator via [Miniscript::iter] method.
-pub struct Iter<'a, Pk: 'a + MiniscriptKey, Ctx: 'a + ScriptContext> {
+pub struct Iter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
     next: Option<&'a Miniscript<Pk, Ctx>>,
     // Here we store vec of path elements, where each element is a tuple, consisting of:
     // 1. Miniscript node on the path
@@ -277,7 +277,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for Iter<'a, Pk, Ctx> {
 
 /// Iterator for traversing all [MiniscriptKey]'s in AST starting from some specific node which
 /// constructs the iterator via [Miniscript::iter_pk] method.
-pub struct PkIter<'a, Pk: 'a + MiniscriptKey, Ctx: 'a + ScriptContext> {
+pub struct PkIter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
     node_iter: Iter<'a, Pk, Ctx>,
     curr_node: Option<&'a Miniscript<Pk, Ctx>>,
     key_index: usize,
@@ -319,7 +319,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkIter<'a, Pk, Ctx>
 
 /// Iterator for traversing all [MiniscriptKey] hashes in AST starting from some specific node which
 /// constructs the iterator via [Miniscript::iter_pkh] method.
-pub struct PkhIter<'a, Pk: 'a + MiniscriptKey, Ctx: 'a + ScriptContext> {
+pub struct PkhIter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
     node_iter: Iter<'a, Pk, Ctx>,
     curr_node: Option<&'a Miniscript<Pk, Ctx>>,
     key_index: usize,
@@ -371,7 +371,7 @@ pub enum PkPkh<Pk: MiniscriptKey> {
 /// Iterator for traversing all [MiniscriptKey]'s and hashes, depending what data are present in AST,
 /// starting from some specific node which constructs the iterator via
 /// [Miniscript::iter_pk_pkh] method.
-pub struct PkPkhIter<'a, Pk: 'a + MiniscriptKey, Ctx: 'a + ScriptContext> {
+pub struct PkPkhIter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
     node_iter: Iter<'a, Pk, Ctx>,
     curr_node: Option<&'a Miniscript<Pk, Ctx>>,
     key_index: usize,

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -440,10 +440,10 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkPkhIter<'a, Pk, C
 #[cfg(test)]
 pub mod test {
     use super::{Miniscript, PkPkh};
+    use crate::miniscript::context::Segwitv0;
     use bitcoin;
     use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
     use bitcoin::secp256k1;
-    use miniscript::context::Segwitv0;
 
     pub type TestData = (
         Miniscript<bitcoin::PublicKey, Segwitv0>,

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -44,15 +44,15 @@ pub mod types;
 
 use self::lex::{lex, TokenIter};
 use self::types::Property;
-pub use miniscript::context::ScriptContext;
-use miniscript::decode::Terminal;
-use miniscript::types::extra_props::ExtData;
-use miniscript::types::Type;
+pub use crate::miniscript::context::ScriptContext;
+use crate::miniscript::decode::Terminal;
+use crate::miniscript::types::extra_props::ExtData;
+use crate::miniscript::types::Type;
 
+use crate::MiniscriptKey;
+use crate::{expression, Error, ForEach, ForEachKey, ToPublicKey, TranslatePk};
 use std::cmp;
 use std::sync::Arc;
-use MiniscriptKey;
-use {expression, Error, ForEach, ForEachKey, ToPublicKey, TranslatePk};
 
 #[cfg(test)]
 mod ms_tests;
@@ -463,25 +463,25 @@ serde_string_impl_pk!(Miniscript, "a miniscript", Ctx; ScriptContext);
 #[cfg(test)]
 mod tests {
 
+    use crate::{Satisfier, ToPublicKey};
     use bitcoin::util::taproot::TapLeafHash;
-    use {Satisfier, ToPublicKey};
 
     use super::{Miniscript, ScriptContext};
     use super::{Segwitv0, Tap};
-    use hex_script;
-    use miniscript::types::{self, ExtData, Property, Type};
-    use miniscript::Terminal;
-    use policy::Liftable;
+    use crate::hex_script;
+    use crate::miniscript::types::{self, ExtData, Property, Type};
+    use crate::miniscript::Terminal;
+    use crate::policy::Liftable;
+    use crate::{DummyKey, DummyKeyHash, MiniscriptKey, TranslatePk, TranslatePk1};
     use std::marker::PhantomData;
-    use {DummyKey, DummyKeyHash, MiniscriptKey, TranslatePk, TranslatePk1};
 
+    use crate::TranslatePk2;
     use bitcoin::hashes::{hash160, sha256, Hash};
     use bitcoin::secp256k1::XOnlyPublicKey;
     use bitcoin::{self, secp256k1};
     use std::str;
     use std::str::FromStr;
     use std::sync::Arc;
-    use TranslatePk2;
 
     type Segwitv0Script = Miniscript<bitcoin::PublicKey, Segwitv0>;
     type Tapscript = Miniscript<bitcoin::secp256k1::XOnlyPublicKey, Tap>;

--- a/src/miniscript/ms_tests.rs
+++ b/src/miniscript/ms_tests.rs
@@ -18,8 +18,8 @@
 //!
 #[cfg(test)]
 mod tests {
+    use crate::{miniscript::types, Miniscript, Segwitv0};
     use std::fmt;
-    use {miniscript::types, Miniscript, Segwitv0};
 
     struct TestType(types::Type);
 

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -22,19 +22,19 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::{cmp, i64, mem};
 
+use crate::{MiniscriptKey, ToPublicKey};
 use bitcoin;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::util::taproot::{ControlBlock, LeafVersion, TapLeafHash};
-use {MiniscriptKey, ToPublicKey};
 
-use bitcoin::secp256k1::XOnlyPublicKey;
-use miniscript::limits::{
+use crate::miniscript::limits::{
     HEIGHT_TIME_THRESHOLD, SEQUENCE_LOCKTIME_DISABLE_FLAG, SEQUENCE_LOCKTIME_TYPE_FLAG,
 };
-use util::witness_size;
-use Miniscript;
-use ScriptContext;
-use Terminal;
+use crate::util::witness_size;
+use crate::Miniscript;
+use crate::ScriptContext;
+use crate::Terminal;
+use bitcoin::secp256k1::XOnlyPublicKey;
 
 /// Type alias for 32 byte Preimage.
 pub type Preimage32 = [u8; 32];

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -1,16 +1,16 @@
 //! Other miscellaneous type properties which are not related to
 //! correctness or malleability.
 
-use miniscript::limits::{
+use crate::miniscript::limits::{
     HEIGHT_TIME_THRESHOLD, SEQUENCE_LOCKTIME_DISABLE_FLAG, SEQUENCE_LOCKTIME_TYPE_FLAG,
 };
 
 use super::{Error, ErrorKind, Property, ScriptContext};
-use script_num_size;
+use crate::script_num_size;
+use crate::MiniscriptKey;
+use crate::Terminal;
 use std::cmp;
 use std::iter::once;
-use MiniscriptKey;
-use Terminal;
 
 /// Helper struct Whether any satisfaction of this fragment contains any timelocks
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -26,8 +26,8 @@ pub use self::correctness::{Base, Correctness, Input};
 pub use self::extra_props::ExtData;
 pub use self::malleability::{Dissat, Malleability};
 use super::{limits::SEQUENCE_LOCKTIME_DISABLE_FLAG, ScriptContext};
-use MiniscriptKey;
-use Terminal;
+use crate::MiniscriptKey;
+use crate::Terminal;
 
 /// None-returning function to help type inference when we need a
 /// closure that simply returns `None`

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -22,15 +22,14 @@ use std::convert::From;
 use std::marker::PhantomData;
 use std::{cmp, error, f64, fmt, mem};
 
-use miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
-use miniscript::types::{self, ErrorKind, ExtData, Property, Type};
-use miniscript::ScriptContext;
-use policy::Concrete;
+use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
+use crate::miniscript::types::{self, ErrorKind, ExtData, Property, Type};
+use crate::miniscript::ScriptContext;
+use crate::policy::Concrete;
+use crate::{policy, Miniscript, MiniscriptKey, Terminal};
 use std::collections::vec_deque::VecDeque;
 use std::hash;
 use std::sync::Arc;
-use {policy, Terminal};
-use {Miniscript, MiniscriptKey};
 
 type PolicyCache<Pk, Ctx> =
     BTreeMap<(Concrete<Pk>, OrdF64, Option<OrdF64>), BTreeMap<CompilationKey, AstElemExt<Pk, Ctx>>>;
@@ -1166,9 +1165,9 @@ mod tests {
     use std::str::FromStr;
     use std::string::String;
 
-    use miniscript::{satisfy, Legacy, Segwitv0, Tap};
-    use policy::Liftable;
-    use script_num_size;
+    use crate::miniscript::{satisfy, Legacy, Segwitv0, Tap};
+    use crate::policy::Liftable;
+    use crate::script_num_size;
 
     type SPolicy = Concrete<String>;
     type BPolicy = Concrete<bitcoin::PublicKey>;
@@ -1564,8 +1563,8 @@ mod benches {
     use test::{black_box, Bencher};
 
     use super::{CompilerError, Concrete};
-    use miniscript::Tap;
-    use Miniscript;
+    use crate::miniscript::Tap;
+    use crate::Miniscript;
     type TapMsRes = Result<Miniscript<String, Tap>, CompilerError>;
     #[bench]
     pub fn compile_basic(bh: &mut Bencher) {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -21,19 +21,19 @@ use std::collections::HashSet;
 use std::{error, fmt, str};
 
 use super::ENTAILMENT_MAX_TERMINALS;
-use errstr;
-use expression::{self, FromTree};
-use miniscript::limits::{HEIGHT_TIME_THRESHOLD, SEQUENCE_LOCKTIME_TYPE_FLAG};
-use miniscript::types::extra_props::TimeLockInfo;
+use crate::errstr;
+use crate::expression::{self, FromTree};
+use crate::miniscript::limits::{HEIGHT_TIME_THRESHOLD, SEQUENCE_LOCKTIME_TYPE_FLAG};
+use crate::miniscript::types::extra_props::TimeLockInfo;
 #[cfg(feature = "compiler")]
-use miniscript::ScriptContext;
+use crate::miniscript::ScriptContext;
 #[cfg(feature = "compiler")]
-use policy::compiler;
+use crate::policy::compiler;
 #[cfg(feature = "compiler")]
-use policy::compiler::CompilerError;
+use crate::policy::compiler::CompilerError;
 #[cfg(feature = "compiler")]
-use Miniscript;
-use {Error, ForEach, ForEachKey, MiniscriptKey};
+use crate::Miniscript;
+use crate::{Error, ForEach, ForEachKey, MiniscriptKey};
 /// Concrete policy which corresponds directly to a Miniscript structure,
 /// and whose disjunctions are annotated with satisfaction probabilities
 /// to assist the compiler

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -21,23 +21,23 @@
 //! The format represents EC public keys abstractly to allow wallets to replace
 //! these with BIP32 paths, pay-to-contract instructions, etc.
 //!
-use {error, fmt};
+use crate::{error, fmt};
 
 #[cfg(feature = "compiler")]
 pub mod compiler;
 pub mod concrete;
 pub mod semantic;
 
-use descriptor::Descriptor;
-use miniscript::{Miniscript, ScriptContext};
-use Terminal;
+use crate::descriptor::Descriptor;
+use crate::miniscript::{Miniscript, ScriptContext};
+use crate::Terminal;
 
 pub use self::concrete::Policy as Concrete;
 /// Semantic policies are "abstract" policies elsewhere; but we
 /// avoid this word because it is a reserved keyword in Rust
 pub use self::semantic::Policy as Semantic;
-use Error;
-use MiniscriptKey;
+use crate::Error;
+use crate::MiniscriptKey;
 
 /// Policy entailment algorithm maximum number of terminals allowed
 const ENTAILMENT_MAX_TERMINALS: usize = 20;
@@ -232,9 +232,9 @@ mod tests {
         super::miniscript::{context::Segwitv0, Miniscript},
         Concrete, Liftable, Semantic,
     };
+    use crate::DummyKey;
     use bitcoin;
     use std::str::FromStr;
-    use DummyKey;
 
     type ConcretePol = Concrete<DummyKey>;
     type SemanticPol = Semantic<DummyKey>;

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -21,9 +21,9 @@ use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 
 use super::concrete::PolicyError;
-use errstr;
-use Error;
-use {expression, ForEach, ForEachKey, MiniscriptKey};
+use crate::errstr;
+use crate::Error;
+use crate::{expression, ForEach, ForEachKey, MiniscriptKey};
 
 use super::ENTAILMENT_MAX_TERMINALS;
 

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -19,23 +19,23 @@
 //! `https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki`
 //!
 
+use crate::util::witness_size;
 use bitcoin::util::sighash::Prevouts;
 use std::borrow::Borrow;
-use util::witness_size;
 
 use super::{sanity_check, Psbt};
 use super::{Error, InputError, PsbtInputSatisfier};
+use crate::descriptor::DescriptorTrait;
+use crate::interpreter;
+use crate::Descriptor;
+use crate::Miniscript;
+use crate::Satisfier;
+use crate::{BareCtx, Legacy, Segwitv0, Tap};
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::secp256k1::{self, Secp256k1};
 use bitcoin::util::key::XOnlyPublicKey;
 use bitcoin::util::taproot::LeafVersion;
 use bitcoin::{self, PublicKey, Script, TxOut};
-use descriptor::DescriptorTrait;
-use interpreter;
-use Descriptor;
-use Miniscript;
-use Satisfier;
-use {BareCtx, Legacy, Segwitv0, Tap};
 
 // Satisfy the taproot descriptor. It is not possible to infer the complete
 // descriptor from psbt because the information about all the scripts might not
@@ -452,7 +452,7 @@ pub(super) fn finalize_input<C: secp256k1::Verification>(
 
 #[cfg(test)]
 mod tests {
-    use psbt::PsbtExt;
+    use crate::psbt::PsbtExt;
 
     use super::*;
 

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -30,18 +30,18 @@ use bitcoin::util::sighash::SighashCache;
 use bitcoin::{self, SchnorrSighashType};
 use bitcoin::{EcdsaSighashType, Script};
 
-use bitcoin::util::taproot::{self, ControlBlock, LeafVersion, TapLeafHash};
-use descriptor;
-use interpreter;
-use miniscript::iter::PkPkh;
-use miniscript::limits::SEQUENCE_LOCKTIME_DISABLE_FLAG;
-use miniscript::satisfy::{After, Older};
-use Preimage32;
-use Satisfier;
-use {
+use crate::descriptor;
+use crate::interpreter;
+use crate::miniscript::iter::PkPkh;
+use crate::miniscript::limits::SEQUENCE_LOCKTIME_DISABLE_FLAG;
+use crate::miniscript::satisfy::{After, Older};
+use crate::Preimage32;
+use crate::Satisfier;
+use crate::{
     Descriptor, DescriptorPublicKey, DescriptorTrait, MiniscriptKey, ToPublicKey, TranslatePk,
     TranslatePk2,
 };
+use bitcoin::util::taproot::{self, ControlBlock, LeafVersion, TapLeafHash};
 
 mod finalizer;
 
@@ -1155,13 +1155,13 @@ impl PsbtSighashMsg {
 mod tests {
     use super::*;
 
+    use crate::Miniscript;
     use bitcoin::consensus::encode::deserialize;
     use bitcoin::hashes::hex::FromHex;
     use bitcoin::secp256k1::PublicKey;
     use bitcoin::util::bip32::{DerivationPath, ExtendedPubKey};
     use bitcoin::{OutPoint, TxIn, TxOut, XOnlyPublicKey};
     use std::str::FromStr;
-    use Miniscript;
 
     #[test]
     fn test_extract_bip174() {
@@ -1203,7 +1203,7 @@ mod tests {
 
     #[test]
     fn test_update_input_tr_with_tapscript() {
-        use Tap;
+        use crate::Tap;
         // keys taken from: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#Specifications
         let root_xpub = ExtendedPubKey::from_str("xpub661MyMwAqRbcFkPHucMnrGNzDwb6teAX1RbKQmqtEF8kK3Z7LZ59qafCjB9eCRLiTVG3uxBxgKvRgbubRhqSKXnGGb1aoaqLrpMBDrVxga8").unwrap();
         let fingerprint = root_xpub.fingerprint();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,9 @@
+use crate::miniscript::context;
 use bitcoin;
 use bitcoin::blockdata::script;
 use bitcoin::Script;
-use miniscript::context;
 
-use {ScriptContext, ToPublicKey};
+use crate::{ScriptContext, ToPublicKey};
 pub(crate) fn varint_len(n: usize) -> usize {
     bitcoin::VarInt(n as u64).len()
 }


### PR DESCRIPTION
Update the MSRV to Rust 1.41.1 and enable edition 2018.

I'm not sure how we want to merge these MSRV PRs across the stack but here is the `rust-miniscript` one.

Discussion: https://github.com/rust-bitcoin/rust-bitcoin/issues/510#issuecomment-881686342