### PR TITLE
Actually return the error

### DIFF
--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -237,3 +237,34 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for SortedMultiVec<Pk, 
         f.write_str(")")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::secp256k1::PublicKey;
+    use miniscript::context::Legacy;
+
+    #[test]
+    fn too_many_pubkeys() {
+        // Arbitrary pubic key.
+        let pk = PublicKey::from_str(
+            "02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443",
+        )
+        .unwrap();
+
+        let over = 1 + MAX_PUBKEYS_PER_MULTISIG;
+
+        let mut pks = Vec::new();
+        for _ in 0..over {
+            pks.push(pk.clone());
+        }
+
+        let res: Result<SortedMultiVec<PublicKey, Legacy>, Error> = SortedMultiVec::new(0, pks);
+        let error = res.err().expect("constructor should err");
+
+        match error {
+            Error::BadDescriptor(_) => {} // ok
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+}

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -46,7 +46,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     pub fn new(k: usize, pks: Vec<Pk>) -> Result<Self, Error> {
         // A sortedmulti() is only defined for <= 20 keys (it maps to CHECKMULTISIG)
         if pks.len() > MAX_PUBKEYS_PER_MULTISIG {
-            Error::BadDescriptor("Too many public keys".to_string());
+            return Err(Error::BadDescriptor("Too many public keys".to_string()));
         }
 
         // Check the limits before creating a new SortedMultiVec


### PR DESCRIPTION
We have what appears to be an error return but do not actually return
the error. This line needs an explicit `return` statement otherwise it
is a noop.