### PR TITLE
Use Key instead of MiniscriptKey

### DIFF
--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -35,7 +35,7 @@ fn main() {
     assert_eq!(descriptor.max_satisfaction_weight().unwrap(), 258);
 
     // Sometimes it is necessary to have additional information to get the
-    // `bitcoin::PublicKey` from the `MiniscriptKey` which can be supplied by
+    // `bitcoin::PublicKey` from the `Key` which can be supplied by
     // the `to_pk_ctx` parameter. For example, when calculating the script
     // pubkey of a descriptor with xpubs, the secp context and child information
     // maybe required.

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -30,19 +30,18 @@ use crate::policy::{semantic, Liftable};
 use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
-    BareCtx, Error, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey, TranslatePk,
-    Translator,
+    BareCtx, Error, ForEachKey, Key, Miniscript, Satisfier, ToPublicKey, TranslatePk, Translator,
 };
 
 /// Create a Bare Descriptor. That is descriptor that is
 /// not wrapped in sh or wsh. This covers the Pk descriptor
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct Bare<Pk: MiniscriptKey> {
+pub struct Bare<Pk: Key> {
     /// underlying miniscript
     ms: Miniscript<Pk, BareCtx>,
 }
 
-impl<Pk: MiniscriptKey> Bare<Pk> {
+impl<Pk: Key> Bare<Pk> {
     /// Create a new raw descriptor
     pub fn new(ms: Miniscript<Pk, BareCtx>) -> Result<Self, Error> {
         // do the top-level checks
@@ -81,7 +80,7 @@ impl<Pk: MiniscriptKey> Bare<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey + ToPublicKey> Bare<Pk> {
+impl<Pk: Key + ToPublicKey> Bare<Pk> {
     /// Obtains the corresponding script pubkey for this descriptor.
     pub fn script_pubkey(&self) -> Script {
         self.ms.encode()
@@ -124,13 +123,13 @@ impl<Pk: MiniscriptKey + ToPublicKey> Bare<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Debug for Bare<Pk> {
+impl<Pk: Key> fmt::Debug for Bare<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.ms)
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Display for Bare<Pk> {
+impl<Pk: Key> fmt::Display for Bare<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let desc = format!("{}", self.ms);
         let checksum = desc_checksum(&desc).map_err(|_| fmt::Error)?;
@@ -138,7 +137,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Bare<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> Liftable<Pk> for Bare<Pk> {
+impl<Pk: Key> Liftable<Pk> for Bare<Pk> {
     fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
         self.ms.lift()
     }
@@ -163,7 +162,7 @@ impl_from_str!(
     }
 );
 
-impl<Pk: MiniscriptKey> ForEachKey<Pk> for Bare<Pk> {
+impl<Pk: Key> ForEachKey<Pk> for Bare<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: F) -> bool
     where
         Pk: 'a,
@@ -175,8 +174,8 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Bare<Pk> {
 
 impl<P, Q> TranslatePk<P, Q> for Bare<P>
 where
-    P: MiniscriptKey,
-    Q: MiniscriptKey,
+    P: Key,
+    Q: Key,
 {
     type Output = Bare<Q>;
 
@@ -190,12 +189,12 @@ where
 
 /// A bare PkH descriptor at top level
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct Pkh<Pk: MiniscriptKey> {
+pub struct Pkh<Pk: Key> {
     /// underlying publickey
     pk: Pk,
 }
 
-impl<Pk: MiniscriptKey> Pkh<Pk> {
+impl<Pk: Key> Pkh<Pk> {
     /// Create a new Pkh descriptor
     pub fn new(pk: Pk) -> Self {
         // do the top-level checks
@@ -223,7 +222,7 @@ impl<Pk: MiniscriptKey> Pkh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
+impl<Pk: Key + ToPublicKey> Pkh<Pk> {
     /// Obtains the corresponding script pubkey for this descriptor.
     pub fn script_pubkey(&self) -> Script {
         // Fine to hard code the `Network` here because we immediately call
@@ -278,13 +277,13 @@ impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Debug for Pkh<Pk> {
+impl<Pk: Key> fmt::Debug for Pkh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "pkh({:?})", self.pk)
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Display for Pkh<Pk> {
+impl<Pk: Key> fmt::Display for Pkh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let desc = format!("pkh({})", self.pk);
         let checksum = desc_checksum(&desc).map_err(|_| fmt::Error)?;
@@ -292,7 +291,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Pkh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> Liftable<Pk> for Pkh<Pk> {
+impl<Pk: Key> Liftable<Pk> for Pkh<Pk> {
     fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
         Ok(semantic::Policy::KeyHash(self.pk.to_pubkeyhash()))
     }
@@ -325,7 +324,7 @@ impl_from_str!(
     }
 );
 
-impl<Pk: MiniscriptKey> ForEachKey<Pk> for Pkh<Pk> {
+impl<Pk: Key> ForEachKey<Pk> for Pkh<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
@@ -337,8 +336,8 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Pkh<Pk> {
 
 impl<P, Q> TranslatePk<P, Q> for Pkh<P>
 where
-    P: MiniscriptKey,
-    Q: MiniscriptKey,
+    P: Key,
+    Q: Key,
 {
     type Output = Pkh<Q>;
 

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -10,7 +10,7 @@ use bitcoin::util::bip32;
 use bitcoin::{self, XOnlyPublicKey, XpubIdentifier};
 
 use crate::prelude::*;
-use crate::{hash256, MiniscriptKey, ToPublicKey};
+use crate::{hash256, Key, ToPublicKey};
 
 /// The descriptor pubkey, either a single pubkey or an xpub.
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
@@ -729,7 +729,7 @@ impl<K: InnerXKey> DescriptorXKey<K> {
     }
 }
 
-impl MiniscriptKey for DescriptorPublicKey {
+impl Key for DescriptorPublicKey {
     // This allows us to be able to derive public keys even for PkH s
     type RawPkHash = Self;
     type Sha256 = sha256::Hash;
@@ -817,7 +817,7 @@ impl fmt::Display for DefiniteDescriptorKey {
     }
 }
 
-impl MiniscriptKey for DefiniteDescriptorKey {
+impl Key for DefiniteDescriptorKey {
     // This allows us to be able to derive public keys even for PkH s
     type RawPkHash = Self;
     type Sha256 = sha256::Hash;

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -37,8 +37,8 @@ use self::checksum::verify_checksum;
 use crate::miniscript::{Legacy, Miniscript, Segwitv0};
 use crate::prelude::*;
 use crate::{
-    expression, hash256, miniscript, BareCtx, Error, ForEachKey, MiniscriptKey, PkTranslator,
-    Satisfier, ToPublicKey, TranslatePk, Translator,
+    expression, hash256, miniscript, BareCtx, Error, ForEachKey, Key, PkTranslator, Satisfier,
+    ToPublicKey, TranslatePk, Translator,
 };
 
 mod bare;
@@ -72,7 +72,7 @@ pub type KeyMap = HashMap<DescriptorPublicKey, DescriptorSecretKey>;
 
 /// Script descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Descriptor<Pk: MiniscriptKey> {
+pub enum Descriptor<Pk: Key> {
     /// A raw scriptpubkey (including pay-to-pubkey) under Legacy context
     Bare(Bare<Pk>),
     /// Pay-to-PubKey-Hash
@@ -87,42 +87,42 @@ pub enum Descriptor<Pk: MiniscriptKey> {
     Tr(Tr<Pk>),
 }
 
-impl<Pk: MiniscriptKey> From<Bare<Pk>> for Descriptor<Pk> {
+impl<Pk: Key> From<Bare<Pk>> for Descriptor<Pk> {
     #[inline]
     fn from(inner: Bare<Pk>) -> Self {
         Descriptor::Bare(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Pkh<Pk>> for Descriptor<Pk> {
+impl<Pk: Key> From<Pkh<Pk>> for Descriptor<Pk> {
     #[inline]
     fn from(inner: Pkh<Pk>) -> Self {
         Descriptor::Pkh(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Wpkh<Pk>> for Descriptor<Pk> {
+impl<Pk: Key> From<Wpkh<Pk>> for Descriptor<Pk> {
     #[inline]
     fn from(inner: Wpkh<Pk>) -> Self {
         Descriptor::Wpkh(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Sh<Pk>> for Descriptor<Pk> {
+impl<Pk: Key> From<Sh<Pk>> for Descriptor<Pk> {
     #[inline]
     fn from(inner: Sh<Pk>) -> Self {
         Descriptor::Sh(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Wsh<Pk>> for Descriptor<Pk> {
+impl<Pk: Key> From<Wsh<Pk>> for Descriptor<Pk> {
     #[inline]
     fn from(inner: Wsh<Pk>) -> Self {
         Descriptor::Wsh(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Tr<Pk>> for Descriptor<Pk> {
+impl<Pk: Key> From<Tr<Pk>> for Descriptor<Pk> {
     #[inline]
     fn from(inner: Tr<Pk>) -> Self {
         Descriptor::Tr(inner)
@@ -172,7 +172,7 @@ impl DescriptorType {
     }
 }
 
-impl<Pk: MiniscriptKey> Descriptor<Pk> {
+impl<Pk: Key> Descriptor<Pk> {
     // Keys
 
     /// Create a new pk descriptor
@@ -339,7 +339,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
+impl<Pk: Key + ToPublicKey> Descriptor<Pk> {
     /// Computes the Bitcoin address of the descriptor, if one exists
     ///
     /// Some descriptors like pk() don't have an address.
@@ -472,8 +472,8 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
 
 impl<P, Q> TranslatePk<P, Q> for Descriptor<P>
 where
-    P: MiniscriptKey,
-    Q: MiniscriptKey,
+    P: Key,
+    Q: Key,
 {
     type Output = Descriptor<Q>;
 
@@ -494,7 +494,7 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey> ForEachKey<Pk> for Descriptor<Pk> {
+impl<Pk: Key> ForEachKey<Pk> for Descriptor<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: F) -> bool
     where
         Pk: 'a,
@@ -821,7 +821,7 @@ impl_from_str!(
     }
 );
 
-impl<Pk: MiniscriptKey> fmt::Debug for Descriptor<Pk> {
+impl<Pk: Key> fmt::Debug for Descriptor<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Descriptor::Bare(ref sub) => write!(f, "{:?}", sub),
@@ -834,7 +834,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Descriptor<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Display for Descriptor<Pk> {
+impl<Pk: Key> fmt::Display for Descriptor<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Descriptor::Bare(ref sub) => write!(f, "{}", sub),

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -31,20 +31,20 @@ use crate::policy::{semantic, Liftable};
 use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
-    push_opcode_size, Error, ForEachKey, Legacy, Miniscript, MiniscriptKey, Satisfier, Segwitv0,
-    ToPublicKey, TranslatePk, Translator,
+    push_opcode_size, Error, ForEachKey, Key, Legacy, Miniscript, Satisfier, Segwitv0, ToPublicKey,
+    TranslatePk, Translator,
 };
 
 /// A Legacy p2sh Descriptor
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct Sh<Pk: MiniscriptKey> {
+pub struct Sh<Pk: Key> {
     /// underlying miniscript
     inner: ShInner<Pk>,
 }
 
 /// Sh Inner
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub enum ShInner<Pk: MiniscriptKey> {
+pub enum ShInner<Pk: Key> {
     /// Nested Wsh
     Wsh(Wsh<Pk>),
     /// Nested Wpkh
@@ -55,7 +55,7 @@ pub enum ShInner<Pk: MiniscriptKey> {
     Ms(Miniscript<Pk, Legacy>),
 }
 
-impl<Pk: MiniscriptKey> Liftable<Pk> for Sh<Pk> {
+impl<Pk: Key> Liftable<Pk> for Sh<Pk> {
     fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
         match self.inner {
             ShInner::Wsh(ref wsh) => wsh.lift(),
@@ -66,7 +66,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Sh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Debug for Sh<Pk> {
+impl<Pk: Key> fmt::Debug for Sh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.inner {
             ShInner::Wsh(ref wsh_inner) => write!(f, "sh({:?})", wsh_inner),
@@ -77,7 +77,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Sh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Display for Sh<Pk> {
+impl<Pk: Key> fmt::Display for Sh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let desc = match self.inner {
             ShInner::Wsh(ref wsh) => format!("sh({})", wsh.to_string_no_checksum()),
@@ -126,7 +126,7 @@ impl_from_str!(
     }
 );
 
-impl<Pk: MiniscriptKey> Sh<Pk> {
+impl<Pk: Key> Sh<Pk> {
     /// Get the Inner
     pub fn into_inner(self) -> ShInner<Pk> {
         self.inner
@@ -236,7 +236,7 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey + ToPublicKey> Sh<Pk> {
+impl<Pk: Key + ToPublicKey> Sh<Pk> {
     /// Obtains the corresponding script pubkey for this descriptor.
     pub fn script_pubkey(&self) -> Script {
         match self.inner {
@@ -376,7 +376,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Sh<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> ForEachKey<Pk> for Sh<Pk> {
+impl<Pk: Key> ForEachKey<Pk> for Sh<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: F) -> bool
     where
         Pk: 'a,
@@ -393,8 +393,8 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Sh<Pk> {
 
 impl<P, Q> TranslatePk<P, Q> for Sh<P>
 where
-    P: MiniscriptKey,
-    Q: MiniscriptKey,
+    P: Key,
+    Q: Key,
 {
     type Output = Sh<Q>;
 

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -27,13 +27,13 @@ use crate::miniscript::decode::Terminal;
 use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
 use crate::prelude::*;
 use crate::{
-    errstr, expression, miniscript, policy, script_num_size, Error, ForEachKey, Miniscript,
-    MiniscriptKey, Satisfier, ToPublicKey, Translator,
+    errstr, expression, miniscript, policy, script_num_size, Error, ForEachKey, Key, Miniscript,
+    Satisfier, ToPublicKey, Translator,
 };
 
 /// Contents of a "sortedmulti" descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SortedMultiVec<Pk: MiniscriptKey, Ctx: ScriptContext> {
+pub struct SortedMultiVec<Pk: Key, Ctx: ScriptContext> {
     /// signatures required
     pub k: usize,
     /// public keys inside sorted Multi
@@ -42,7 +42,7 @@ pub struct SortedMultiVec<Pk: MiniscriptKey, Ctx: ScriptContext> {
     pub(crate) phantom: PhantomData<Ctx>,
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// Create a new instance of `SortedMultiVec` given a list of keys and the threshold
     ///
     /// Internally checks all the applicable size limits and pubkey types limitations according to the current `Ctx`.
@@ -100,7 +100,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     ) -> Result<SortedMultiVec<Q, Ctx>, FuncError>
     where
         T: Translator<Pk, Q, FuncError>,
-        Q: MiniscriptKey,
+        Q: Key,
     {
         let pks: Result<Vec<Q>, _> = self.pks.iter().map(|pk| t.pk(pk)).collect();
         Ok(SortedMultiVec {
@@ -111,7 +111,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for SortedMultiVec<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> ForEachKey<Pk> for SortedMultiVec<Pk, Ctx> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
@@ -121,7 +121,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for SortedMultiVec<Pk
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// utility function to sanity a sorted multi vec
     pub fn sanity_check(&self) -> Result<(), Error> {
         let ms: Miniscript<Pk, Ctx> =
@@ -133,7 +133,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     /// Create Terminal::Multi containing sorted pubkeys
     pub fn sorted_node(&self) -> Terminal<Pk, Ctx>
     where
@@ -211,7 +211,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> policy::Liftable<Pk> for SortedMultiVec<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> policy::Liftable<Pk> for SortedMultiVec<Pk, Ctx> {
     fn lift(&self) -> Result<policy::semantic::Policy<Pk>, Error> {
         let ret = policy::semantic::Policy::Threshold(
             self.k,
@@ -225,13 +225,13 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> policy::Liftable<Pk> for SortedMulti
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for SortedMultiVec<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> fmt::Debug for SortedMultiVec<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for SortedMultiVec<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> fmt::Display for SortedMultiVec<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "sortedmulti({}", self.k)?;
         for k in &self.pks {

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -20,7 +20,7 @@ use bitcoin::util::taproot::{ControlBlock, TAPROOT_ANNEX_PREFIX};
 use super::{stack, BitcoinKey, Error, Stack, TypedHash160};
 use crate::miniscript::context::{NoChecks, ScriptContext};
 use crate::prelude::*;
-use crate::{BareCtx, Legacy, Miniscript, MiniscriptKey, PkTranslator, Segwitv0, Tap};
+use crate::{BareCtx, Key, Legacy, Miniscript, PkTranslator, Segwitv0, Tap};
 
 /// Attempts to parse a slice as a Bitcoin public key, checking compressedness
 /// if asked to, but otherwise dropping it

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -39,7 +39,7 @@ mod stack;
 pub use self::error::Error;
 use self::error::PkEvalErrInner;
 use self::stack::Stack;
-use crate::MiniscriptKey;
+use crate::Key;
 
 /// An iterable Miniscript-structured representation of the spending of a coin
 pub struct Interpreter<'txin> {
@@ -83,15 +83,15 @@ impl KeySigPair {
 }
 
 // Internally used enum for different types of bitcoin keys
-// Even though we implement MiniscriptKey for BitcoinKey, we make sure that there
+// Even though we implement Key for BitcoinKey, we make sure that there
 // are little mis-use
 // - The only constructors for this are only called in from_txdata that take care
 //   using the correct enum variant
 // - This does not implement ToPublicKey to avoid context dependant encoding/decoding of 33/32
 //   byte keys. This allows us to keep a single NoChecks context instead of a context for
 //   for NoChecksSchnorr/NoChecksEcdsa.
-// Long term TODO: There really should be not be any need for Miniscript<Pk: MiniscriptKey> struct
-// to have the Pk: MiniscriptKey bound. The bound should be on all of it's methods. That would
+// Long term TODO: There really should be not be any need for Miniscript<Pk: Key> struct
+// to have the Pk: Key bound. The bound should be on all of it's methods. That would
 // require changing Miniscript struct to three generics Miniscript<Pk, Pkh, Ctx> and bound on
 // all of the methods of Miniscript to ensure that Pkh = Pk::Hash
 #[derive(Hash, Eq, Ord, PartialEq, PartialOrd, Clone, Copy, Debug)]
@@ -147,7 +147,7 @@ impl TypedHash160 {
     }
 }
 
-impl MiniscriptKey for BitcoinKey {
+impl Key for BitcoinKey {
     type RawPkHash = TypedHash160;
     type Sha256 = sha256::Hash;
     type Hash256 = hash256::Hash;
@@ -1049,7 +1049,7 @@ mod tests {
     use super::inner::ToNoChecks;
     use super::*;
     use crate::miniscript::context::NoChecks;
-    use crate::{Miniscript, MiniscriptKey, ToPublicKey};
+    use crate::{Key, Miniscript, ToPublicKey};
 
     fn setup_keys_sigs(
         n: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,9 @@ use std::error;
 
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
+/// Export a type alias to make usage of the library more ergonomic since the
+/// `Key` trait name is so generic that it may cause naming conflicts.
+pub use Key as MiniscriptKey;
 
 pub use crate::descriptor::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey};
 pub use crate::interpreter::Interpreter;
@@ -144,7 +147,7 @@ pub use crate::miniscript::{hash256, Miniscript};
 use crate::prelude::*;
 
 ///Public key trait which can be converted to Hash type
-pub trait MiniscriptKey: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash {
+pub trait Key: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash {
     /// Returns true if the pubkey is uncompressed. Defaults to `false`.
     fn is_uncompressed(&self) -> bool {
         false
@@ -157,24 +160,24 @@ pub trait MiniscriptKey: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Ha
         false
     }
 
-    /// The associated PublicKey Hash for this [`MiniscriptKey`],
+    /// The associated PublicKey Hash for this [`Key`],
     /// used in the raw_pkh fragment
     /// This fragment is only internally used for representing partial descriptors when parsing from script
     /// The library does not support creating partial descriptors yet.
     type RawPkHash: Clone + Eq + Ord + fmt::Display + fmt::Debug + hash::Hash;
 
-    /// The associated [`sha256::Hash`] for this [`MiniscriptKey`],
+    /// The associated [`sha256::Hash`] for this [`Key`],
     /// used in the hash256 fragment.
     type Sha256: Clone + Eq + Ord + fmt::Display + fmt::Debug + hash::Hash;
 
-    /// The associated [`hash256::Hash`] for this [`MiniscriptKey`],
+    /// The associated [`hash256::Hash`] for this [`Key`],
     /// used in the hash256 fragment.
     type Hash256: Clone + Eq + Ord + fmt::Display + fmt::Debug + hash::Hash;
-    /// The associated [`ripedmd160::Hash`] for this [`MiniscriptKey`] type.
+    /// The associated [`ripedmd160::Hash`] for this [`Key`] type.
     /// used in the ripemd160 fragment
     type Ripemd160: Clone + Eq + Ord + fmt::Display + fmt::Debug + hash::Hash;
 
-    /// The associated [`hash160::Hash`] for this [`MiniscriptKey`] type.
+    /// The associated [`hash160::Hash`] for this [`Key`] type.
     /// used in the hash160 fragment
     type Hash160: Clone + Eq + Ord + fmt::Display + fmt::Debug + hash::Hash;
 
@@ -182,7 +185,7 @@ pub trait MiniscriptKey: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Ha
     fn to_pubkeyhash(&self) -> Self::RawPkHash;
 }
 
-impl MiniscriptKey for bitcoin::secp256k1::PublicKey {
+impl Key for bitcoin::secp256k1::PublicKey {
     type RawPkHash = hash160::Hash;
     type Sha256 = sha256::Hash;
     type Hash256 = hash256::Hash;
@@ -194,7 +197,7 @@ impl MiniscriptKey for bitcoin::secp256k1::PublicKey {
     }
 }
 
-impl MiniscriptKey for bitcoin::PublicKey {
+impl Key for bitcoin::PublicKey {
     /// Returns the compressed-ness of the underlying secp256k1 key.
     fn is_uncompressed(&self) -> bool {
         !self.compressed
@@ -211,7 +214,7 @@ impl MiniscriptKey for bitcoin::PublicKey {
     }
 }
 
-impl MiniscriptKey for bitcoin::secp256k1::XOnlyPublicKey {
+impl Key for bitcoin::secp256k1::XOnlyPublicKey {
     type RawPkHash = hash160::Hash;
     type Sha256 = sha256::Hash;
     type Hash256 = hash256::Hash;
@@ -227,7 +230,7 @@ impl MiniscriptKey for bitcoin::secp256k1::XOnlyPublicKey {
     }
 }
 
-impl MiniscriptKey for String {
+impl Key for String {
     type RawPkHash = String;
     type Sha256 = String; // specify hashes as string
     type Hash256 = String;
@@ -240,7 +243,7 @@ impl MiniscriptKey for String {
 }
 
 /// Trait describing public key types which can be converted to bitcoin pubkeys
-pub trait ToPublicKey: MiniscriptKey {
+pub trait ToPublicKey: Key {
     /// Converts an object to a public key
     fn to_public_key(&self) -> bitcoin::PublicKey;
 
@@ -253,22 +256,22 @@ pub trait ToPublicKey: MiniscriptKey {
     /// Converts a hashed version of the public key to a `hash160` hash.
     ///
     /// This method must be consistent with `to_public_key`, in the sense
-    /// that calling `MiniscriptKey::to_pubkeyhash` followed by this function
+    /// that calling `Key::to_pubkeyhash` followed by this function
     /// should give the same result as calling `to_public_key` and hashing
     /// the result directly.
-    fn hash_to_hash160(hash: &<Self as MiniscriptKey>::RawPkHash) -> hash160::Hash;
+    fn hash_to_hash160(hash: &<Self as Key>::RawPkHash) -> hash160::Hash;
 
-    /// Converts the generic associated [`MiniscriptKey::Sha256`] to [`sha256::Hash`]
-    fn to_sha256(hash: &<Self as MiniscriptKey>::Sha256) -> sha256::Hash;
+    /// Converts the generic associated [`Key::Sha256`] to [`sha256::Hash`]
+    fn to_sha256(hash: &<Self as Key>::Sha256) -> sha256::Hash;
 
-    /// Converts the generic associated [`MiniscriptKey::Hash256`] to [`hash256::Hash`]
-    fn to_hash256(hash: &<Self as MiniscriptKey>::Hash256) -> hash256::Hash;
+    /// Converts the generic associated [`Key::Hash256`] to [`hash256::Hash`]
+    fn to_hash256(hash: &<Self as Key>::Hash256) -> hash256::Hash;
 
-    /// Converts the generic associated [`MiniscriptKey::Ripemd160`] to [`ripemd160::Hash`]
-    fn to_ripemd160(hash: &<Self as MiniscriptKey>::Ripemd160) -> ripemd160::Hash;
+    /// Converts the generic associated [`Key::Ripemd160`] to [`ripemd160::Hash`]
+    fn to_ripemd160(hash: &<Self as Key>::Ripemd160) -> ripemd160::Hash;
 
-    /// Converts the generic associated [`MiniscriptKey::Hash160`] to [`hash160::Hash`]
-    fn to_hash160(hash: &<Self as MiniscriptKey>::Hash160) -> hash160::Hash;
+    /// Converts the generic associated [`Key::Hash160`] to [`hash160::Hash`]
+    fn to_hash160(hash: &<Self as Key>::Hash160) -> hash160::Hash;
 }
 
 impl ToPublicKey for bitcoin::PublicKey {
@@ -373,7 +376,7 @@ impl str::FromStr for DummyKey {
     }
 }
 
-impl MiniscriptKey for DummyKey {
+impl Key for DummyKey {
     type RawPkHash = DummyKeyHash;
     type Sha256 = DummySha256Hash;
     type Hash256 = DummyHash256;
@@ -565,8 +568,8 @@ impl hash::Hash for DummyHash160Hash {
 /// associated with the other key. Used by the [`TranslatePk`] trait to do the actual translations.
 pub trait Translator<P, Q, E>
 where
-    P: MiniscriptKey,
-    Q: MiniscriptKey,
+    P: Key,
+    Q: Key,
 {
     /// Translates public keys P -> Q.
     fn pk(&mut self, pk: &P) -> Result<Q, E>;
@@ -592,8 +595,8 @@ where
 /// from Pk/Pkh don't change in translation
 pub trait PkTranslator<P, Q, E>
 where
-    P: MiniscriptKey,
-    Q: MiniscriptKey<Sha256 = P::Sha256>,
+    P: Key,
+    Q: Key<Sha256 = P::Sha256>,
 {
     /// Provides the translation public keys P -> Q
     fn pk(&mut self, pk: &P) -> Result<Q, E>;
@@ -605,8 +608,8 @@ where
 impl<P, Q, E, T> Translator<P, Q, E> for T
 where
     T: PkTranslator<P, Q, E>,
-    P: MiniscriptKey,
-    Q: MiniscriptKey<
+    P: Key,
+    Q: Key<
         Sha256 = P::Sha256,
         Hash256 = P::Hash256,
         Ripemd160 = P::Ripemd160,
@@ -617,29 +620,23 @@ where
         <Self as PkTranslator<P, Q, E>>::pk(self, pk)
     }
 
-    fn pkh(
-        &mut self,
-        pkh: &<P as MiniscriptKey>::RawPkHash,
-    ) -> Result<<Q as MiniscriptKey>::RawPkHash, E> {
+    fn pkh(&mut self, pkh: &<P as Key>::RawPkHash) -> Result<<Q as Key>::RawPkHash, E> {
         <Self as PkTranslator<P, Q, E>>::pkh(self, pkh)
     }
 
-    fn sha256(&mut self, sha256: &<P as MiniscriptKey>::Sha256) -> Result<<Q>::Sha256, E> {
+    fn sha256(&mut self, sha256: &<P as Key>::Sha256) -> Result<<Q>::Sha256, E> {
         Ok(sha256.clone())
     }
 
-    fn hash256(&mut self, hash256: &<P as MiniscriptKey>::Hash256) -> Result<<Q>::Hash256, E> {
+    fn hash256(&mut self, hash256: &<P as Key>::Hash256) -> Result<<Q>::Hash256, E> {
         Ok(hash256.clone())
     }
 
-    fn ripemd160(
-        &mut self,
-        ripemd160: &<P as MiniscriptKey>::Ripemd160,
-    ) -> Result<<Q>::Ripemd160, E> {
+    fn ripemd160(&mut self, ripemd160: &<P as Key>::Ripemd160) -> Result<<Q>::Ripemd160, E> {
         Ok(ripemd160.clone())
     }
 
-    fn hash160(&mut self, hash160: &<P as MiniscriptKey>::Hash160) -> Result<<Q>::Hash160, E> {
+    fn hash160(&mut self, hash160: &<P as Key>::Hash160) -> Result<<Q>::Hash160, E> {
         Ok(hash160.clone())
     }
 }
@@ -648,8 +645,8 @@ where
 /// the actual translation function calls.
 pub trait TranslatePk<P, Q>
 where
-    P: MiniscriptKey,
-    Q: MiniscriptKey,
+    P: Key,
+    Q: Key,
 {
     /// The associated output type. This must be `Self<Q>`.
     type Output;
@@ -662,9 +659,9 @@ where
 }
 
 /// Either a key or keyhash, but both contain Pk
-// pub struct ForEach<'a, Pk: MiniscriptKey>(&'a Pk);
+// pub struct ForEach<'a, Pk: Key>(&'a Pk);
 
-// impl<'a, Pk: MiniscriptKey<Hash = Pk>> ForEach<'a, Pk> {
+// impl<'a, Pk: Key<Hash = Pk>> ForEach<'a, Pk> {
 //     /// Convenience method to avoid distinguishing between keys and hashes when these are the same type
 //     pub fn as_key(&self) -> &'a Pk {
 //         self.0
@@ -672,7 +669,7 @@ where
 // }
 
 /// Trait describing the ability to iterate over every key
-pub trait ForEachKey<Pk: MiniscriptKey> {
+pub trait ForEachKey<Pk: Key> {
     /// Run a predicate on every key in the descriptor, returning whether
     /// the predicate returned true for every key
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: F) -> bool
@@ -912,7 +909,7 @@ impl error::Error for Error {
 #[doc(hidden)]
 impl<Pk, Ctx> From<miniscript::types::Error<Pk, Ctx>> for Error
 where
-    Pk: MiniscriptKey,
+    Pk: Key,
     Ctx: ScriptContext,
 {
     fn from(e: miniscript::types::Error<Pk, Ctx>) -> Error {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,18 +26,18 @@ macro_rules! impl_from_tree {
     ) => {
         impl<Pk $(, $gen)*> $crate::expression::FromTree for $name
         where
-            Pk: MiniscriptKey + core::str::FromStr,
+            Pk: Key + core::str::FromStr,
             Pk::RawPkHash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
             Pk::Hash256: core::str::FromStr,
             Pk::Ripemd160: core::str::FromStr,
             Pk::Hash160: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Ripemd160 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash160 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Ripemd160 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Hash160 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
             {
 
@@ -60,18 +60,18 @@ macro_rules! impl_from_str {
     ) => {
         impl<Pk $(, $gen)*> core::str::FromStr for $name
         where
-            Pk: MiniscriptKey + core::str::FromStr,
+            Pk: Key + core::str::FromStr,
             Pk::RawPkHash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
             Pk::Hash256: core::str::FromStr,
             Pk::Ripemd160: core::str::FromStr,
             Pk::Hash160: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Ripemd160 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash160 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Ripemd160 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Hash160 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
             {
                 type Err = $err_ty;
@@ -94,18 +94,18 @@ macro_rules! impl_block_str {
     ) => {
         impl<Pk $(, $gen)*> $name
         where
-            Pk: MiniscriptKey + core::str::FromStr,
+            Pk: Key + core::str::FromStr,
             Pk::RawPkHash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
             Pk::Hash256: core::str::FromStr,
             Pk::Ripemd160: core::str::FromStr,
             Pk::Hash160: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Ripemd160 as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash160 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Ripemd160 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as Key>::Hash160 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
             {
                 $(#[$meta])*
@@ -123,22 +123,22 @@ macro_rules! serde_string_impl_pk {
         #[cfg(feature = "serde")]
         impl<'de, Pk $(, $gen)*> $crate::serde::Deserialize<'de> for $name<Pk $(, $gen)*>
         where
-            Pk: $crate::MiniscriptKey + core::str::FromStr,
+            Pk: $crate::Key + core::str::FromStr,
             Pk::RawPkHash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
             Pk::Hash256: core::str::FromStr,
             Pk::Ripemd160: core::str::FromStr,
             Pk::Hash160: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: core::fmt::Display,
-            <<Pk as $crate::MiniscriptKey>::RawPkHash as core::str::FromStr>::Err:
+            <<Pk as $crate::Key>::RawPkHash as core::str::FromStr>::Err:
                 core::fmt::Display,
-            <<Pk as $crate::MiniscriptKey>::Sha256 as core::str::FromStr>::Err:
+            <<Pk as $crate::Key>::Sha256 as core::str::FromStr>::Err:
                 core::fmt::Display,
-            <<Pk as $crate::MiniscriptKey>::Hash256 as core::str::FromStr>::Err:
+            <<Pk as $crate::Key>::Hash256 as core::str::FromStr>::Err:
                 core::fmt::Display,
-            <<Pk as $crate::MiniscriptKey>::Ripemd160 as core::str::FromStr>::Err:
+            <<Pk as $crate::Key>::Ripemd160 as core::str::FromStr>::Err:
                 core::fmt::Display,
-            <<Pk as $crate::MiniscriptKey>::Hash160 as core::str::FromStr>::Err:
+            <<Pk as $crate::Key>::Hash160 as core::str::FromStr>::Err:
                 core::fmt::Display,
             $($gen : $gen_con,)*
         {
@@ -154,22 +154,22 @@ macro_rules! serde_string_impl_pk {
                 struct Visitor<Pk $(, $gen)*>(PhantomData<(Pk $(, $gen)*)>);
                 impl<'de, Pk $(, $gen)*> $crate::serde::de::Visitor<'de> for Visitor<Pk $(, $gen)*>
                 where
-                    Pk: $crate::MiniscriptKey + core::str::FromStr,
+                    Pk: $crate::Key + core::str::FromStr,
                     Pk::RawPkHash: core::str::FromStr,
                     Pk::Sha256: core::str::FromStr,
                     Pk::Hash256: core::str::FromStr,
                     Pk::Ripemd160: core::str::FromStr,
                     Pk::Hash160: core::str::FromStr,
                     <Pk as core::str::FromStr>::Err: core::fmt::Display,
-                    <<Pk as $crate::MiniscriptKey>::RawPkHash as core::str::FromStr>::Err:
+                    <<Pk as $crate::Key>::RawPkHash as core::str::FromStr>::Err:
                         core::fmt::Display,
-                    <<Pk as $crate::MiniscriptKey>::Sha256 as core::str::FromStr>::Err:
+                    <<Pk as $crate::Key>::Sha256 as core::str::FromStr>::Err:
                         core::fmt::Display,
-                    <<Pk as $crate::MiniscriptKey>::Hash256 as core::str::FromStr>::Err:
+                    <<Pk as $crate::Key>::Hash256 as core::str::FromStr>::Err:
                         core::fmt::Display,
-                    <<Pk as $crate::MiniscriptKey>::Ripemd160 as core::str::FromStr>::Err:
+                    <<Pk as $crate::Key>::Ripemd160 as core::str::FromStr>::Err:
                         core::fmt::Display,
-                    <<Pk as $crate::MiniscriptKey>::Hash160 as core::str::FromStr>::Err:
+                    <<Pk as $crate::Key>::Hash160 as core::str::FromStr>::Err:
                         core::fmt::Display,
                     $($gen: $gen_con,)*
                 {
@@ -208,7 +208,7 @@ macro_rules! serde_string_impl_pk {
         #[cfg(feature = "serde")]
         impl<'de, Pk $(, $gen)*> $crate::serde::Serialize for $name<Pk $(, $gen)*>
         where
-            Pk: $crate::MiniscriptKey,
+            Pk: $crate::Key,
             $($gen: $gen_con,)*
         {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -23,7 +23,7 @@ use std::error;
 
 use crate::miniscript::iter::PkPkh;
 use crate::prelude::*;
-use crate::{Miniscript, MiniscriptKey, ScriptContext};
+use crate::{Key, Miniscript, ScriptContext};
 
 /// Possible reasons Miniscript guarantees can fail
 /// We currently mark Miniscript as Non-Analyzable if
@@ -83,7 +83,7 @@ impl error::Error for AnalysisError {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Whether all spend paths of miniscript require a signature
     pub fn requires_sig(&self) -> bool {
         self.ty.mall.safe

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -31,11 +31,11 @@ use crate::miniscript::ScriptContext;
 use crate::prelude::*;
 use crate::util::MsKeyBuilder;
 use crate::{
-    errstr, expression, script_num_size, Error, ForEachKey, Miniscript, MiniscriptKey, Terminal,
-    ToPublicKey, TranslatePk, Translator,
+    errstr, expression, script_num_size, Error, ForEachKey, Key, Miniscript, Terminal, ToPublicKey,
+    TranslatePk, Translator,
 };
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     /// Internal helper function for displaying wrapper types; returns
     /// a character to display before the `:` as well as a reference
     /// to the wrapped type to allow easy recursion
@@ -58,8 +58,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
 
 impl<Pk, Q, Ctx> TranslatePk<Pk, Q> for Terminal<Pk, Ctx>
 where
-    Pk: MiniscriptKey,
-    Q: MiniscriptKey,
+    Pk: Key,
+    Q: Key,
     Ctx: ScriptContext,
 {
     type Output = Terminal<Q, Ctx>;
@@ -73,7 +73,7 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     pub(super) fn real_for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: &mut F) -> bool
     where
         Pk: 'a,
@@ -120,7 +120,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
 
     pub(super) fn real_translate_pk<Q, CtxQ, T, E>(&self, t: &mut T) -> Result<Terminal<Q, CtxQ>, E>
     where
-        Q: MiniscriptKey,
+        Q: Key,
         CtxQ: ScriptContext,
         T: Translator<Pk, Q, E>,
     {
@@ -194,7 +194,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for Terminal<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> ForEachKey<Pk> for Terminal<Pk, Ctx> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
@@ -204,7 +204,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for Terminal<Pk, Ctx>
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("[")?;
         if let Ok(type_map) = types::Type::type_check(self, |_| None) {
@@ -302,7 +302,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Terminal<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> fmt::Display for Terminal<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Terminal::PkK(ref pk) => write!(f, "pk_k({})", pk),
@@ -584,13 +584,13 @@ impl_from_tree!(
 );
 
 /// Helper trait to add a `push_astelem` method to `script::Builder`
-trait PushAstElem<Pk: MiniscriptKey, Ctx: ScriptContext> {
+trait PushAstElem<Pk: Key, Ctx: ScriptContext> {
     fn push_astelem(self, ast: &Miniscript<Pk, Ctx>) -> Self
     where
         Pk: ToPublicKey;
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> PushAstElem<Pk, Ctx> for script::Builder {
+impl<Pk: Key, Ctx: ScriptContext> PushAstElem<Pk, Ctx> for script::Builder {
     fn push_astelem(self, ast: &Miniscript<Pk, Ctx>) -> Self
     where
         Pk: ToPublicKey,
@@ -599,7 +599,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> PushAstElem<Pk, Ctx> for script::Bui
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     /// Encode the element as a fragment of Bitcoin Script. The inverse
     /// function, from Script to an AST element, is implemented in the
     /// `parse` module.

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -32,7 +32,7 @@ use crate::miniscript::types::extra_props::ExtData;
 use crate::miniscript::types::{Property, Type};
 use crate::miniscript::ScriptContext;
 use crate::prelude::*;
-use crate::{bitcoin, hash256, Error, Miniscript, MiniscriptKey, ToPublicKey};
+use crate::{bitcoin, hash256, Error, Key, Miniscript, ToPublicKey};
 
 fn return_none<T>(_: usize) -> Option<T> {
     None
@@ -125,7 +125,7 @@ enum NonTerm {
 /// All AST elements
 #[allow(broken_intra_doc_links)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Terminal<Pk: MiniscriptKey, Ctx: ScriptContext> {
+pub enum Terminal<Pk: Key, Ctx: ScriptContext> {
     /// `1`
     True,
     /// `0`
@@ -212,9 +212,9 @@ macro_rules! match_token {
 
 ///Vec representing terminals stack while decoding.
 #[derive(Debug)]
-struct TerminalStack<Pk: MiniscriptKey, Ctx: ScriptContext>(Vec<Miniscript<Pk, Ctx>>);
+struct TerminalStack<Pk: Key, Ctx: ScriptContext>(Vec<Miniscript<Pk, Ctx>>);
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {
     ///Wrapper around self.0.pop()
     fn pop(&mut self) -> Option<Miniscript<Pk, Ctx>> {
         self.0.pop()

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -21,11 +21,11 @@ use core::ops::Deref;
 use sync::Arc;
 
 use super::decode::Terminal;
-use super::{Miniscript, MiniscriptKey, ScriptContext};
+use super::{Key, Miniscript, ScriptContext};
 use crate::prelude::*;
 
 /// Iterator-related extensions for [Miniscript]
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Creates a new [Iter] iterator that will iterate over all [Miniscript] items within
     /// AST by traversing its branches. For the specific algorithm please see
     /// [Iter::next] function.
@@ -226,7 +226,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 
 /// Iterator for traversing all [Miniscript] miniscript AST references starting from some specific
 /// node which constructs the iterator via [Miniscript::iter] method.
-pub struct Iter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
+pub struct Iter<'a, Pk: Key, Ctx: ScriptContext> {
     next: Option<&'a Miniscript<Pk, Ctx>>,
     // Here we store vec of path elements, where each element is a tuple, consisting of:
     // 1. Miniscript node on the path
@@ -234,7 +234,7 @@ pub struct Iter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
     path: Vec<(&'a Miniscript<Pk, Ctx>, usize)>,
 }
 
-impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iter<'a, Pk, Ctx> {
+impl<'a, Pk: Key, Ctx: ScriptContext> Iter<'a, Pk, Ctx> {
     fn new(miniscript: &'a Miniscript<Pk, Ctx>) -> Self {
         Iter {
             next: Some(miniscript),
@@ -243,7 +243,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iter<'a, Pk, Ctx> {
     }
 }
 
-impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for Iter<'a, Pk, Ctx> {
+impl<'a, Pk: Key, Ctx: ScriptContext> Iterator for Iter<'a, Pk, Ctx> {
     type Item = &'a Miniscript<Pk, Ctx>;
 
     /// First, the function returns `self`, then the first child of the self (if any),
@@ -286,15 +286,15 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for Iter<'a, Pk, Ctx> {
     }
 }
 
-/// Iterator for traversing all [MiniscriptKey]'s in AST starting from some specific node which
+/// Iterator for traversing all [Key]'s in AST starting from some specific node which
 /// constructs the iterator via [Miniscript::iter_pk] method.
-pub struct PkIter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
+pub struct PkIter<'a, Pk: Key, Ctx: ScriptContext> {
     node_iter: Iter<'a, Pk, Ctx>,
     curr_node: Option<&'a Miniscript<Pk, Ctx>>,
     key_index: usize,
 }
 
-impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> PkIter<'a, Pk, Ctx> {
+impl<'a, Pk: Key, Ctx: ScriptContext> PkIter<'a, Pk, Ctx> {
     fn new(miniscript: &'a Miniscript<Pk, Ctx>) -> Self {
         let mut iter = Iter::new(miniscript);
         PkIter {
@@ -305,7 +305,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> PkIter<'a, Pk, Ctx> {
     }
 }
 
-impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkIter<'a, Pk, Ctx> {
+impl<'a, Pk: Key, Ctx: ScriptContext> Iterator for PkIter<'a, Pk, Ctx> {
     type Item = Pk;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -328,15 +328,15 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkIter<'a, Pk, Ctx>
     }
 }
 
-/// Iterator for traversing all [MiniscriptKey] hashes in AST starting from some specific node which
+/// Iterator for traversing all [Key] hashes in AST starting from some specific node which
 /// constructs the iterator via [Miniscript::iter_pkh] method.
-pub struct PkhIter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
+pub struct PkhIter<'a, Pk: Key, Ctx: ScriptContext> {
     node_iter: Iter<'a, Pk, Ctx>,
     curr_node: Option<&'a Miniscript<Pk, Ctx>>,
     key_index: usize,
 }
 
-impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> PkhIter<'a, Pk, Ctx> {
+impl<'a, Pk: Key, Ctx: ScriptContext> PkhIter<'a, Pk, Ctx> {
     fn new(miniscript: &'a Miniscript<Pk, Ctx>) -> Self {
         let mut iter = Iter::new(miniscript);
         PkhIter {
@@ -347,7 +347,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> PkhIter<'a, Pk, Ctx> {
     }
 }
 
-impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkhIter<'a, Pk, Ctx> {
+impl<'a, Pk: Key, Ctx: ScriptContext> Iterator for PkhIter<'a, Pk, Ctx> {
     type Item = Pk::RawPkHash;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -372,14 +372,14 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkhIter<'a, Pk, Ctx
 
 /// Enum representing either key or a key hash value coming from a miniscript item inside AST
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum PkPkh<Pk: MiniscriptKey> {
+pub enum PkPkh<Pk: Key> {
     /// Plain public key
     PlainPubkey(Pk),
     /// Hashed public key
     HashedPubkey(Pk::RawPkHash),
 }
 
-impl<Pk: MiniscriptKey<RawPkHash = Pk>> PkPkh<Pk> {
+impl<Pk: Key<RawPkHash = Pk>> PkPkh<Pk> {
     /// Convenience method to avoid distinguishing between keys and hashes when these are the same type
     pub fn as_key(self) -> Pk {
         match self {
@@ -389,16 +389,16 @@ impl<Pk: MiniscriptKey<RawPkHash = Pk>> PkPkh<Pk> {
     }
 }
 
-/// Iterator for traversing all [MiniscriptKey]'s and hashes, depending what data are present in AST,
+/// Iterator for traversing all [Key]'s and hashes, depending what data are present in AST,
 /// starting from some specific node which constructs the iterator via
 /// [Miniscript::iter_pk_pkh] method.
-pub struct PkPkhIter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
+pub struct PkPkhIter<'a, Pk: Key, Ctx: ScriptContext> {
     node_iter: Iter<'a, Pk, Ctx>,
     curr_node: Option<&'a Miniscript<Pk, Ctx>>,
     key_index: usize,
 }
 
-impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> PkPkhIter<'a, Pk, Ctx> {
+impl<'a, Pk: Key, Ctx: ScriptContext> PkPkhIter<'a, Pk, Ctx> {
     fn new(miniscript: &'a Miniscript<Pk, Ctx>) -> Self {
         let mut iter = Iter::new(miniscript);
         PkPkhIter {
@@ -433,7 +433,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> PkPkhIter<'a, Pk, Ctx> {
     }
 }
 
-impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkPkhIter<'a, Pk, Ctx> {
+impl<'a, Pk: Key, Ctx: ScriptContext> Iterator for PkPkhIter<'a, Pk, Ctx> {
     type Item = PkPkh<Pk>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -10,7 +10,7 @@ use crate::miniscript::limits::{
     LOCKTIME_THRESHOLD, SEQUENCE_LOCKTIME_DISABLE_FLAG, SEQUENCE_LOCKTIME_TYPE_FLAG,
 };
 use crate::prelude::*;
-use crate::{script_num_size, MiniscriptKey, Terminal};
+use crate::{script_num_size, Key, Terminal};
 
 /// Timelock information for satisfaction of a fragment.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default, Hash)]
@@ -897,7 +897,7 @@ impl Property for ExtData {
     where
         C: FnMut(usize) -> Option<Self>,
         Ctx: ScriptContext,
-        Pk: MiniscriptKey,
+        Pk: Key,
     {
         let wrap_err = |result: Result<Self, ErrorKind>| {
             result.map_err(|kind| Error {

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -29,7 +29,7 @@ pub use self::extra_props::ExtData;
 pub use self::malleability::{Dissat, Malleability};
 use super::limits::SEQUENCE_LOCKTIME_DISABLE_FLAG;
 use super::ScriptContext;
-use crate::{MiniscriptKey, Terminal};
+use crate::{Key, Terminal};
 
 /// None-returning function to help type inference when we need a
 /// closure that simply returns `None`
@@ -99,14 +99,14 @@ pub enum ErrorKind {
 
 /// Error type for typechecking
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct Error<Pk: MiniscriptKey, Ctx: ScriptContext> {
+pub struct Error<Pk: Key, Ctx: ScriptContext> {
     /// The fragment that failed typecheck
     pub fragment: Terminal<Pk, Ctx>,
     /// The reason that typechecking failed
     pub error: ErrorKind,
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Error<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> fmt::Display for Error<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.error {
             ErrorKind::InvalidTime => write!(
@@ -216,7 +216,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Error<Pk, Ctx> {
 }
 
 #[cfg(feature = "std")]
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> error::Error for Error<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> error::Error for Error<Pk, Ctx> {
     fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
@@ -394,7 +394,7 @@ pub trait Property: Sized {
     ) -> Result<Self, Error<Pk, Ctx>>
     where
         C: FnMut(usize) -> Option<Self>,
-        Pk: MiniscriptKey,
+        Pk: Key,
         Ctx: ScriptContext,
     {
         let mut get_child = |sub, n| {
@@ -782,7 +782,7 @@ impl Property for Type {
     ) -> Result<Self, Error<Pk, Ctx>>
     where
         C: FnMut(usize) -> Option<Self>,
-        Pk: MiniscriptKey,
+        Pk: Key,
         Ctx: ScriptContext,
     {
         let wrap_err = |result: Result<Self, ErrorKind>| {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -38,13 +38,13 @@ use crate::expression::{self, FromTree};
 use crate::miniscript::limits::{LOCKTIME_THRESHOLD, SEQUENCE_LOCKTIME_TYPE_FLAG};
 use crate::miniscript::types::extra_props::TimelockInfo;
 use crate::prelude::*;
-use crate::{errstr, Error, ForEachKey, MiniscriptKey, Translator};
+use crate::{errstr, Error, ForEachKey, Key, Translator};
 
 /// Concrete policy which corresponds directly to a Miniscript structure,
 /// and whose disjunctions are annotated with satisfaction probabilities
 /// to assist the compiler
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Policy<Pk: MiniscriptKey> {
+pub enum Policy<Pk: Key> {
     /// Unsatisfiable
     Unsatisfiable,
     /// Trivially satisfiable
@@ -166,7 +166,7 @@ impl error::Error for PolicyError {
     }
 }
 
-impl<Pk: MiniscriptKey> Policy<Pk> {
+impl<Pk: Key> Policy<Pk> {
     /// Flatten the [`Policy`] tree structure into a Vector of tuple `(leaf script, leaf probability)`
     /// with leaf probabilities corresponding to odds for sub-branch in the policy.
     /// We calculate the probability of selecting the sub-branch at every level and calculate the
@@ -339,7 +339,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
+impl<Pk: Key> ForEachKey<Pk> for Policy<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
@@ -362,7 +362,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> Policy<Pk> {
+impl<Pk: Key> Policy<Pk> {
     /// Convert a policy using one kind of public key to another
     /// type of public key
     ///
@@ -428,7 +428,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     pub fn translate_pk<Q, E, T>(&self, t: &mut T) -> Result<Policy<Q>, E>
     where
         T: Translator<Pk, Q, E>,
-        Q: MiniscriptKey,
+        Q: Key,
     {
         self._translate_pk(t)
     }
@@ -436,7 +436,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     fn _translate_pk<Q, E, T>(&self, t: &mut T) -> Result<Policy<Q>, E>
     where
         T: Translator<Pk, Q, E>,
-        Q: MiniscriptKey,
+        Q: Key,
     {
         match *self {
             Policy::Unsatisfiable => Ok(Policy::Unsatisfiable),
@@ -677,7 +677,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
+impl<Pk: Key> fmt::Debug for Policy<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Policy::Unsatisfiable => f.write_str("UNSATISFIABLE()"),
@@ -720,7 +720,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
+impl<Pk: Key> fmt::Display for Policy<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Policy::Unsatisfiable => f.write_str("UNSATISFIABLE"),
@@ -898,7 +898,7 @@ impl_from_tree!(
 
 /// Create a Huffman Tree from compiled [Miniscript] nodes
 #[cfg(feature = "compiler")]
-fn with_huffman_tree<Pk: MiniscriptKey>(
+fn with_huffman_tree<Pk: Key>(
     ms: Vec<(OrdF64, Miniscript<Pk, Tap>)>,
 ) -> Result<TapTree<Pk>, Error> {
     let mut node_weights = BinaryHeap::<(Reverse<OrdF64>, TapTree<Pk>)>::new();

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -36,7 +36,7 @@ pub use self::concrete::Policy as Concrete;
 pub use self::semantic::Policy as Semantic;
 use crate::descriptor::Descriptor;
 use crate::miniscript::{Miniscript, ScriptContext};
-use crate::{Error, MiniscriptKey, Terminal};
+use crate::{Error, Key, Terminal};
 
 /// Policy entailment algorithm maximum number of terminals allowed
 const ENTAILMENT_MAX_TERMINALS: usize = 20;
@@ -53,7 +53,7 @@ const ENTAILMENT_MAX_TERMINALS: usize = 20;
 /// exceed resource limits for any compilation, but cannot detect such
 /// policies while lifting. Note that our compiler would not succeed for any
 /// such policies.
-pub trait Liftable<Pk: MiniscriptKey> {
+pub trait Liftable<Pk: Key> {
     /// Convert the object into an abstract policy
     fn lift(&self) -> Result<Semantic<Pk>, Error>;
 }
@@ -92,7 +92,7 @@ impl error::Error for LiftError {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Lifting corresponds conversion of miniscript into Policy
     /// [policy.semantic.Policy] for human readable or machine analysis.
     /// However, naively lifting miniscripts can result in incorrect
@@ -112,7 +112,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Miniscript<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> Liftable<Pk> for Miniscript<Pk, Ctx> {
     fn lift(&self) -> Result<Semantic<Pk>, Error> {
         // check whether the root miniscript can have a spending path that is
         // a combination of heightlock and timelock
@@ -121,7 +121,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Miniscript<Pk, Ctx>
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
+impl<Pk: Key, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
     fn lift(&self) -> Result<Semantic<Pk>, Error> {
         let ret = match *self {
             Terminal::PkK(ref pk) | Terminal::PkH(ref pk) => Semantic::KeyHash(pk.to_pubkeyhash()),
@@ -173,7 +173,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey> Liftable<Pk> for Descriptor<Pk> {
+impl<Pk: Key> Liftable<Pk> for Descriptor<Pk> {
     fn lift(&self) -> Result<Semantic<Pk>, Error> {
         match *self {
             Descriptor::Bare(ref bare) => bare.lift(),
@@ -186,13 +186,13 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Descriptor<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> Liftable<Pk> for Semantic<Pk> {
+impl<Pk: Key> Liftable<Pk> for Semantic<Pk> {
     fn lift(&self) -> Result<Semantic<Pk>, Error> {
         Ok(self.clone())
     }
 }
 
-impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
+impl<Pk: Key> Liftable<Pk> for Concrete<Pk> {
     fn lift(&self) -> Result<Semantic<Pk>, Error> {
         // do not lift if there is a possible satisfaction
         // involving combination of timelocks and heightlocks

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -20,7 +20,7 @@ use core::{fmt, str};
 use super::concrete::PolicyError;
 use super::ENTAILMENT_MAX_TERMINALS;
 use crate::prelude::*;
-use crate::{errstr, expression, timelock, Error, ForEachKey, MiniscriptKey, Translator};
+use crate::{errstr, expression, timelock, Error, ForEachKey, Key, Translator};
 
 /// Abstract policy which corresponds to the semantics of a Miniscript
 /// and which allows complex forms of analysis, e.g. filtering and
@@ -29,7 +29,7 @@ use crate::{errstr, expression, timelock, Error, ForEachKey, MiniscriptKey, Tran
 /// representing the same policy are lifted to the same `Semantic`,
 /// regardless of their choice of `pk` or `pk_h` nodes.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Policy<Pk: MiniscriptKey> {
+pub enum Policy<Pk: Key> {
     /// Unsatisfiable
     Unsatisfiable,
     /// Trivially satisfiable
@@ -52,7 +52,7 @@ pub enum Policy<Pk: MiniscriptKey> {
     Threshold(usize, Vec<Policy<Pk>>),
 }
 
-impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
+impl<Pk: Key> ForEachKey<Pk> for Policy<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
@@ -72,7 +72,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> Policy<Pk> {
+impl<Pk: Key> Policy<Pk> {
     /// Convert a policy using one kind of public key to another
     /// type of public key
     ///
@@ -138,7 +138,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     pub fn translate_pkh<Q, E, T>(&self, t: &mut T) -> Result<Policy<Q>, E>
     where
         T: Translator<Pk, Q, E>,
-        Q: MiniscriptKey,
+        Q: Key,
     {
         self._translate_pkh(t)
     }
@@ -146,7 +146,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     fn _translate_pkh<Q, E, T>(&self, t: &mut T) -> Result<Policy<Q>, E>
     where
         T: Translator<Pk, Q, E>,
-        Q: MiniscriptKey,
+        Q: Key,
     {
         match *self {
             Policy::Unsatisfiable => Ok(Policy::Unsatisfiable),
@@ -251,7 +251,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
+impl<Pk: Key> fmt::Debug for Policy<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Policy::Unsatisfiable => f.write_str("UNSATISFIABLE()"),
@@ -284,7 +284,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
+impl<Pk: Key> fmt::Display for Policy<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Policy::Unsatisfiable => f.write_str("UNSATISFIABLE"),
@@ -414,7 +414,7 @@ impl_from_tree!(
     }
 );
 
-impl<Pk: MiniscriptKey> Policy<Pk> {
+impl<Pk: Key> Policy<Pk> {
     /// Flatten out trees of `And`s and `Or`s; eliminate `Trivial` and
     /// `Unsatisfiable`s. Does not reorder any branches; use `.sort`.
     pub fn normalized(self) -> Policy<Pk> {
@@ -633,7 +633,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     }
 }
 
-impl<Pk: MiniscriptKey> Policy<Pk> {
+impl<Pk: Key> Policy<Pk> {
     /// "Sort" a policy to bring it into a canonical form to allow comparisons.
     /// Does **not** allow policies to be compared for functional equivalence;
     /// in general this appears to require Gröbner basis techniques that are not

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -36,8 +36,8 @@ use crate::miniscript::limits::SEQUENCE_LOCKTIME_DISABLE_FLAG;
 use crate::miniscript::satisfy::{After, Older};
 use crate::prelude::*;
 use crate::{
-    descriptor, interpreter, DefiniteDescriptorKey, Descriptor, MiniscriptKey, PkTranslator,
-    Preimage32, Satisfier, ToPublicKey, TranslatePk,
+    descriptor, interpreter, DefiniteDescriptorKey, Descriptor, Key, PkTranslator, Preimage32,
+    Satisfier, ToPublicKey, TranslatePk,
 };
 
 mod finalizer;
@@ -285,7 +285,7 @@ impl<'psbt> PsbtInputSatisfier<'psbt> {
     }
 }
 
-impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfier<'psbt> {
+impl<'psbt, Pk: Key + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfier<'psbt> {
     fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::SchnorrSig> {
         self.psbt.inputs[self.index].tap_key_sig
     }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,9 +6,9 @@ use std::str::FromStr;
 use bitcoin::hashes::{hash160, ripemd160, sha256};
 use bitcoin::secp256k1;
 
-use crate::{hash256, MiniscriptKey, Translator};
+use crate::{hash256, Key, Translator};
 
-/// Translate from a String MiniscriptKey type to bitcoin::PublicKey
+/// Translate from a String Key type to bitcoin::PublicKey
 /// If the hashmap is populated, this will lookup for keys in HashMap
 /// Otherwise, this will return a translation to a random key
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use bitcoin::Script;
 
 use crate::miniscript::context;
 use crate::prelude::*;
-use crate::{MiniscriptKey, ScriptContext, ToPublicKey};
+use crate::{Key, ScriptContext, ToPublicKey};
 pub(crate) fn varint_len(n: usize) -> usize {
     bitcoin::VarInt(n as u64).len()
 }

--- a/tests/test_cpp.rs
+++ b/tests/test_cpp.rs
@@ -17,7 +17,7 @@ use bitcoin::{self, Amount, OutPoint, Transaction, TxIn, TxOut, Txid};
 use bitcoind::bitcoincore_rpc::{json, Client, RpcApi};
 use miniscript::miniscript::iter;
 use miniscript::psbt::PsbtExt;
-use miniscript::{Descriptor, Miniscript, MiniscriptKey, Segwitv0};
+use miniscript::{Descriptor, Key, Miniscript, Segwitv0};
 
 mod setup;
 use setup::test_util::{self, PubData, TestData};

--- a/tests/test_desc.rs
+++ b/tests/test_desc.rs
@@ -20,7 +20,7 @@ use bitcoin::{
 use bitcoind::bitcoincore_rpc::{json, Client, RpcApi};
 use miniscript::miniscript::iter;
 use miniscript::psbt::{PsbtExt, PsbtInputExt};
-use miniscript::{Descriptor, Miniscript, MiniscriptKey, ScriptContext, ToPublicKey};
+use miniscript::{Descriptor, Key, Miniscript, ScriptContext, ToPublicKey};
 mod setup;
 
 use rand::RngCore;


### PR DESCRIPTION
One of the main traits in this lib is `MiniscriptKey`, we can shorten this to `Key` with no loss of meaning. This makes the whole codebase more terse. Terse code, if clear, is easier to read because there is less clutter. Also terseness assists the formatter and can reduce lines of code.

This patch is the result of running

  `s/MiniscriptKey/Key/g` on all source files.

## Notes

This is an invasive change, I will not be offended if review is a simple 'no'. Outside the `miniscript` library users can still do `miniscript::Key` if the trait is too terse for their taste.