### PR TITLE
Increase terseness in descriptor module

### DIFF
--- a/integration_test/src/test_util.rs
+++ b/integration_test/src/test_util.rs
@@ -21,10 +21,8 @@ extern crate rand;
 
 use self::rand::RngCore;
 use bitcoin::hashes::{hex::ToHex, Hash};
-use miniscript::{
-    descriptor::{DescriptorSinglePub, SinglePubKey},
-    Descriptor, DescriptorPublicKey, Miniscript, ScriptContext, TranslatePk,
-};
+use miniscript::descriptor::{SinglePub, SinglePubKey};
+use miniscript::{Descriptor, DescriptorPublicKey, Miniscript, ScriptContext, TranslatePk};
 use std::str::FromStr;
 
 use bitcoin;
@@ -163,24 +161,24 @@ pub fn parse_insane_ms<Ctx: ScriptContext>(
             if avail {
                 i = i + 1;
                 if pk_str.starts_with("K") {
-                    DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::FullKey(pubdata.pks[i]),
                     })
                 } else if pk_str.starts_with("X") {
-                    DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::XOnly(pubdata.x_only_pks[i]),
                     })
                 } else {
                     // Parse any other keys as known to allow compatibility with existing tests
-                    DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::FullKey(pubdata.pks[i]),
                     })
                 }
             } else {
-                DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                DescriptorPublicKey::Single(SinglePub {
                     origin: None,
                     key: SinglePubKey::FullKey(random_pk(59)),
                 })
@@ -191,24 +189,24 @@ pub fn parse_insane_ms<Ctx: ScriptContext>(
             if avail {
                 j = j - 1;
                 if pk_str.starts_with("K") {
-                    DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::FullKey(pubdata.pks[j]),
                     })
                 } else if pk_str.starts_with("X") {
-                    DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::XOnly(pubdata.x_only_pks[j]),
                     })
                 } else {
                     // Parse any other keys as known to allow compatibility with existing tests
-                    DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::FullKey(pubdata.pks[j]),
                     })
                 }
             } else {
-                DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                DescriptorPublicKey::Single(SinglePub {
                     origin: None,
                     key: SinglePubKey::FullKey(random_pk(59)),
                 })
@@ -230,12 +228,12 @@ pub fn parse_test_desc(desc: &str, pubdata: &PubData) -> Descriptor<DescriptorPu
             if avail {
                 i = i + 1;
                 if pk_str.starts_with("K") {
-                    Ok(DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    Ok(DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::FullKey(pubdata.pks[i]),
                     }))
                 } else if pk_str.starts_with("X") {
-                    Ok(DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    Ok(DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::XOnly(pubdata.x_only_pks[i]),
                     }))
@@ -243,7 +241,7 @@ pub fn parse_test_desc(desc: &str, pubdata: &PubData) -> Descriptor<DescriptorPu
                     panic!("Key must start with either K or X")
                 }
             } else {
-                Ok(DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                Ok(DescriptorPublicKey::Single(SinglePub {
                     origin: None,
                     key: SinglePubKey::FullKey(random_pk(59)),
                 }))
@@ -254,12 +252,12 @@ pub fn parse_test_desc(desc: &str, pubdata: &PubData) -> Descriptor<DescriptorPu
             if avail {
                 j = j - 1;
                 if pkh_str.starts_with("K") {
-                    Ok(DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    Ok(DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::FullKey(pubdata.pks[j]),
                     }))
                 } else if pkh_str.starts_with("X") {
-                    Ok(DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                    Ok(DescriptorPublicKey::Single(SinglePub {
                         origin: None,
                         key: SinglePubKey::XOnly(pubdata.x_only_pks[j]),
                     }))
@@ -267,7 +265,7 @@ pub fn parse_test_desc(desc: &str, pubdata: &PubData) -> Descriptor<DescriptorPu
                     panic!("Key must start with either K or X")
                 }
             } else {
-                Ok(DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+                Ok(DescriptorPublicKey::Single(SinglePub {
                     origin: None,
                     key: SinglePubKey::FullKey(random_pk(61)),
                 }))

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -12,15 +12,6 @@ use bitcoin::{
 
 use {MiniscriptKey, ToPublicKey};
 
-/// Single public key without any origin or range information
-#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
-pub enum SinglePubKey {
-    /// FullKey (compressed or uncompressed)
-    FullKey(bitcoin::PublicKey),
-    /// XOnlyPublicKey
-    XOnly(XOnlyPublicKey),
-}
-
 /// The MiniscriptKey corresponding to Descriptors. This can
 /// either be Single public key or a Xpub
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
@@ -29,6 +20,15 @@ pub enum DescriptorPublicKey {
     SinglePub(DescriptorSinglePub),
     /// Xpub
     XPub(DescriptorXKey<bip32::ExtendedPubKey>),
+}
+
+/// A Secret Key that can be either a single key or an Xprv
+#[derive(Debug)]
+pub enum DescriptorSecretKey {
+    /// Single Secret Key
+    SinglePriv(DescriptorSinglePriv),
+    /// Xprv
+    XPrv(DescriptorXKey<bip32::ExtendedPrivKey>),
 }
 
 /// A Single Descriptor Key with optional origin information
@@ -49,13 +49,26 @@ pub struct DescriptorSinglePriv {
     pub key: bitcoin::PrivateKey,
 }
 
-/// A Secret Key that can be either a single key or an Xprv
-#[derive(Debug)]
-pub enum DescriptorSecretKey {
-    /// Single Secret Key
-    SinglePriv(DescriptorSinglePriv),
-    /// Xprv
-    XPrv(DescriptorXKey<bip32::ExtendedPrivKey>),
+/// Instance of an extended key with origin and derivation path
+#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
+pub struct DescriptorXKey<K: InnerXKey> {
+    /// Origin information
+    pub origin: Option<(bip32::Fingerprint, bip32::DerivationPath)>,
+    /// The extended key
+    pub xkey: K,
+    /// The derivation path
+    pub derivation_path: bip32::DerivationPath,
+    /// Whether the descriptor is wildcard
+    pub wildcard: Wildcard,
+}
+
+/// Single public key without any origin or range information
+#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
+pub enum SinglePubKey {
+    /// FullKey (compressed or uncompressed)
+    FullKey(bitcoin::PublicKey),
+    /// XOnlyPublicKey
+    XOnly(XOnlyPublicKey),
 }
 
 impl fmt::Display for DescriptorSecretKey {
@@ -122,19 +135,6 @@ pub enum Wildcard {
     Unhardened,
     /// Unhardened wildcard, e.g. *h
     Hardened,
-}
-
-/// Instance of an extended key with origin and derivation path
-#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
-pub struct DescriptorXKey<K: InnerXKey> {
-    /// Origin information
-    pub origin: Option<(bip32::Fingerprint, bip32::DerivationPath)>,
-    /// The extended key
-    pub xkey: K,
-    /// The derivation path
-    pub derivation_path: bip32::DerivationPath,
-    /// Whether the descriptor is wildcard
-    pub wildcard: Wildcard,
 }
 
 impl DescriptorSinglePriv {

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -12,44 +12,43 @@ use bitcoin::{
 
 use {MiniscriptKey, ToPublicKey};
 
-/// The MiniscriptKey corresponding to Descriptors. This can
-/// either be Single public key or a Xpub
+/// The descriptor pubkey, either a single pubkey or an xpub.
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
 pub enum DescriptorPublicKey {
-    /// Single Public Key
+    /// Single public key.
     SinglePub(DescriptorSinglePub),
-    /// Xpub
+    /// Extended public key (xpub).
     XPub(DescriptorXKey<bip32::ExtendedPubKey>),
 }
 
-/// A Secret Key that can be either a single key or an Xprv
+/// The descriptor secret key, either a single private key or an xprv.
 #[derive(Debug)]
 pub enum DescriptorSecretKey {
-    /// Single Secret Key
+    /// Single private key.
     SinglePriv(DescriptorSinglePriv),
-    /// Xprv
+    /// Extended private key (xpriv).
     XPrv(DescriptorXKey<bip32::ExtendedPrivKey>),
 }
 
-/// A Single Descriptor Key with optional origin information
+/// A descriptor [`SinglePubKey`] with optional origin information.
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
 pub struct DescriptorSinglePub {
-    /// Origin information
+    /// Origin information (fingerprint and derivation path).
     pub origin: Option<(bip32::Fingerprint, bip32::DerivationPath)>,
-    /// The key
+    /// The public key.
     pub key: SinglePubKey,
 }
 
-/// A Single Descriptor Secret Key with optional origin information
+/// A descriptor [`bitcoin::PrivateKey`] with optional origin information.
 #[derive(Debug)]
 pub struct DescriptorSinglePriv {
-    /// Origin information
+    /// Origin information (fingerprint and derivation path).
     pub origin: Option<bip32::KeySource>,
-    /// The key
+    /// The private key.
     pub key: bitcoin::PrivateKey,
 }
 
-/// Instance of an extended key with origin and derivation path
+/// An extended key with origin, derivation path, and wildcard.
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
 pub struct DescriptorXKey<K: InnerXKey> {
     /// Origin information
@@ -62,12 +61,12 @@ pub struct DescriptorXKey<K: InnerXKey> {
     pub wildcard: Wildcard,
 }
 
-/// Single public key without any origin or range information
+/// Single public key without any origin or range information.
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
 pub enum SinglePubKey {
-    /// FullKey (compressed or uncompressed)
+    /// A bitcoin public key (compressed or uncompressed).
     FullKey(bitcoin::PublicKey),
-    /// XOnlyPublicKey
+    /// An xonly public key.
     XOnly(XOnlyPublicKey),
 }
 

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -43,7 +43,7 @@ pub struct DescriptorSinglePub {
 #[derive(Debug)]
 pub struct DescriptorSinglePriv {
     /// Origin information (fingerprint and derivation path).
-    pub origin: Option<bip32::KeySource>,
+    pub origin: Option<(bip32::Fingerprint, bip32::DerivationPath)>,
     /// The private key.
     pub key: bitcoin::PrivateKey,
 }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -62,7 +62,7 @@ mod key;
 
 pub use self::key::{
     ConversionError, DescriptorKeyParseError, DescriptorPublicKey, DescriptorSecretKey,
-    DescriptorSinglePriv, DescriptorSinglePub, DescriptorXKey, InnerXKey, SinglePubKey, Wildcard,
+    DescriptorXKey, InnerXKey, SinglePriv, SinglePub, SinglePubKey, Wildcard,
 };
 
 /// Alias type for a map of public key to secret key
@@ -835,9 +835,7 @@ mod tests {
     use bitcoin::util::bip32;
     use bitcoin::{self, secp256k1, EcdsaSighashType, PublicKey};
     use descriptor::key::Wildcard;
-    use descriptor::{
-        DescriptorPublicKey, DescriptorSecretKey, DescriptorSinglePub, DescriptorXKey,
-    };
+    use descriptor::{DescriptorPublicKey, DescriptorSecretKey, DescriptorXKey, SinglePub};
     use hex_script;
     use std::cmp;
     use std::collections::HashMap;
@@ -854,10 +852,9 @@ mod tests {
     impl cmp::PartialEq for DescriptorSecretKey {
         fn eq(&self, other: &Self) -> bool {
             match (self, other) {
-                (
-                    &DescriptorSecretKey::SinglePriv(ref a),
-                    &DescriptorSecretKey::SinglePriv(ref b),
-                ) => a.origin == b.origin && a.key == b.key,
+                (&DescriptorSecretKey::Single(ref a), &DescriptorSecretKey::Single(ref b)) => {
+                    a.origin == b.origin && a.key == b.key
+                }
                 (&DescriptorSecretKey::XPrv(ref a), &DescriptorSecretKey::XPrv(ref b)) => {
                     a.origin == b.origin
                         && a.xkey == b.xkey
@@ -1531,7 +1528,7 @@ mod tests {
 
         // Raw (compressed) pubkey
         let key = "03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8";
-        let expected = DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+        let expected = DescriptorPublicKey::Single(SinglePub {
             key: SinglePubKey::FullKey(
                 bitcoin::PublicKey::from_str(
                     "03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8",
@@ -1545,7 +1542,7 @@ mod tests {
 
         // Raw (uncompressed) pubkey
         let key = "04f5eeb2b10c944c6b9fbcfff94c35bdeecd93df977882babc7f3a2cf7f5c81d3b09a68db7f0e04f21de5d4230e75e6dbe7ad16eefe0d4325a62067dc6f369446a";
-        let expected = DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+        let expected = DescriptorPublicKey::Single(SinglePub {
             key: SinglePubKey::FullKey(bitcoin::PublicKey::from_str(
                 "04f5eeb2b10c944c6b9fbcfff94c35bdeecd93df977882babc7f3a2cf7f5c81d3b09a68db7f0e04f21de5d4230e75e6dbe7ad16eefe0d4325a62067dc6f369446a",
             )
@@ -1558,7 +1555,7 @@ mod tests {
         // Raw pubkey with origin
         let desc =
             "[78412e3a/0'/42/0']0231c7d3fc85c148717848033ce276ae2b464a4e2c367ed33886cc428b8af48ff8";
-        let expected = DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+        let expected = DescriptorPublicKey::Single(SinglePub {
             key: SinglePubKey::FullKey(
                 bitcoin::PublicKey::from_str(
                     "0231c7d3fc85c148717848033ce276ae2b464a4e2c367ed33886cc428b8af48ff8",


### PR DESCRIPTION
In an effort to better understand the `descriptor` module and its associated types; do some refactoring and re-naming of types making the key struct identifiers more terse.

- Patch 1: refactor, code layout
- Patch 2: docs improvements
- Patch 3: Minor refactor
- Patch 4: Use more terse names, this is the bulk of the PR

If this is too invasive for someone only recently making their way around the crate, feel free to say so :)