### PR TITLE
Re-name `as_public` -> `to_public`

### DIFF
--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -156,7 +156,7 @@ impl DescriptorXKey<bip32::ExtendedPrivKey> {
     /// private key before turning it into a public key.
     ///
     /// If the key already has an origin, the derivation steps applied will be appended to the path
-    /// already present, otherwise this key will be treated as "root" key and an origin will be
+    /// already present, otherwise this key will be treated as a master key and an origin will be
     /// added with this key's fingerprint and the derivation steps applied.
     fn as_public<C: Signing>(
         &self,

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -253,12 +253,12 @@ impl DescriptorSecretKey {
         &self,
         secp: &Secp256k1<C>,
     ) -> Result<DescriptorPublicKey, DescriptorKeyParseError> {
-        Ok(match self {
-            &DescriptorSecretKey::Single(ref sk) => DescriptorPublicKey::Single(sk.to_public(secp)),
-            &DescriptorSecretKey::XPrv(ref xprv) => {
-                DescriptorPublicKey::XPub(xprv.to_public(secp)?)
-            }
-        })
+        let pk = match self {
+            DescriptorSecretKey::Single(prv) => DescriptorPublicKey::Single(prv.to_public(secp)),
+            DescriptorSecretKey::XPrv(xprv) => DescriptorPublicKey::XPub(xprv.to_public(secp)?),
+        };
+
+        Ok(pk)
     }
 }
 

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -137,17 +137,14 @@ pub enum Wildcard {
 }
 
 impl SinglePriv {
-    /// Returns the public key of this key
-    fn to_public<C: Signing>(
-        &self,
-        secp: &Secp256k1<C>,
-    ) -> Result<SinglePub, DescriptorKeyParseError> {
+    /// Returns the public key of this key.
+    fn to_public<C: Signing>(&self, secp: &Secp256k1<C>) -> SinglePub {
         let pub_key = self.key.public_key(secp);
 
-        Ok(SinglePub {
+        SinglePub {
             origin: self.origin.clone(),
             key: SinglePubKey::FullKey(pub_key),
-        })
+        }
     }
 }
 
@@ -254,9 +251,7 @@ impl DescriptorSecretKey {
         secp: &Secp256k1<C>,
     ) -> Result<DescriptorPublicKey, DescriptorKeyParseError> {
         Ok(match self {
-            &DescriptorSecretKey::Single(ref sk) => {
-                DescriptorPublicKey::Single(sk.to_public(secp)?)
-            }
+            &DescriptorSecretKey::Single(ref sk) => DescriptorPublicKey::Single(sk.to_public(secp)),
             &DescriptorSecretKey::XPrv(ref xprv) => {
                 DescriptorPublicKey::XPub(xprv.to_public(secp)?)
             }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -722,7 +722,7 @@ impl Descriptor<DescriptorPublicKey> {
                          key_map: &mut KeyMap|
          -> Result<DescriptorPublicKey, DescriptorKeyParseError> {
             let (public_key, secret_key) = match DescriptorSecretKey::from_str(s) {
-                Ok(sk) => (sk.as_public(&secp)?, Some(sk)),
+                Ok(sk) => (sk.to_public(&secp)?, Some(sk)),
                 Err(_) => (DescriptorPublicKey::from_str(s)?, None),
             };
 


### PR DESCRIPTION
As we have been doing in `rust-bitcoin` attempt to use idiomatic names for our conversion functions.

Re-name the key conversion functions `as_public` to be `to_public` because they take a borrowed type and return an owned, non-Copy type.

While we are it at do a bunch of refactoring to the individual functions. Each done as a separate patch, can drop any not wanted.