### PR TITLE
Refactor opcode calculations

### DIFF
--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -381,7 +381,7 @@ impl ScriptContext for Legacy {
     fn check_local_consensus_validity<Pk: MiniscriptKey>(
         ms: &Miniscript<Pk, Self>,
     ) -> Result<(), ScriptContextError> {
-        match ms.ext.ops_count_sat {
+        match ms.ext.ops.op_count() {
             None => Err(ScriptContextError::MaxOpCountExceeded),
             Some(op_count) if op_count > MAX_OPS_PER_SCRIPT => {
                 Err(ScriptContextError::MaxOpCountExceeded)
@@ -494,7 +494,7 @@ impl ScriptContext for Segwitv0 {
     fn check_local_consensus_validity<Pk: MiniscriptKey>(
         ms: &Miniscript<Pk, Self>,
     ) -> Result<(), ScriptContextError> {
-        match ms.ext.ops_count_sat {
+        match ms.ext.ops.op_count() {
             None => Err(ScriptContextError::MaxOpCountExceeded),
             Some(op_count) if op_count > MAX_OPS_PER_SCRIPT => {
                 Err(ScriptContextError::MaxOpCountExceeded)
@@ -711,7 +711,7 @@ impl ScriptContext for BareCtx {
     fn check_local_consensus_validity<Pk: MiniscriptKey>(
         ms: &Miniscript<Pk, Self>,
     ) -> Result<(), ScriptContextError> {
-        match ms.ext.ops_count_sat {
+        match ms.ext.ops.op_count() {
             None => Err(ScriptContextError::MaxOpCountExceeded),
             Some(op_count) if op_count > MAX_OPS_PER_SCRIPT => {
                 Err(ScriptContextError::MaxOpCountExceeded)

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -575,7 +575,7 @@ mod tests {
                 assert_eq!(format!("{:x}", ms.encode()), expected_hex);
                 assert_eq!(ms.ty.mall.non_malleable, non_mal);
                 assert_eq!(ms.ty.mall.safe, need_sig);
-                assert_eq!(ms.ext.ops_count_sat.unwrap(), ops);
+                assert_eq!(ms.ext.ops.op_count().unwrap(), ops);
             }
             (Err(_), false) => return,
             _ => unreachable!(),

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -39,6 +39,34 @@ impl Default for TimeLockInfo {
     }
 }
 
+/// Helper struct to store information about op code limits. Note that this only
+/// counts the non-push opcodes. This is not relevant for TapScript context
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct OpLimits {
+    /// The worst case static(executed + unexecuted) ops-count for this Miniscript fragment.
+    pub count: usize,
+    /// The worst case additional ops-count for satisfying this Miniscript fragment.
+    pub sat: Option<usize>,
+    /// The worst case additional ops-count for dissatisfying this Miniscript fragment.
+    pub nsat: Option<usize>,
+}
+
+impl OpLimits {
+    /// Creates a new instance of [`OpLimits`]
+    pub fn new(op_static: usize, op_sat: Option<usize>, op_nsat: Option<usize>) -> Self {
+        OpLimits {
+            count: op_static,
+            sat: op_sat,
+            nsat: op_nsat,
+        }
+    }
+
+    /// Worst case opcode count when this element is satisfied
+    pub fn op_count(&self) -> Option<usize> {
+        opt_add(Some(self.count), self.sat)
+    }
+}
+
 impl TimeLockInfo {
     /// Whether the current contains any possible unspendable
     /// path
@@ -100,12 +128,8 @@ pub struct ExtData {
     pub pk_cost: usize,
     /// Whether this fragment can be verify-wrapped for free
     pub has_free_verify: bool,
-    /// The worst case static(unexecuted) ops-count for this Miniscript fragment.
-    pub ops_count_static: usize,
-    /// The worst case ops-count for satisfying this Miniscript fragment.
-    pub ops_count_sat: Option<usize>,
-    /// The worst case ops-count for dissatisfying this Miniscript fragment.
-    pub ops_count_nsat: Option<usize>,
+    /// Opcode limits for this fragment.
+    pub ops: OpLimits,
     /// The worst case number of stack elements for satisfying this Miniscript fragment.
     pub stack_elem_count_sat: Option<usize>,
     /// The worst case number of stack elements for dissatisfying this Miniscript fragment.
@@ -147,9 +171,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: 1,
             has_free_verify: false,
-            ops_count_static: 0,
-            ops_count_sat: Some(0),
-            ops_count_nsat: None,
+            ops: OpLimits::new(0, Some(0), None),
             stack_elem_count_sat: Some(0),
             stack_elem_count_dissat: None,
             max_sat_size: Some((0, 0)),
@@ -164,9 +186,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: 1,
             has_free_verify: false,
-            ops_count_static: 0,
-            ops_count_sat: None,
-            ops_count_nsat: Some(0),
+            ops: OpLimits::new(0, None, Some(0)),
             stack_elem_count_sat: None,
             stack_elem_count_dissat: Some(0),
             max_sat_size: None,
@@ -181,9 +201,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: 34,
             has_free_verify: false,
-            ops_count_static: 0,
-            ops_count_sat: Some(0),
-            ops_count_nsat: Some(0),
+            ops: OpLimits::new(0, Some(0), Some(0)),
             stack_elem_count_sat: Some(1),
             stack_elem_count_dissat: Some(1),
             max_sat_size: Some((73, 73)),
@@ -198,9 +216,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: 24,
             has_free_verify: false,
-            ops_count_static: 3,
-            ops_count_sat: Some(3),
-            ops_count_nsat: Some(3),
+            ops: OpLimits::new(3, Some(0), Some(0)),
             stack_elem_count_sat: Some(2),
             stack_elem_count_dissat: Some(2),
             max_sat_size: Some((34 + 73, 34 + 73)),
@@ -221,9 +237,9 @@ impl Property for ExtData {
         ExtData {
             pk_cost: num_cost + 34 * n + 1,
             has_free_verify: true,
-            ops_count_static: 1,
-            ops_count_sat: Some(n + 1),
-            ops_count_nsat: Some(n + 1),
+            // Multi is the only case because of which we need to count additional
+            // executed opcodes.
+            ops: OpLimits::new(1, Some(n), Some(n)),
             stack_elem_count_sat: Some(k + 1),
             stack_elem_count_dissat: Some(k + 1),
             max_sat_size: Some((1 + 73 * k, 1 + 73 * k)),
@@ -244,9 +260,8 @@ impl Property for ExtData {
         ExtData {
             pk_cost: num_cost + 33 * n /*pks*/ + (n-1) /*checksigadds*/ + 1,
             has_free_verify: true,
-            ops_count_static: 1, // We don't care about opcounts in tapscript
-            ops_count_sat: Some(n + 1),
-            ops_count_nsat: Some(n + 1),
+            // These numbers are irrelevant here are there is no op limit in tapscript
+            ops: OpLimits::new(n, Some(0), Some(0)),
             stack_elem_count_sat: Some(n),
             stack_elem_count_dissat: Some(n),
             max_sat_size: Some(((n - k) + 66 * k, (n - k) + 66 * k)),
@@ -266,9 +281,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: 33 + 6,
             has_free_verify: true,
-            ops_count_static: 4,
-            ops_count_sat: Some(4),
-            ops_count_nsat: Some(4),
+            ops: OpLimits::new(4, Some(0), Some(0)),
             stack_elem_count_sat: Some(1),
             stack_elem_count_dissat: Some(1),
             max_sat_size: Some((33, 33)),
@@ -283,9 +296,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: 33 + 6,
             has_free_verify: true,
-            ops_count_static: 4,
-            ops_count_sat: Some(4),
-            ops_count_nsat: Some(4),
+            ops: OpLimits::new(4, Some(0), Some(0)),
             stack_elem_count_sat: Some(1),
             stack_elem_count_dissat: Some(1),
             max_sat_size: Some((33, 33)),
@@ -300,9 +311,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: 21 + 6,
             has_free_verify: true,
-            ops_count_static: 4,
-            ops_count_sat: Some(4),
-            ops_count_nsat: Some(4),
+            ops: OpLimits::new(4, Some(0), Some(0)),
             stack_elem_count_sat: Some(1),
             stack_elem_count_dissat: Some(1),
             max_sat_size: Some((33, 33)),
@@ -317,9 +326,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: 21 + 6,
             has_free_verify: true,
-            ops_count_static: 4,
-            ops_count_sat: Some(4),
-            ops_count_nsat: Some(4),
+            ops: OpLimits::new(4, Some(0), Some(0)),
             stack_elem_count_sat: Some(1),
             stack_elem_count_dissat: Some(1),
             max_sat_size: Some((33, 33)),
@@ -338,9 +345,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: script_num_size(t as usize) + 1,
             has_free_verify: false,
-            ops_count_static: 1,
-            ops_count_sat: Some(1),
-            ops_count_nsat: None,
+            ops: OpLimits::new(1, Some(0), None),
             stack_elem_count_sat: Some(0),
             stack_elem_count_dissat: None,
             max_sat_size: Some((0, 0)),
@@ -361,9 +366,7 @@ impl Property for ExtData {
         ExtData {
             pk_cost: script_num_size(t as usize) + 1,
             has_free_verify: false,
-            ops_count_static: 1,
-            ops_count_sat: Some(1),
-            ops_count_nsat: None,
+            ops: OpLimits::new(1, Some(0), None),
             stack_elem_count_sat: Some(0),
             stack_elem_count_dissat: None,
             max_sat_size: Some((0, 0)),
@@ -384,9 +387,7 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: self.pk_cost + 2,
             has_free_verify: false,
-            ops_count_static: self.ops_count_static + 2,
-            ops_count_sat: self.ops_count_sat.map(|x| x + 2),
-            ops_count_nsat: self.ops_count_nsat.map(|x| x + 2),
+            ops: OpLimits::new(2 + self.ops.count, self.ops.sat, self.ops.nsat),
             stack_elem_count_sat: self.stack_elem_count_sat,
             stack_elem_count_dissat: self.stack_elem_count_dissat,
             max_sat_size: self.max_sat_size,
@@ -401,9 +402,7 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: self.pk_cost + 1,
             has_free_verify: self.has_free_verify,
-            ops_count_static: self.ops_count_static + 1,
-            ops_count_sat: self.ops_count_sat.map(|x| x + 1),
-            ops_count_nsat: self.ops_count_nsat.map(|x| x + 1),
+            ops: OpLimits::new(1 + self.ops.count, self.ops.sat, self.ops.nsat),
             stack_elem_count_sat: self.stack_elem_count_sat,
             stack_elem_count_dissat: self.stack_elem_count_dissat,
             max_sat_size: self.max_sat_size,
@@ -418,9 +417,7 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: self.pk_cost + 1,
             has_free_verify: true,
-            ops_count_static: self.ops_count_static + 1,
-            ops_count_sat: self.ops_count_sat.map(|x| x + 1),
-            ops_count_nsat: self.ops_count_nsat.map(|x| x + 1),
+            ops: OpLimits::new(1 + self.ops.count, self.ops.sat, self.ops.nsat),
             stack_elem_count_sat: self.stack_elem_count_sat,
             stack_elem_count_dissat: self.stack_elem_count_dissat,
             max_sat_size: self.max_sat_size,
@@ -435,9 +432,7 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: self.pk_cost + 3,
             has_free_verify: false,
-            ops_count_static: self.ops_count_static + 3,
-            ops_count_sat: self.ops_count_sat.map(|x| x + 3),
-            ops_count_nsat: Some(self.ops_count_static + 3),
+            ops: OpLimits::new(3 + self.ops.count, self.ops.sat, Some(0)),
             stack_elem_count_sat: self.stack_elem_count_sat.map(|x| x + 1),
             stack_elem_count_dissat: Some(1),
             max_sat_size: self.max_sat_size.map(|(w, s)| (w + 2, s + 1)),
@@ -456,9 +451,7 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: self.pk_cost + if self.has_free_verify { 0 } else { 1 },
             has_free_verify: false,
-            ops_count_static: self.ops_count_static + verify_cost,
-            ops_count_sat: self.ops_count_sat.map(|x| x + verify_cost),
-            ops_count_nsat: None,
+            ops: OpLimits::new(verify_cost + self.ops.count, self.ops.sat, None),
             stack_elem_count_sat: self.stack_elem_count_sat,
             stack_elem_count_dissat: None,
             max_sat_size: self.max_sat_size,
@@ -473,9 +466,7 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: self.pk_cost + 4,
             has_free_verify: false,
-            ops_count_static: self.ops_count_static + 4,
-            ops_count_sat: self.ops_count_sat.map(|x| x + 4),
-            ops_count_nsat: Some(self.ops_count_static + 4),
+            ops: OpLimits::new(4 + self.ops.count, self.ops.sat, Some(0)),
             stack_elem_count_sat: self.stack_elem_count_sat,
             stack_elem_count_dissat: Some(1),
             max_sat_size: self.max_sat_size,
@@ -490,9 +481,7 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: self.pk_cost + 1,
             has_free_verify: false,
-            ops_count_static: self.ops_count_static + 1,
-            ops_count_sat: self.ops_count_sat.map(|x| x + 1),
-            ops_count_nsat: self.ops_count_nsat.map(|x| x + 1),
+            ops: OpLimits::new(1 + self.ops.count, self.ops.sat, self.ops.nsat),
             stack_elem_count_sat: self.stack_elem_count_sat,
             stack_elem_count_dissat: self.stack_elem_count_dissat,
             max_sat_size: self.max_sat_size,
@@ -504,78 +493,20 @@ impl Property for ExtData {
         })
     }
 
-    fn cast_true(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
-            pk_cost: self.pk_cost + 1,
-            has_free_verify: false,
-            ops_count_static: self.ops_count_static,
-            ops_count_sat: self.ops_count_sat,
-            ops_count_nsat: None,
-            stack_elem_count_sat: self.stack_elem_count_sat,
-            stack_elem_count_dissat: None,
-            max_sat_size: self.max_sat_size,
-            max_dissat_size: None,
-            timelock_info: self.timelock_info,
-            // Technically max(1, self.exec_stack_elem_count_sat), same rationale as cast_dupif
-            exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
-            exec_stack_elem_count_dissat: None,
-        })
-    }
-
     fn cast_or_i_false(self) -> Result<Self, ErrorKind> {
         // never called directly
         unreachable!()
-    }
-
-    fn cast_unlikely(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
-            pk_cost: self.pk_cost + 4,
-            has_free_verify: false,
-            ops_count_static: self.ops_count_static + 3,
-            ops_count_sat: self.ops_count_sat.map(|x| x + 3),
-            ops_count_nsat: Some(self.ops_count_static + 3),
-            stack_elem_count_sat: self.stack_elem_count_sat.map(|x| x + 1),
-            stack_elem_count_dissat: self.stack_elem_count_dissat.map(|x| x + 1),
-            max_sat_size: self.max_sat_size.map(|(w, s)| (w + 2, s + 1)),
-            max_dissat_size: self.max_dissat_size.map(|(w, s)| (w + 1, s + 1)),
-            // TODO: fix dissat stack elem counting above in a later commit
-            // Technically max(1, self.exec_stack_elem_count_sat), same rationale as cast_dupif
-            exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
-            exec_stack_elem_count_dissat: self.exec_stack_elem_count_dissat,
-            timelock_info: self.timelock_info,
-        })
-    }
-
-    fn cast_likely(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
-            pk_cost: self.pk_cost + 4,
-            has_free_verify: false,
-            ops_count_static: self.ops_count_static + 3,
-            ops_count_sat: self.ops_count_sat.map(|x| x + 3),
-            ops_count_nsat: Some(self.ops_count_static + 3),
-            stack_elem_count_sat: self.stack_elem_count_sat.map(|x| x + 1),
-            stack_elem_count_dissat: self.stack_elem_count_dissat.map(|x| x + 1),
-            max_sat_size: self.max_sat_size.map(|(w, s)| (w + 1, s + 1)),
-            max_dissat_size: self.max_dissat_size.map(|(w, s)| (w + 2, s + 1)),
-            timelock_info: self.timelock_info,
-            // TODO: fix dissat stack elem counting above in a later commit
-            // Technically max(1, self.exec_stack_elem_count_sat), same rationale as cast_dupif
-            exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
-            exec_stack_elem_count_dissat: self.exec_stack_elem_count_dissat,
-        })
     }
 
     fn and_b(l: Self, r: Self) -> Result<Self, ErrorKind> {
         Ok(ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 1,
             has_free_verify: false,
-            ops_count_static: l.ops_count_static + r.ops_count_static + 1,
-            ops_count_sat: l
-                .ops_count_sat
-                .and_then(|x| r.ops_count_sat.map(|y| x + y + 1)),
-            ops_count_nsat: l
-                .ops_count_nsat
-                .and_then(|x| r.ops_count_nsat.map(|y| x + y + 1)),
+            ops: OpLimits::new(
+                1 + l.ops.count + r.ops.count,
+                opt_add(l.ops.sat, r.ops.sat),
+                opt_add(l.ops.nsat, r.ops.nsat),
+            ),
             stack_elem_count_sat: l
                 .stack_elem_count_sat
                 .and_then(|l| r.stack_elem_count_sat.map(|r| l + r)),
@@ -606,9 +537,11 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: l.pk_cost + r.pk_cost,
             has_free_verify: r.has_free_verify,
-            ops_count_static: l.ops_count_static + r.ops_count_static,
-            ops_count_sat: l.ops_count_sat.and_then(|x| r.ops_count_sat.map(|y| x + y)),
-            ops_count_nsat: None,
+            ops: OpLimits::new(
+                l.ops.count + r.ops.count,
+                opt_add(l.ops.sat, r.ops.sat),
+                None,
+            ),
             stack_elem_count_sat: l
                 .stack_elem_count_sat
                 .and_then(|l| r.stack_elem_count_sat.map(|r| l + r)),
@@ -631,16 +564,14 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 1,
             has_free_verify: false,
-            ops_count_static: l.ops_count_static + r.ops_count_static + 1,
-            ops_count_sat: cmp::max(
-                l.ops_count_sat
-                    .and_then(|x| r.ops_count_nsat.map(|y| y + x + 1)),
-                r.ops_count_sat
-                    .and_then(|x| l.ops_count_nsat.map(|y| y + x + 1)),
+            ops: OpLimits::new(
+                l.ops.count + r.ops.count + 1,
+                cmp::max(
+                    opt_add(l.ops.sat, r.ops.nsat),
+                    opt_add(l.ops.nsat, r.ops.sat),
+                ),
+                opt_add(l.ops.nsat, r.ops.nsat),
             ),
-            ops_count_nsat: l
-                .ops_count_nsat
-                .and_then(|x| r.ops_count_nsat.map(|y| x + y + 1)),
             stack_elem_count_sat: cmp::max(
                 l.stack_elem_count_sat
                     .and_then(|l| r.stack_elem_count_dissat.map(|r| l + r)),
@@ -681,15 +612,11 @@ impl Property for ExtData {
         let res = ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 3,
             has_free_verify: false,
-            ops_count_static: l.ops_count_static + r.ops_count_static + 1,
-            ops_count_sat: cmp::max(
-                l.ops_count_sat.map(|x| x + 3 + r.ops_count_static),
-                r.ops_count_sat
-                    .and_then(|x| l.ops_count_nsat.map(|y| y + x + 3)),
+            ops: OpLimits::new(
+                l.ops.count + r.ops.count + 3,
+                cmp::max(l.ops.sat, opt_add(l.ops.nsat, r.ops.sat)),
+                opt_add(l.ops.nsat, r.ops.nsat),
             ),
-            ops_count_nsat: l
-                .ops_count_nsat
-                .and_then(|x| r.ops_count_nsat.map(|y| x + y + 3)),
             stack_elem_count_sat: cmp::max(
                 l.stack_elem_count_sat,
                 l.stack_elem_count_dissat
@@ -723,13 +650,11 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 2,
             has_free_verify: false,
-            ops_count_static: l.ops_count_static + r.ops_count_static + 2,
-            ops_count_sat: cmp::max(
-                l.ops_count_sat.map(|x| x + 2 + r.ops_count_static),
-                r.ops_count_sat
-                    .and_then(|x| l.ops_count_nsat.map(|y| y + x + 2)),
+            ops: OpLimits::new(
+                l.ops.count + r.ops.count + 2,
+                cmp::max(l.ops.sat, opt_add(l.ops.nsat, r.ops.sat)),
+                None,
             ),
-            ops_count_nsat: None,
             stack_elem_count_sat: cmp::max(
                 l.stack_elem_count_sat,
                 l.stack_elem_count_dissat
@@ -755,16 +680,11 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 3,
             has_free_verify: false,
-            ops_count_static: l.ops_count_static + r.ops_count_static + 3,
-            ops_count_sat: cmp::max(
-                l.ops_count_sat.map(|x| x + 3 + r.ops_count_static),
-                r.ops_count_sat.map(|x| x + 3 + l.ops_count_static),
+            ops: OpLimits::new(
+                l.ops.count + r.ops.count + 3,
+                cmp::max(l.ops.sat, r.ops.sat),
+                cmp::max(l.ops.nsat, r.ops.nsat),
             ),
-            ops_count_nsat: match (l.ops_count_nsat, r.ops_count_nsat) {
-                (Some(a), Some(b)) => Some(cmp::max(a, b) + 3),
-                (_, Some(x)) | (Some(x), _) => Some(x + 3),
-                (None, None) => None,
-            },
             stack_elem_count_sat: match (l.stack_elem_count_sat, r.stack_elem_count_sat) {
                 (Some(l), Some(r)) => Some(1 + cmp::max(l, r)),
                 (Some(l), None) => Some(1 + l),
@@ -807,16 +727,14 @@ impl Property for ExtData {
         Ok(ExtData {
             pk_cost: a.pk_cost + b.pk_cost + c.pk_cost + 3,
             has_free_verify: false,
-            ops_count_static: a.ops_count_static + b.ops_count_static + c.ops_count_static + 3,
-            ops_count_sat: cmp::max(
-                a.ops_count_sat
-                    .and_then(|x| b.ops_count_sat.map(|y| x + y + c.ops_count_static + 3)),
-                c.ops_count_sat
-                    .and_then(|z| a.ops_count_nsat.map(|y| y + z + b.ops_count_static + 3)),
+            ops: OpLimits::new(
+                a.ops.count + b.ops.count + c.ops.count + 3,
+                cmp::max(
+                    opt_add(a.ops.sat, b.ops.sat),
+                    opt_add(a.ops.nsat, c.ops.sat),
+                ),
+                opt_add(a.ops.nsat, c.ops.nsat),
             ),
-            ops_count_nsat: c
-                .ops_count_nsat
-                .and_then(|z| a.ops_count_nsat.map(|x| x + b.ops_count_static + z + 3)),
             stack_elem_count_sat: cmp::max(
                 a.stack_elem_count_sat
                     .and_then(|a| b.stack_elem_count_sat.map(|b| b + a)),
@@ -855,12 +773,10 @@ impl Property for ExtData {
         S: FnMut(usize) -> Result<Self, ErrorKind>,
     {
         let mut pk_cost = 1 + script_num_size(k); //Equal and k
-        let mut ops_count_static = 0 as usize;
+        let mut ops_count = 0 as usize;
         let mut ops_count_sat_vec = Vec::with_capacity(n);
         let mut ops_count_nsat_sum = 0 as usize;
-        let mut ops_count_nsat = Some(0);
-        let mut ops_count_sat = Some(0);
-        let mut sat_count = 0;
+        let mut op_count_sat = Some(0);
         let mut timelocks = Vec::with_capacity(n);
         let mut stack_elem_count_sat_vec = Vec::with_capacity(n);
         let mut stack_elem_count_sat = Some(0);
@@ -877,7 +793,7 @@ impl Property for ExtData {
             let sub = sub_ck(i)?;
 
             pk_cost += sub.pk_cost;
-            ops_count_static += sub.ops_count_static;
+            ops_count += sub.ops.count;
             timelocks.push(sub.timelock_info);
 
             if let Some(n_items) = sub.stack_elem_count_dissat {
@@ -894,19 +810,9 @@ impl Property for ExtData {
             stack_elem_count_sat_vec.push((sub.stack_elem_count_sat, sub.stack_elem_count_dissat));
             max_sat_size_vec.push((sub.max_sat_size, sub.max_sat_size));
 
-            match (sub.ops_count_sat, sub.ops_count_nsat) {
-                (Some(x), Some(y)) => {
-                    ops_count_sat_vec.push(Some(x as i32 - y as i32));
-                    ops_count_nsat = ops_count_nsat.map(|v| y + v);
-                    ops_count_nsat_sum = ops_count_nsat_sum + y;
-                }
-                (Some(x), None) => {
-                    sat_count = sat_count + 1;
-                    ops_count_sat = ops_count_sat.map(|y| x + y);
-                    ops_count_nsat = None;
-                }
-                _ => {}
-            }
+            let sub_nsat = sub.ops.nsat.expect("Thresh children must be d");
+            ops_count_nsat_sum += sub_nsat;
+            ops_count_sat_vec.push((sub.ops.sat, sub_nsat));
             exec_stack_elem_count_sat_vec.push((
                 sub.exec_stack_elem_count_sat,
                 sub.exec_stack_elem_count_dissat,
@@ -961,26 +867,25 @@ impl Property for ExtData {
             };
         }
 
-        let remaining_sat = k - sat_count;
-        let mut sum: i32 = 0;
-        if k < sat_count || ops_count_sat_vec.len() < remaining_sat {
-            ops_count_sat = None;
-        } else {
-            ops_count_sat_vec.sort();
-            ops_count_sat_vec.reverse();
-            sum = ops_count_sat_vec
-                .split_off(remaining_sat)
-                .iter()
-                .map(|z| z.unwrap())
-                .sum();
+        ops_count_sat_vec.sort_by(|a, b| {
+            a.0.map(|x| x as isize - a.1 as isize)
+                .cmp(&b.0.map(|x| x as isize - b.1 as isize))
+        });
+        for (i, &(x, y)) in ops_count_sat_vec.iter().enumerate() {
+            op_count_sat = if i <= k {
+                opt_add(op_count_sat, x)
+            } else {
+                opt_add(op_count_sat, Some(y))
+            };
         }
         Ok(ExtData {
             pk_cost: pk_cost + n - 1, //all pk cost + (n-1)*ADD
             has_free_verify: true,
-            ops_count_static: ops_count_static + (n - 1) + 1, //adds and equal
-            ops_count_sat: ops_count_sat
-                .map(|x: usize| (x + (n - 1) + 1 + (sum + ops_count_nsat_sum as i32) as usize)), //adds and equal
-            ops_count_nsat: ops_count_nsat.map(|x| x + (n - 1) + 1), //adds and equal
+            ops: OpLimits::new(
+                ops_count + 1 + (n - 1), // adds and equal
+                op_count_sat,
+                Some(ops_count_nsat_sum),
+            ),
             stack_elem_count_sat,
             stack_elem_count_dissat,
             max_sat_size,
@@ -1137,4 +1042,9 @@ fn opt_max<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
     } else {
         None
     }
+}
+
+// Returns Some(x+y) is both x and y are Some. Otherwise, return none
+fn opt_add(a: Option<usize>, b: Option<usize>) -> Option<usize> {
+    a.and_then(|x| b.map(|y| x + y))
 }

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -339,7 +339,9 @@ pub trait Property: Sized {
     fn cast_zeronotequal(self) -> Result<Self, ErrorKind>;
 
     /// Cast by changing `[X]` to `AndV([X], True)`
-    fn cast_true(self) -> Result<Self, ErrorKind>;
+    fn cast_true(self) -> Result<Self, ErrorKind> {
+        Self::and_v(self, Self::from_true())
+    }
 
     /// Cast by changing `[X]` to `or_i([X], 0)` or `or_i(0, [X])`
     fn cast_or_i_false(self) -> Result<Self, ErrorKind>;
@@ -347,13 +349,13 @@ pub trait Property: Sized {
     /// Cast by changing `[X]` to `or_i([X], 0)`. Default implementation
     /// simply passes through to `cast_or_i_false`
     fn cast_unlikely(self) -> Result<Self, ErrorKind> {
-        self.cast_or_i_false()
+        Self::or_i(self, Self::from_false())
     }
 
     /// Cast by changing `[X]` to `or_i(0, [X])`. Default implementation
     /// simply passes through to `cast_or_i_false`
     fn cast_likely(self) -> Result<Self, ErrorKind> {
-        self.cast_or_i_false()
+        Self::or_i(Self::from_false(), self)
     }
 
     /// Computes the type of an `AndB` fragment

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1517,7 +1517,7 @@ mod tests {
             keys.iter().map(|pubkey| Concrete::Key(*pubkey)).collect();
         let thresh_res: Result<SegwitMiniScript, _> =
             Concrete::Threshold(keys.len() - 1, keys).compile();
-        let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops_count_sat));
+        let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops.op_count()));
         assert_eq!(
             thresh_res,
             Err(CompilerError::LimitsExceeded),
@@ -1529,7 +1529,7 @@ mod tests {
         let keys: Vec<Concrete<bitcoin::PublicKey>> =
             keys.iter().map(|pubkey| Concrete::Key(*pubkey)).collect();
         let thresh_res = Concrete::Threshold(keys.len() - 1, keys).compile::<Legacy>();
-        let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops_count_sat));
+        let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops.op_count()));
         assert_eq!(
             thresh_res,
             Err(CompilerError::LimitsExceeded),


### PR DESCRIPTION
- Instead of explicitly counting all opcodes required while satisfaction,
we explicitly track only additional opcodes while satisfaction and
dissatisfaction.

- Removes some unnecessary code around wrapper casting

Double-checked and compared with the c++ codebase