### PR TITLE
Remove extern crates

### DIFF
--- a/examples/htlc.rs
+++ b/examples/htlc.rs
@@ -14,9 +14,6 @@
 
 //! Example: Create an HTLC with miniscript using the policy compiler
 
-extern crate bitcoin;
-extern crate miniscript;
-
 use bitcoin::Network;
 use miniscript::descriptor::Wsh;
 use miniscript::policy::{Concrete, Liftable};

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -14,9 +14,6 @@
 
 //! Example: Parsing a descriptor from a string
 
-use bitcoin;
-use miniscript;
-
 use miniscript::{descriptor::DescriptorType, Descriptor, DescriptorTrait};
 use std::str::FromStr;
 

--- a/examples/psbt.rs
+++ b/examples/psbt.rs
@@ -1,5 +1,3 @@
-use bitcoin;
-
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::hex::FromHex;
 use miniscript::psbt::PsbtExt;

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -14,9 +14,6 @@
 
 //! Example: Signing a 2-of-3 multisignature
 
-use bitcoin;
-use miniscript;
-
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::secp256k1; // secp256k1 re-exported from rust-bitcoin
 use miniscript::DescriptorTrait;

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -14,9 +14,6 @@
 
 //! Example: Verifying a signed transaction
 
-use bitcoin;
-use miniscript;
-
 use bitcoin::consensus::Decodable;
 use bitcoin::util::sighash;
 use bitcoin::{secp256k1, TxOut}; // secp256k1 re-exported from rust-bitcoin

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 
 pub use bitcoin;
 #[cfg(feature = "serde")]
-pub extern crate serde;
+pub use serde;
 #[cfg(all(test, feature = "unstable"))]
 extern crate test;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,6 @@
 //! ## Deriving an address from a descriptor
 //!
 //! ```rust
-//! extern crate bitcoin;
-//! extern crate miniscript;
-//!
 //! use std::str::FromStr;
 //! use miniscript::{DescriptorTrait};
 //!

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -172,9 +172,6 @@ impl<Ctx: ScriptContext> Miniscript<Ctx::Key, Ctx> {
     /// ## Decode/Parse a miniscript from script hex
     ///
     /// ```rust
-    /// extern crate bitcoin;
-    /// extern crate miniscript;
-    ///
     /// use miniscript::Miniscript;
     /// use miniscript::{Segwitv0, Tap};
     /// use miniscript::bitcoin::secp256k1::XOnlyPublicKey;


### PR DESCRIPTION
Now we have edition 2018 we can remove the usage of `extern crate`.

- Patch 1 does the `examples/`
- Patch 2 does the docs
- Patch 3 does the main crate