### PR TITLE
integration_test: Enable edition 2018

### DIFF
--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "integration_tests_miniscript"
 version = "0.1.0"
 authors = ["Steven Roose <steven@stevenroose.org>", "Sanket K <sanket1729@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 miniscript = {path = "../"}

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -12,11 +12,11 @@ use crate::test_util::TestData;
 struct StdLogger;
 
 impl log::Log for StdLogger {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
         metadata.target().contains("jsonrpc") || metadata.target().contains("bitcoincore_rpc")
     }
 
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         if self.enabled(record.metadata()) {
             println!(
                 "[{}][{}]: {}",

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -2,12 +2,6 @@
 //!
 //! This is how some external user would use rust-miniscript
 
-extern crate bitcoincore_rpc;
-extern crate log;
-
-extern crate bitcoin;
-extern crate miniscript;
-
 use bitcoincore_rpc::{Auth, Client, RpcApi};
 
 mod test_cpp;

--- a/integration_test/src/test_util.rs
+++ b/integration_test/src/test_util.rs
@@ -17,12 +17,10 @@
 //! The keys/hashes are automatically translated so that the tests knows how to satisfy things that don't end with !
 //!
 
-extern crate rand;
-
-use self::rand::RngCore;
 use bitcoin::hashes::{hex::ToHex, Hash};
 use miniscript::descriptor::{SinglePub, SinglePubKey};
 use miniscript::{Descriptor, DescriptorPublicKey, Miniscript, ScriptContext, TranslatePk};
+use rand::RngCore;
 use std::str::FromStr;
 
 use bitcoin;

--- a/integration_test/src/test_util.rs
+++ b/integration_test/src/test_util.rs
@@ -23,7 +23,6 @@ use miniscript::{Descriptor, DescriptorPublicKey, Miniscript, ScriptContext, Tra
 use rand::RngCore;
 use std::str::FromStr;
 
-use bitcoin;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::secp256k1;
 


### PR DESCRIPTION
As we did for the main crate, enable edition 2018 in the `integration_test` crate.