### PR TITLE
Use the term 'abstract' instead of 'semantic'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ See this (link)[https://github.com/rust-bitcoin/rust-miniscript/pull/349/commits
 - Changes to the miniscript type system to detect an invalid
   combination of heightlocks and timelocks
      - Lift miniscripts can now fail. Earlier it always succeeded and gave
-       the resulting Semantic Policy
+       the resulting Abstract Policy
      - Compiler will not compile policies that contain at least one
      unspendable path
 - Added support for Descriptor PublicKeys(xpub)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ including embedded Miniscripts
 * Parsing and serializing descriptors to a human-readable string format
 * Compilation of abstract spending policies to Miniscript (enabled by the
 `compiler` flag)
-* Semantic analysis of Miniscripts and spending policies, with user-defined
+* Abstract analysis of Miniscripts and spending policies, with user-defined
 public key types
 * Encoding and decoding Miniscript as Bitcoin Script, given key types that
 are convertible to `bitcoin::PublicKey`

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -38,8 +38,8 @@ name = "roundtrip_concrete"
 path = "fuzz_targets/roundtrip_concrete.rs"
 
 [[bin]]
-name = "roundtrip_semantic"
-path = "fuzz_targets/roundtrip_semantic.rs"
+name = "roundtrip_abstract"
+path = "fuzz_targets/roundtrip_abstract.rs"
 
 [[bin]]
 name = "compile_descriptor"

--- a/fuzz/fuzz_targets/roundtrip_abstract.rs
+++ b/fuzz/fuzz_targets/roundtrip_abstract.rs
@@ -3,7 +3,7 @@ extern crate miniscript;
 use miniscript::{policy, DummyKey};
 use std::str::FromStr;
 
-type DummyPolicy = policy::Semantic<DummyKey>;
+type DummyPolicy = policy::Abstract<DummyKey>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -24,7 +24,7 @@ use bitcoin::{self, blockdata::script, Script};
 
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::ScriptContext;
-use crate::policy::{semantic, Liftable};
+use crate::policy::{Abstract, Liftable};
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
     BareCtx, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey,
@@ -98,7 +98,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Bare<Pk> {
 }
 
 impl<Pk: MiniscriptKey> Liftable<Pk> for Bare<Pk> {
-    fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
+    fn lift(&self) -> Result<Abstract<Pk>, Error> {
         self.ms.lift()
     }
 }
@@ -300,8 +300,8 @@ impl<Pk: MiniscriptKey> fmt::Display for Pkh<Pk> {
 }
 
 impl<Pk: MiniscriptKey> Liftable<Pk> for Pkh<Pk> {
-    fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
-        Ok(semantic::Policy::KeyHash(self.pk.to_pubkeyhash()))
+    fn lift(&self) -> Result<Abstract<Pk>, Error> {
+        Ok(Abstract::KeyHash(self.pk.to_pubkeyhash()))
     }
 }
 

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -22,7 +22,7 @@ use bitcoin::{self, Script};
 
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::{ScriptContext, ScriptContextError};
-use crate::policy::{semantic, Liftable};
+use crate::policy::{Abstract, Liftable};
 use crate::util::varint_len;
 use crate::{
     Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, Segwitv0, ToPublicKey,
@@ -120,7 +120,7 @@ pub enum WshInner<Pk: MiniscriptKey> {
 }
 
 impl<Pk: MiniscriptKey> Liftable<Pk> for Wsh<Pk> {
-    fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
+    fn lift(&self) -> Result<Abstract<Pk>, Error> {
         match self.inner {
             WshInner::SortedMulti(ref smv) => smv.lift(),
             WshInner::Ms(ref ms) => ms.lift(),
@@ -407,8 +407,8 @@ impl<Pk: MiniscriptKey> fmt::Display for Wpkh<Pk> {
 }
 
 impl<Pk: MiniscriptKey> Liftable<Pk> for Wpkh<Pk> {
-    fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
-        Ok(semantic::Policy::KeyHash(self.pk.to_pubkeyhash()))
+    fn lift(&self) -> Result<Abstract<Pk>, Error> {
+        Ok(Abstract::KeyHash(self.pk.to_pubkeyhash()))
     }
 }
 

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -24,7 +24,7 @@ use bitcoin::{self, blockdata::script, Script};
 
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::ScriptContext;
-use crate::policy::{semantic, Liftable};
+use crate::policy::{Abstract, Liftable};
 use crate::push_opcode_size;
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
@@ -58,10 +58,10 @@ pub enum ShInner<Pk: MiniscriptKey> {
 }
 
 impl<Pk: MiniscriptKey> Liftable<Pk> for Sh<Pk> {
-    fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
+    fn lift(&self) -> Result<Abstract<Pk>, Error> {
         match self.inner {
             ShInner::Wsh(ref wsh) => wsh.lift(),
-            ShInner::Wpkh(ref pk) => Ok(semantic::Policy::KeyHash(pk.as_inner().to_pubkeyhash())),
+            ShInner::Wpkh(ref pk) => Ok(Abstract::KeyHash(pk.as_inner().to_pubkeyhash())),
             ShInner::SortedMulti(ref smv) => smv.lift(),
             ShInner::Ms(ref ms) => ms.lift(),
         }

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -24,7 +24,7 @@ use crate::expression;
 use crate::miniscript::{
     self, context::ScriptContext, decode::Terminal, limits::MAX_PUBKEYS_PER_MULTISIG,
 };
-use crate::policy;
+use crate::policy::{Abstract, Liftable};
 use crate::script_num_size;
 use crate::{
     errstr, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey,
@@ -210,14 +210,14 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> policy::Liftable<Pk> for SortedMultiVec<Pk, Ctx> {
-    fn lift(&self) -> Result<policy::semantic::Policy<Pk>, Error> {
-        let ret = policy::semantic::Policy::Threshold(
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for SortedMultiVec<Pk, Ctx> {
+    fn lift(&self) -> Result<Abstract<Pk>, Error> {
+        let ret = Abstract::Threshold(
             self.k,
             self.pks
                 .clone()
                 .into_iter()
-                .map(|k| policy::semantic::Policy::KeyHash(k.to_pubkeyhash()))
+                .map(|k| Abstract::KeyHash(k.to_pubkeyhash()))
                 .collect(),
         );
         Ok(ret)

--- a/src/policy/abstract.rs
+++ b/src/policy/abstract.rs
@@ -30,8 +30,8 @@ use super::ENTAILMENT_MAX_TERMINALS;
 /// Abstract policy which corresponds to the semantics of a Miniscript
 /// and which allows complex forms of analysis, e.g. filtering and
 /// normalization.
-/// Semantic policies store only hashes of keys to ensure that objects
-/// representing the same policy are lifted to the same `Semantic`,
+/// Abstract policies store only hashes of keys to ensure that objects
+/// representing the same policy are lifted to the same `Abstract`,
 /// regardless of their choice of `pk` or `pk_h` nodes.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Policy<Pk: MiniscriptKey> {
@@ -84,11 +84,11 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// # Example
     ///
     /// ```
-    /// use miniscript::{bitcoin::{hashes::hash160, PublicKey}, policy::semantic::Policy};
+    /// use miniscript::{bitcoin::{hashes::hash160, PublicKey}, policy::Abstract};
     /// use std::str::FromStr;
     /// let alice_pkh = "236ada020df3208d2517f4b0db03e16f92cd8cf1";
     /// let bob_pkh = "3e89b972416ae33870b4634d03b8cdc773200cac";
-    /// let placeholder_policy = Policy::<String>::from_str("and(pkh(alice_pkh),pkh(bob_pkh))").unwrap();
+    /// let placeholder_policy = Abstract::<String>::from_str("and(pkh(alice_pkh),pkh(bob_pkh))").unwrap();
     ///
     /// let real_policy = placeholder_policy.translate_pkh(|placeholder| match placeholder.as_str() {
     ///     "alice_pkh" => hash160::Hash::from_str(alice_pkh),
@@ -96,7 +96,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     ///     _ => panic!("unknown key hash!")
     /// }).unwrap();
     ///
-    /// let expected_policy = Policy::<PublicKey>::from_str(&format!("and(pkh({}),pkh({}))", alice_pkh, bob_pkh)).unwrap();
+    /// let expected_policy = Abstract::<PublicKey>::from_str(&format!("and(pkh({}),pkh({}))", alice_pkh, bob_pkh)).unwrap();
     /// assert_eq!(real_policy, expected_policy);
     /// ```
     pub fn translate_pkh<Fpkh, Q, E>(&self, mut translatefpkh: Fpkh) -> Result<Policy<Q>, E>
@@ -304,7 +304,7 @@ where
     }
 }
 
-serde_string_impl_pk!(Policy, "a miniscript semantic policy");
+serde_string_impl_pk!(Policy, "a miniscript abstract policy");
 
 impl<Pk> expression::FromTree for Policy<Pk>
 where
@@ -369,10 +369,10 @@ where
 
                 let thresh = expression::parse_num(top.args[0].name)?;
 
-                // thresh(1) and thresh(n) are disallowed in semantic policies
+                // thresh(1) and thresh(n) are disallowed in abstract policies
                 if thresh <= 1 || thresh >= (nsubs as u32 - 1) {
                     return Err(errstr(
-                        "Semantic Policy thresh cannot have k = 1 or k =n, use `and`/`or` instead",
+                        "Abstract Policy thresh cannot have k = 1 or k =n, use `and`/`or` instead",
                     ));
                 }
                 if thresh >= (nsubs as u32) {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -79,9 +79,9 @@ pub enum PolicyError {
     ZeroTime,
     /// `after` fragment can only have ` n < 2^31`
     TimeTooFar,
-    /// Semantic Policy Error: `And` `Or` fragments must take args: k > 1
+    /// Abstract Policy Error: `And` `Or` fragments must take args: k > 1
     InsufficientArgsforAnd,
-    /// Semantic Policy Error: `And` `Or` fragments must take args: k > 1
+    /// Abstract Policy Error: `And` `Or` fragments must take args: k > 1
     InsufficientArgsforOr,
     /// Entailment max terminals exceeded
     EntailmentMaxTerminals,
@@ -109,10 +109,10 @@ impl fmt::Display for PolicyError {
             }
             PolicyError::ZeroTime => f.write_str("Time must be greater than 0; n > 0"),
             PolicyError::InsufficientArgsforAnd => {
-                f.write_str("Semantic Policy 'And' fragment must have at least 2 args ")
+                f.write_str("Abstract Policy 'And' fragment must have at least 2 args ")
             }
             PolicyError::InsufficientArgsforOr => {
-                f.write_str("Semantic Policy 'Or' fragment must have at least 2 args ")
+                f.write_str("Abstract Policy 'Or' fragment must have at least 2 args ")
             }
             PolicyError::EntailmentMaxTerminals => write!(
                 f,


### PR DESCRIPTION
Currently we are introducing a new term 'semantic' for what
is (according to the code comment) typically referred to as 'abstract'.
The justification give is that `abstract` is a reserved Rust keyword.

Rust provides a mechanism for using keywords as identifiers, one just
has to prefix with `r#`. Also, in this case we have aliases for abstract
and concrete `Policy` already so we barely ever need the `r#` trick.

Use the term 'abstract' instead of 'semantic', involves:

- Rename module `semantic` -> `abstract`
- Rename fuzz target `roundtrip_semantic.rs` -> `roundtrip_abstract.rs`
- Rename type `Semantic` -> `Abstract`
- Use `Abstract` everywhere instead of `semantic::Policy`