### PR TITLE
Make the integration script more quiet

### DIFF
--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -9,8 +9,6 @@ mkdir -p ${TESTDIR}/1
 # To kill any remaining open bitcoind.
 killall -9 bitcoind 2> /dev/null
 
-echo $PATH
-
 BLOCKFILTERARG=""
 if bitcoind -version | grep -q "v0\.\(19\|2\)"; then
     BLOCKFILTERARG="-blockfilterindex=1"

--- a/integration_test/run.sh
+++ b/integration_test/run.sh
@@ -7,7 +7,7 @@ rm -rf ${TESTDIR}
 mkdir -p ${TESTDIR}/1
 
 # To kill any remaining open bitcoind.
-killall -9 bitcoind
+killall -9 bitcoind 2> /dev/null
 
 echo $PATH
 


### PR DESCRIPTION
Currently we have two initial output lines when running the integration test script. The first is confusing (to me at least) and the second is unnecessary it seems (please correct me if I am wrong).

- Patch one removes the warning: `bitcoind: no process found`
- Patch two removes the printing of `$PATH`