### PR TITLE
Shorten translatefpk identifier

### DIFF
--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -217,8 +217,8 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Bare<P> {
 
     fn translate_pk<Fpk, Fpkh, E>(
         &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
+        mut fpk: Fpk,
+        mut fpkh: Fpkh,
     ) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
@@ -227,7 +227,7 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Bare<P> {
     {
         Ok(Bare::new(
             self.ms
-                .translate_pk(&mut translatefpk, &mut translatefpkh)?,
+                .translate_pk(&mut fpk, &mut fpkh)?,
         )
         .expect("Translation cannot fail inside Bare"))
     }
@@ -429,14 +429,14 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Pkh<P> {
 
     fn translate_pk<Fpk, Fpkh, E>(
         &self,
-        mut translatefpk: Fpk,
-        _translatefpkh: Fpkh,
+        mut fpk: Fpk,
+        _fpkh: Fpkh,
     ) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
         Q: MiniscriptKey,
     {
-        Ok(Pkh::new(translatefpk(&self.pk)?))
+        Ok(Pkh::new(fpk(&self.pk)?))
     }
 }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -443,13 +443,13 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
 impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Descriptor<P> {
     type Output = Descriptor<Q>;
     /// Convert a descriptor using abstract keys to one using specific keys
-    /// This will panic if translatefpk returns an uncompressed key when
+    /// This will panic if fpk returns an uncompressed key when
     /// converting to a Segwit descriptor. To prevent this panic, ensure
-    /// translatefpk returns an error in this case instead.
+    /// fpk returns an error in this case instead.
     fn translate_pk<Fpk, Fpkh, E>(
         &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
+        mut fpk: Fpk,
+        mut fpkh: Fpkh,
     ) -> Result<Descriptor<Q>, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
@@ -458,22 +458,22 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Descriptor<P> {
     {
         let desc = match *self {
             Descriptor::Bare(ref bare) => {
-                Descriptor::Bare(bare.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                Descriptor::Bare(bare.translate_pk(&mut fpk, &mut fpkh)?)
             }
             Descriptor::Pkh(ref pk) => {
-                Descriptor::Pkh(pk.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                Descriptor::Pkh(pk.translate_pk(&mut fpk, &mut fpkh)?)
             }
             Descriptor::Wpkh(ref pk) => {
-                Descriptor::Wpkh(pk.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                Descriptor::Wpkh(pk.translate_pk(&mut fpk, &mut fpkh)?)
             }
             Descriptor::Sh(ref sh) => {
-                Descriptor::Sh(sh.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                Descriptor::Sh(sh.translate_pk(&mut fpk, &mut fpkh)?)
             }
             Descriptor::Wsh(ref wsh) => {
-                Descriptor::Wsh(wsh.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                Descriptor::Wsh(wsh.translate_pk(&mut fpk, &mut fpkh)?)
             }
             Descriptor::Tr(ref tr) => {
-                Descriptor::Tr(tr.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                Descriptor::Tr(tr.translate_pk(&mut fpk, &mut fpkh)?)
             }
         };
         Ok(desc)

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -302,8 +302,8 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Wsh<P> {
 
     fn translate_pk<Fpk, Fpkh, E>(
         &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
+        mut fpk: Fpk,
+        mut fpkh: Fpkh,
     ) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
@@ -312,10 +312,10 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Wsh<P> {
     {
         let inner = match self.inner {
             WshInner::SortedMulti(ref smv) => {
-                WshInner::SortedMulti(smv.translate_pk(&mut translatefpk)?)
+                WshInner::SortedMulti(smv.translate_pk(&mut fpk)?)
             }
             WshInner::Ms(ref ms) => {
-                WshInner::Ms(ms.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                WshInner::Ms(ms.translate_pk(&mut fpk, &mut fpkh)?)
             }
         };
         Ok(Wsh { inner: inner })
@@ -539,14 +539,14 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Wpkh<P> {
 
     fn translate_pk<Fpk, Fpkh, E>(
         &self,
-        mut translatefpk: Fpk,
-        _translatefpkh: Fpkh,
+        mut fpk: Fpk,
+        _fpkh: Fpkh,
     ) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
         Q: MiniscriptKey,
     {
-        Ok(Wpkh::new(translatefpk(&self.pk)?).expect("Uncompressed keys in Wpkh"))
+        Ok(Wpkh::new(fpk(&self.pk)?).expect("Uncompressed keys in Wpkh"))
     }
 }

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -426,8 +426,8 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Sh<P> {
 
     fn translate_pk<Fpk, Fpkh, E>(
         &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
+        mut fpk: Fpk,
+        mut fpkh: Fpkh,
     ) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
@@ -436,16 +436,16 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Sh<P> {
     {
         let inner = match self.inner {
             ShInner::Wsh(ref wsh) => {
-                ShInner::Wsh(wsh.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                ShInner::Wsh(wsh.translate_pk(&mut fpk, &mut fpkh)?)
             }
             ShInner::Wpkh(ref wpkh) => {
-                ShInner::Wpkh(wpkh.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                ShInner::Wpkh(wpkh.translate_pk(&mut fpk, &mut fpkh)?)
             }
             ShInner::SortedMulti(ref smv) => {
-                ShInner::SortedMulti(smv.translate_pk(&mut translatefpk)?)
+                ShInner::SortedMulti(smv.translate_pk(&mut fpk)?)
             }
             ShInner::Ms(ref ms) => {
-                ShInner::Ms(ms.translate_pk(&mut translatefpk, &mut translatefpkh)?)
+                ShInner::Ms(ms.translate_pk(&mut fpk, &mut fpkh)?)
             }
         };
         Ok(Sh { inner: inner })

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -90,18 +90,18 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
         pks.map(|pks| SortedMultiVec::new(k as usize, pks))?
     }
 
-    /// This will panic if translatefpk returns an uncompressed key when
+    /// This will panic if fpk returns an uncompressed key when
     /// converting to a Segwit descriptor. To prevent this panic, ensure
-    /// translatefpk returns an error in this case instead.
+    /// fpk returns an error in this case instead.
     pub fn translate_pk<FPk, Q, FuncError>(
         &self,
-        translatefpk: &mut FPk,
+        fpk: &mut FPk,
     ) -> Result<SortedMultiVec<Q, Ctx>, FuncError>
     where
         FPk: FnMut(&Pk) -> Result<Q, FuncError>,
         Q: MiniscriptKey,
     {
-        let pks: Result<Vec<Q>, _> = self.pks.iter().map(&mut *translatefpk).collect();
+        let pks: Result<Vec<Q>, _> = self.pks.iter().map(&mut *fpk).collect();
         Ok(SortedMultiVec {
             k: self.k,
             pks: pks?,

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -129,8 +129,8 @@ impl<Pk: MiniscriptKey> TapTree<Pk> {
     // Helper function to translate keys
     fn translate_helper<FPk, FPkh, Q, Error>(
         &self,
-        translatefpk: &mut FPk,
-        translatefpkh: &mut FPkh,
+        fpk: &mut FPk,
+        fpkh: &mut FPkh,
     ) -> Result<TapTree<Q>, Error>
     where
         FPk: FnMut(&Pk) -> Result<Q, Error>,
@@ -139,11 +139,11 @@ impl<Pk: MiniscriptKey> TapTree<Pk> {
     {
         let frag = match self {
             TapTree::Tree(l, r) => TapTree::Tree(
-                Arc::new(l.translate_helper(translatefpk, translatefpkh)?),
-                Arc::new(r.translate_helper(translatefpk, translatefpkh)?),
+                Arc::new(l.translate_helper(fpk, fpkh)?),
+                Arc::new(r.translate_helper(fpk, fpkh)?),
             ),
             TapTree::Leaf(ms) => {
-                TapTree::Leaf(Arc::new(ms.translate_pk(translatefpk, translatefpkh)?))
+                TapTree::Leaf(Arc::new(ms.translate_pk(fpk, fpkh)?))
             }
         };
         Ok(frag)
@@ -657,8 +657,8 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Tr<P> {
 
     fn translate_pk<Fpk, Fpkh, E>(
         &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
+        mut fpk: Fpk,
+        mut fpkh: Fpkh,
     ) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
@@ -666,9 +666,9 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Tr<P> {
         Q: MiniscriptKey,
     {
         let translate_desc = Tr {
-            internal_key: translatefpk(&self.internal_key)?,
+            internal_key: fpk(&self.internal_key)?,
             tree: match &self.tree {
-                Some(tree) => Some(tree.translate_helper(&mut translatefpk, &mut translatefpkh)?),
+                Some(tree) => Some(tree.translate_helper(&mut fpk, &mut fpkh)?),
                 None => None,
             },
             spend_info: Mutex::new(None),

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -70,14 +70,14 @@ impl<Pk: MiniscriptKey, Q: MiniscriptKey, Ctx: ScriptContext> TranslatePk<Pk, Q>
     /// Segwit Miniscript using uncompressed public keys
     fn translate_pk<FPk, FPkh, FuncError>(
         &self,
-        mut translatefpk: FPk,
-        mut translatefpkh: FPkh,
+        mut fpk: FPk,
+        mut fpkh: FPkh,
     ) -> Result<Self::Output, FuncError>
     where
         FPk: FnMut(&Pk) -> Result<Q, FuncError>,
         FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, FuncError>,
     {
-        self.real_translate_pk(&mut translatefpk, &mut translatefpkh)
+        self.real_translate_pk(&mut fpk, &mut fpkh)
     }
 }
 
@@ -129,8 +129,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     }
     pub(super) fn real_translate_pk<FPk, FPkh, Q, Error, CtxQ>(
         &self,
-        translatefpk: &mut FPk,
-        translatefpkh: &mut FPkh,
+        fpk: &mut FPk,
+        fpkh: &mut FPkh,
     ) -> Result<Terminal<Q, CtxQ>, Error>
     where
         FPk: FnMut(&Pk) -> Result<Q, Error>,
@@ -139,8 +139,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
         CtxQ: ScriptContext,
     {
         let frag: Terminal<Q, CtxQ> = match *self {
-            Terminal::PkK(ref p) => Terminal::PkK(translatefpk(p)?),
-            Terminal::PkH(ref p) => Terminal::PkH(translatefpkh(p)?),
+            Terminal::PkK(ref p) => Terminal::PkK(fpk(p)?),
+            Terminal::PkH(ref p) => Terminal::PkH(fpkh(p)?),
             Terminal::After(n) => Terminal::After(n),
             Terminal::Older(n) => Terminal::Older(n),
             Terminal::Sha256(x) => Terminal::Sha256(x),
@@ -150,73 +150,73 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             Terminal::True => Terminal::True,
             Terminal::False => Terminal::False,
             Terminal::Alt(ref sub) => Terminal::Alt(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
+                sub.real_translate_pk(fpk, fpkh)?,
             )),
             Terminal::Swap(ref sub) => Terminal::Swap(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
+                sub.real_translate_pk(fpk, fpkh)?,
             )),
             Terminal::Check(ref sub) => Terminal::Check(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
+                sub.real_translate_pk(fpk, fpkh)?,
             )),
             Terminal::DupIf(ref sub) => Terminal::DupIf(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
+                sub.real_translate_pk(fpk, fpkh)?,
             )),
             Terminal::Verify(ref sub) => Terminal::Verify(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
+                sub.real_translate_pk(fpk, fpkh)?,
             )),
             Terminal::NonZero(ref sub) => Terminal::NonZero(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
+                sub.real_translate_pk(fpk, fpkh)?,
             )),
             Terminal::ZeroNotEqual(ref sub) => Terminal::ZeroNotEqual(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
+                sub.real_translate_pk(fpk, fpkh)?,
             )),
             Terminal::AndV(ref left, ref right) => Terminal::AndV(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::AndB(ref left, ref right) => Terminal::AndB(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::AndOr(ref a, ref b, ref c) => Terminal::AndOr(
-                Arc::new(a.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(b.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(c.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(a.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(b.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(c.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::OrB(ref left, ref right) => Terminal::OrB(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::OrD(ref left, ref right) => Terminal::OrD(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::OrC(ref left, ref right) => Terminal::OrC(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::OrI(ref left, ref right) => Terminal::OrI(
                 Arc::new(
-                    left.real_translate_pk(&mut *&mut *translatefpk, &mut *&mut *translatefpkh)?,
+                    left.real_translate_pk(&mut *&mut *fpk, &mut *&mut *fpkh)?,
                 ),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::Thresh(k, ref subs) => {
                 let subs: Result<Vec<Arc<Miniscript<Q, _>>>, _> = subs
                     .iter()
                     .map(|s| {
-                        s.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)
+                        s.real_translate_pk(&mut *fpk, &mut *fpkh)
                             .and_then(|x| Ok(Arc::new(x)))
                     })
                     .collect();
                 Terminal::Thresh(k, subs?)
             }
             Terminal::Multi(k, ref keys) => {
-                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut *translatefpk).collect();
+                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut *fpk).collect();
                 Terminal::Multi(k, keys?)
             }
             Terminal::MultiA(k, ref keys) => {
-                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut *translatefpk).collect();
+                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut *fpk).collect();
                 Terminal::MultiA(k, keys?)
             }
         };

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -279,19 +279,19 @@ impl<Pk: MiniscriptKey, Q: MiniscriptKey, Ctx: ScriptContext> TranslatePk<Pk, Q>
 {
     type Output = Miniscript<Q, Ctx>;
 
-    /// This will panic if translatefpk returns an uncompressed key when
+    /// This will panic if fpk returns an uncompressed key when
     /// converting to a Segwit descriptor. To prevent this panic, ensure
-    /// translatefpk returns an error in this case instead.
+    /// fpk returns an error in this case instead.
     fn translate_pk<FPk, FPkh, FuncError>(
         &self,
-        mut translatefpk: FPk,
-        mut translatefpkh: FPkh,
+        mut fpk: FPk,
+        mut fpkh: FPkh,
     ) -> Result<Self::Output, FuncError>
     where
         FPk: FnMut(&Pk) -> Result<Q, FuncError>,
         FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, FuncError>,
     {
-        self.real_translate_pk(&mut translatefpk, &mut translatefpkh)
+        self.real_translate_pk(&mut fpk, &mut fpkh)
     }
 }
 
@@ -306,8 +306,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 
     pub(crate) fn real_translate_pk<FPk, FPkh, Q, FuncError, CtxQ>(
         &self,
-        translatefpk: &mut FPk,
-        translatefpkh: &mut FPkh,
+        fpk: &mut FPk,
+        fpkh: &mut FPkh,
     ) -> Result<Miniscript<Q, CtxQ>, FuncError>
     where
         FPk: FnMut(&Pk) -> Result<Q, FuncError>,
@@ -315,7 +315,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         Q: MiniscriptKey,
         CtxQ: ScriptContext,
     {
-        let inner = self.node.real_translate_pk(translatefpk, translatefpkh)?;
+        let inner = self.node.real_translate_pk(fpk, fpkh)?;
         let ms = Miniscript {
             //directly copying the type and ext is safe because translating public
             //key should not change any properties

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -99,15 +99,15 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// let expected_policy = Policy::<PublicKey>::from_str(&format!("and(pkh({}),pkh({}))", alice_pkh, bob_pkh)).unwrap();
     /// assert_eq!(real_policy, expected_policy);
     /// ```
-    pub fn translate_pkh<Fpkh, Q, E>(&self, mut translatefpkh: Fpkh) -> Result<Policy<Q>, E>
+    pub fn translate_pkh<Fpkh, Q, E>(&self, mut fpkh: Fpkh) -> Result<Policy<Q>, E>
     where
         Fpkh: FnMut(&Pk::Hash) -> Result<Q::Hash, E>,
         Q: MiniscriptKey,
     {
-        self._translate_pkh(&mut translatefpkh)
+        self._translate_pkh(&mut fpkh)
     }
 
-    fn _translate_pkh<Fpkh, Q, E>(&self, translatefpkh: &mut Fpkh) -> Result<Policy<Q>, E>
+    fn _translate_pkh<Fpkh, Q, E>(&self, fpkh: &mut Fpkh) -> Result<Policy<Q>, E>
     where
         Fpkh: FnMut(&Pk::Hash) -> Result<Q::Hash, E>,
         Q: MiniscriptKey,
@@ -115,7 +115,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         match *self {
             Policy::Unsatisfiable => Ok(Policy::Unsatisfiable),
             Policy::Trivial => Ok(Policy::Trivial),
-            Policy::KeyHash(ref pkh) => translatefpkh(pkh).map(Policy::KeyHash),
+            Policy::KeyHash(ref pkh) => fpkh(pkh).map(Policy::KeyHash),
             Policy::Sha256(ref h) => Ok(Policy::Sha256(h.clone())),
             Policy::Hash256(ref h) => Ok(Policy::Hash256(h.clone())),
             Policy::Ripemd160(ref h) => Ok(Policy::Ripemd160(h.clone())),
@@ -125,7 +125,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             Policy::Threshold(k, ref subs) => {
                 let new_subs: Result<Vec<Policy<Q>>, _> = subs
                     .iter()
-                    .map(|sub| sub._translate_pkh(translatefpkh))
+                    .map(|sub| sub._translate_pkh(fpkh))
                     .collect();
                 new_subs.map(|ok| Policy::Threshold(k, ok))
             }


### PR DESCRIPTION
Recently we refactored the translate pk traits, in doing so the identifier `fpk` and `fpkh` were favoured over `translatefpk`, and
`translatefpkh` respectively. I missed a bunch of places.

Be uniform across the code base and use the identifiers `fpk` and `fpkh`.

This patch is the result of applying `s/translatefpk/fpk/g` to all source files.

Refactor only, no logic changes.
