### PR TITLE
Refactor implementations of `TranslatePk`

### DIFF
--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -212,24 +212,21 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Bare<Pk> {
     }
 }
 
-impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Bare<P> {
+impl<P, Q> TranslatePk<P, Q> for Bare<P>
+where
+    P: MiniscriptKey,
+    Q: MiniscriptKey,
+{
     type Output = Bare<Q>;
 
-    fn translate_pk<Fpk, Fpkh, E>(
-        &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
-    ) -> Result<Self::Output, E>
+    fn translate_pk<Fpk, Fpkh, E>(&self, mut fpk: Fpk, mut fpkh: Fpkh) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
         Q: MiniscriptKey,
     {
-        Ok(Bare::new(
-            self.ms
-                .translate_pk(&mut translatefpk, &mut translatefpkh)?,
-        )
-        .expect("Translation cannot fail inside Bare"))
+        Ok(Bare::new(self.ms.translate_pk(&mut fpk, &mut fpkh)?)
+            .expect("Translation cannot fail inside Bare"))
     }
 }
 
@@ -424,19 +421,18 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Pkh<Pk> {
     }
 }
 
-impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Pkh<P> {
+impl<P, Q> TranslatePk<P, Q> for Pkh<P>
+where
+    P: MiniscriptKey,
+    Q: MiniscriptKey,
+{
     type Output = Pkh<Q>;
 
-    fn translate_pk<Fpk, Fpkh, E>(
-        &self,
-        mut translatefpk: Fpk,
-        _translatefpkh: Fpkh,
-    ) -> Result<Self::Output, E>
+    fn translate_pk<Fpk, Fpkh, E>(&self, mut fpk: Fpk, _fpkh: Fpkh) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
-        Q: MiniscriptKey,
     {
-        Ok(Pkh::new(translatefpk(&self.pk)?))
+        Ok(Pkh::new(fpk(&self.pk)?))
     }
 }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -440,41 +440,31 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
     }
 }
 
-impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Descriptor<P> {
+impl<P, Q> TranslatePk<P, Q> for Descriptor<P>
+where
+    P: MiniscriptKey,
+    Q: MiniscriptKey,
+{
     type Output = Descriptor<Q>;
-    /// Convert a descriptor using abstract keys to one using specific keys
-    /// This will panic if translatefpk returns an uncompressed key when
-    /// converting to a Segwit descriptor. To prevent this panic, ensure
-    /// translatefpk returns an error in this case instead.
-    fn translate_pk<Fpk, Fpkh, E>(
-        &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
-    ) -> Result<Descriptor<Q>, E>
+    /// Converts a descriptor using abstract keys to one using specific keys.
+    ///
+    /// # Panics
+    ///
+    /// If `fpk` returns an uncompressed key when converting to a Segwit descriptor.
+    /// To prevent this panic, ensure `fpk` returns an error in this case instead.
+    fn translate_pk<Fpk, Fpkh, E>(&self, mut fpk: Fpk, mut fpkh: Fpkh) -> Result<Descriptor<Q>, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
         Q: MiniscriptKey,
     {
         let desc = match *self {
-            Descriptor::Bare(ref bare) => {
-                Descriptor::Bare(bare.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
-            Descriptor::Pkh(ref pk) => {
-                Descriptor::Pkh(pk.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
-            Descriptor::Wpkh(ref pk) => {
-                Descriptor::Wpkh(pk.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
-            Descriptor::Sh(ref sh) => {
-                Descriptor::Sh(sh.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
-            Descriptor::Wsh(ref wsh) => {
-                Descriptor::Wsh(wsh.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
-            Descriptor::Tr(ref tr) => {
-                Descriptor::Tr(tr.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
+            Descriptor::Bare(ref bare) => Descriptor::Bare(bare.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Pkh(ref pk) => Descriptor::Pkh(pk.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Wpkh(ref pk) => Descriptor::Wpkh(pk.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Sh(ref sh) => Descriptor::Sh(sh.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Wsh(ref wsh) => Descriptor::Wsh(wsh.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Tr(ref tr) => Descriptor::Tr(tr.translate_pk(&mut fpk, &mut fpkh)?),
         };
         Ok(desc)
     }

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -421,32 +421,23 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Sh<Pk> {
     }
 }
 
-impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Sh<P> {
+impl<P, Q> TranslatePk<P, Q> for Sh<P>
+where
+    P: MiniscriptKey,
+    Q: MiniscriptKey,
+{
     type Output = Sh<Q>;
 
-    fn translate_pk<Fpk, Fpkh, E>(
-        &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
-    ) -> Result<Self::Output, E>
+    fn translate_pk<Fpk, Fpkh, E>(&self, mut fpk: Fpk, mut fpkh: Fpkh) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
-        Q: MiniscriptKey,
     {
         let inner = match self.inner {
-            ShInner::Wsh(ref wsh) => {
-                ShInner::Wsh(wsh.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
-            ShInner::Wpkh(ref wpkh) => {
-                ShInner::Wpkh(wpkh.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
-            ShInner::SortedMulti(ref smv) => {
-                ShInner::SortedMulti(smv.translate_pk(&mut translatefpk)?)
-            }
-            ShInner::Ms(ref ms) => {
-                ShInner::Ms(ms.translate_pk(&mut translatefpk, &mut translatefpkh)?)
-            }
+            ShInner::Wsh(ref wsh) => ShInner::Wsh(wsh.translate_pk(&mut fpk, &mut fpkh)?),
+            ShInner::Wpkh(ref wpkh) => ShInner::Wpkh(wpkh.translate_pk(&mut fpk, &mut fpkh)?),
+            ShInner::SortedMulti(ref smv) => ShInner::SortedMulti(smv.translate_pk(&mut fpk)?),
+            ShInner::Ms(ref ms) => ShInner::Ms(ms.translate_pk(&mut fpk, &mut fpkh)?),
         };
         Ok(Sh { inner: inner })
     }

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -90,18 +90,18 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
         pks.map(|pks| SortedMultiVec::new(k as usize, pks))?
     }
 
-    /// This will panic if translatefpk returns an uncompressed key when
+    /// This will panic if fpk returns an uncompressed key when
     /// converting to a Segwit descriptor. To prevent this panic, ensure
-    /// translatefpk returns an error in this case instead.
+    /// fpk returns an error in this case instead.
     pub fn translate_pk<FPk, Q, FuncError>(
         &self,
-        translatefpk: &mut FPk,
+        fpk: &mut FPk,
     ) -> Result<SortedMultiVec<Q, Ctx>, FuncError>
     where
         FPk: FnMut(&Pk) -> Result<Q, FuncError>,
         Q: MiniscriptKey,
     {
-        let pks: Result<Vec<Q>, _> = self.pks.iter().map(&mut *translatefpk).collect();
+        let pks: Result<Vec<Q>, _> = self.pks.iter().map(&mut *fpk).collect();
         Ok(SortedMultiVec {
             k: self.k,
             pks: pks?,

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -652,23 +652,22 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Tr<Pk> {
     }
 }
 
-impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Tr<P> {
+impl<P, Q> TranslatePk<P, Q> for Tr<P>
+where
+    P: MiniscriptKey,
+    Q: MiniscriptKey,
+{
     type Output = Tr<Q>;
 
-    fn translate_pk<Fpk, Fpkh, E>(
-        &self,
-        mut translatefpk: Fpk,
-        mut translatefpkh: Fpkh,
-    ) -> Result<Self::Output, E>
+    fn translate_pk<Fpk, Fpkh, E>(&self, mut fpk: Fpk, mut fpkh: Fpkh) -> Result<Self::Output, E>
     where
         Fpk: FnMut(&P) -> Result<Q, E>,
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
-        Q: MiniscriptKey,
     {
         let translate_desc = Tr {
-            internal_key: translatefpk(&self.internal_key)?,
+            internal_key: fpk(&self.internal_key)?,
             tree: match &self.tree {
-                Some(tree) => Some(tree.translate_helper(&mut translatefpk, &mut translatefpkh)?),
+                Some(tree) => Some(tree.translate_helper(&mut fpk, &mut fpkh)?),
                 None => None,
             },
             spend_info: Mutex::new(None),

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -129,8 +129,8 @@ impl<Pk: MiniscriptKey> TapTree<Pk> {
     // Helper function to translate keys
     fn translate_helper<FPk, FPkh, Q, Error>(
         &self,
-        translatefpk: &mut FPk,
-        translatefpkh: &mut FPkh,
+        fpk: &mut FPk,
+        fpkh: &mut FPkh,
     ) -> Result<TapTree<Q>, Error>
     where
         FPk: FnMut(&Pk) -> Result<Q, Error>,
@@ -139,12 +139,10 @@ impl<Pk: MiniscriptKey> TapTree<Pk> {
     {
         let frag = match self {
             TapTree::Tree(l, r) => TapTree::Tree(
-                Arc::new(l.translate_helper(translatefpk, translatefpkh)?),
-                Arc::new(r.translate_helper(translatefpk, translatefpkh)?),
+                Arc::new(l.translate_helper(fpk, fpkh)?),
+                Arc::new(r.translate_helper(fpk, fpkh)?),
             ),
-            TapTree::Leaf(ms) => {
-                TapTree::Leaf(Arc::new(ms.translate_pk(translatefpk, translatefpkh)?))
-            }
+            TapTree::Leaf(ms) => TapTree::Leaf(Arc::new(ms.translate_pk(fpk, fpkh)?)),
         };
         Ok(frag)
     }

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -22,6 +22,7 @@ use crate::miniscript::iter::PkPkh;
 use crate::{Miniscript, MiniscriptKey, ScriptContext};
 use std::collections::HashSet;
 use std::fmt;
+
 /// Possible reasons Miniscript guarantees can fail
 /// We currently mark Miniscript as Non-Analyzable if
 /// 1. It is unsafe(does not require a digital signature to spend it)

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -127,6 +127,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             }
         }
     }
+
     pub(super) fn real_translate_pk<FPk, FPkh, Q, Error, CtxQ>(
         &self,
         translatefpk: &mut FPk,

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -60,24 +60,25 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     }
 }
 
-impl<Pk: MiniscriptKey, Q: MiniscriptKey, Ctx: ScriptContext> TranslatePk<Pk, Q>
-    for Terminal<Pk, Ctx>
+impl<Pk, Q, Ctx> TranslatePk<Pk, Q> for Terminal<Pk, Ctx>
+where
+    Pk: MiniscriptKey,
+    Q: MiniscriptKey,
+    Ctx: ScriptContext,
 {
     type Output = Terminal<Q, Ctx>;
 
-    /// Convert an AST element with one public key type to one of another
-    /// public key type .This will panic while converting to
-    /// Segwit Miniscript using uncompressed public keys
-    fn translate_pk<FPk, FPkh, FuncError>(
-        &self,
-        mut translatefpk: FPk,
-        mut translatefpkh: FPkh,
-    ) -> Result<Self::Output, FuncError>
+    /// Converts an AST element with one public key type to one of another public key type.
+    ///
+    /// # Panics
+    ///
+    /// While converting to Segwit Miniscript using uncompressed public keys.
+    fn translate_pk<Fpk, Fpkh, E>(&self, mut fpk: Fpk, mut fpkh: Fpkh) -> Result<Self::Output, E>
     where
-        FPk: FnMut(&Pk) -> Result<Q, FuncError>,
-        FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, FuncError>,
+        Fpk: FnMut(&Pk) -> Result<Q, E>,
+        Fpkh: FnMut(&Pk::Hash) -> Result<Q::Hash, E>,
     {
-        self.real_translate_pk(&mut translatefpk, &mut translatefpkh)
+        self.real_translate_pk(&mut fpk, &mut fpkh)
     }
 }
 
@@ -128,20 +129,20 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
         }
     }
 
-    pub(super) fn real_translate_pk<FPk, FPkh, Q, Error, CtxQ>(
+    pub(super) fn real_translate_pk<Fpk, Fpkh, Q, E, CtxQ>(
         &self,
-        translatefpk: &mut FPk,
-        translatefpkh: &mut FPkh,
-    ) -> Result<Terminal<Q, CtxQ>, Error>
+        fpk: &mut Fpk,
+        fpkh: &mut Fpkh,
+    ) -> Result<Terminal<Q, CtxQ>, E>
     where
-        FPk: FnMut(&Pk) -> Result<Q, Error>,
-        FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, Error>,
+        Fpk: FnMut(&Pk) -> Result<Q, E>,
+        Fpkh: FnMut(&Pk::Hash) -> Result<Q::Hash, E>,
         Q: MiniscriptKey,
         CtxQ: ScriptContext,
     {
         let frag: Terminal<Q, CtxQ> = match *self {
-            Terminal::PkK(ref p) => Terminal::PkK(translatefpk(p)?),
-            Terminal::PkH(ref p) => Terminal::PkH(translatefpkh(p)?),
+            Terminal::PkK(ref p) => Terminal::PkK(fpk(p)?),
+            Terminal::PkH(ref p) => Terminal::PkH(fpkh(p)?),
             Terminal::After(n) => Terminal::After(n),
             Terminal::Older(n) => Terminal::Older(n),
             Terminal::Sha256(x) => Terminal::Sha256(x),
@@ -150,74 +151,68 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             Terminal::Hash160(x) => Terminal::Hash160(x),
             Terminal::True => Terminal::True,
             Terminal::False => Terminal::False,
-            Terminal::Alt(ref sub) => Terminal::Alt(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
-            )),
-            Terminal::Swap(ref sub) => Terminal::Swap(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
-            )),
-            Terminal::Check(ref sub) => Terminal::Check(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
-            )),
-            Terminal::DupIf(ref sub) => Terminal::DupIf(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
-            )),
-            Terminal::Verify(ref sub) => Terminal::Verify(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
-            )),
-            Terminal::NonZero(ref sub) => Terminal::NonZero(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
-            )),
-            Terminal::ZeroNotEqual(ref sub) => Terminal::ZeroNotEqual(Arc::new(
-                sub.real_translate_pk(translatefpk, translatefpkh)?,
-            )),
+            Terminal::Alt(ref sub) => Terminal::Alt(Arc::new(sub.real_translate_pk(fpk, fpkh)?)),
+            Terminal::Swap(ref sub) => Terminal::Swap(Arc::new(sub.real_translate_pk(fpk, fpkh)?)),
+            Terminal::Check(ref sub) => {
+                Terminal::Check(Arc::new(sub.real_translate_pk(fpk, fpkh)?))
+            }
+            Terminal::DupIf(ref sub) => {
+                Terminal::DupIf(Arc::new(sub.real_translate_pk(fpk, fpkh)?))
+            }
+            Terminal::Verify(ref sub) => {
+                Terminal::Verify(Arc::new(sub.real_translate_pk(fpk, fpkh)?))
+            }
+            Terminal::NonZero(ref sub) => {
+                Terminal::NonZero(Arc::new(sub.real_translate_pk(fpk, fpkh)?))
+            }
+            Terminal::ZeroNotEqual(ref sub) => {
+                Terminal::ZeroNotEqual(Arc::new(sub.real_translate_pk(fpk, fpkh)?))
+            }
             Terminal::AndV(ref left, ref right) => Terminal::AndV(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::AndB(ref left, ref right) => Terminal::AndB(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::AndOr(ref a, ref b, ref c) => Terminal::AndOr(
-                Arc::new(a.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(b.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(c.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(a.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(b.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(c.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::OrB(ref left, ref right) => Terminal::OrB(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::OrD(ref left, ref right) => Terminal::OrD(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::OrC(ref left, ref right) => Terminal::OrC(
-                Arc::new(left.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)?),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *fpk, &mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::OrI(ref left, ref right) => Terminal::OrI(
-                Arc::new(
-                    left.real_translate_pk(&mut *&mut *translatefpk, &mut *&mut *translatefpkh)?,
-                ),
-                Arc::new(right.real_translate_pk(translatefpk, translatefpkh)?),
+                Arc::new(left.real_translate_pk(&mut *&mut *fpk, &mut *&mut *fpkh)?),
+                Arc::new(right.real_translate_pk(fpk, fpkh)?),
             ),
             Terminal::Thresh(k, ref subs) => {
                 let subs: Result<Vec<Arc<Miniscript<Q, _>>>, _> = subs
                     .iter()
                     .map(|s| {
-                        s.real_translate_pk(&mut *translatefpk, &mut *translatefpkh)
+                        s.real_translate_pk(&mut *fpk, &mut *fpkh)
                             .and_then(|x| Ok(Arc::new(x)))
                     })
                     .collect();
                 Terminal::Thresh(k, subs?)
             }
             Terminal::Multi(k, ref keys) => {
-                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut *translatefpk).collect();
+                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut *fpk).collect();
                 Terminal::Multi(k, keys?)
             }
             Terminal::MultiA(k, ref keys) => {
-                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut *translatefpk).collect();
+                let keys: Result<Vec<Q>, _> = keys.iter().map(&mut *fpk).collect();
                 Terminal::MultiA(k, keys?)
             }
         };

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -275,24 +275,32 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for Miniscript<Pk, Ct
     }
 }
 
-impl<Pk: MiniscriptKey, Q: MiniscriptKey, Ctx: ScriptContext> TranslatePk<Pk, Q>
-    for Miniscript<Pk, Ctx>
+impl<Pk, Q, Ctx> TranslatePk<Pk, Q> for Miniscript<Pk, Ctx>
+where
+    Pk: MiniscriptKey,
+    Q: MiniscriptKey,
+    Ctx: ScriptContext,
 {
     type Output = Miniscript<Q, Ctx>;
 
-    /// This will panic if translatefpk returns an uncompressed key when
-    /// converting to a Segwit descriptor. To prevent this panic, ensure
-    /// translatefpk returns an error in this case instead.
-    fn translate_pk<FPk, FPkh, FuncError>(
+    /// Translates a struct from one generic to another where the translation
+    /// for Pk is provided by function `fpk`, and translation for PkH is
+    /// provided by function `fpkh`.
+    ///
+    /// # Panics
+    ///
+    /// If `fpk` returns an uncompressed key when converting to a Segwit descriptor.
+    /// To prevent this panic, ensure `fpk` returns an error in this case instead.
+    fn translate_pk<Fpk, Fpkh, FuncError>(
         &self,
-        mut translatefpk: FPk,
-        mut translatefpkh: FPkh,
+        mut fpk: Fpk,
+        mut fpkh: Fpkh,
     ) -> Result<Self::Output, FuncError>
     where
-        FPk: FnMut(&Pk) -> Result<Q, FuncError>,
-        FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, FuncError>,
+        Fpk: FnMut(&Pk) -> Result<Q, FuncError>,
+        Fpkh: FnMut(&Pk::Hash) -> Result<Q::Hash, FuncError>,
     {
-        self.real_translate_pk(&mut translatefpk, &mut translatefpkh)
+        self.real_translate_pk(&mut fpk, &mut fpkh)
     }
 }
 
@@ -305,18 +313,18 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         self.node.real_for_each_key(pred)
     }
 
-    pub(crate) fn real_translate_pk<FPk, FPkh, Q, FuncError, CtxQ>(
+    pub(crate) fn real_translate_pk<Fpk, Fpkh, Q, FuncError, CtxQ>(
         &self,
-        translatefpk: &mut FPk,
-        translatefpkh: &mut FPkh,
+        fpk: &mut Fpk,
+        fpkh: &mut Fpkh,
     ) -> Result<Miniscript<Q, CtxQ>, FuncError>
     where
-        FPk: FnMut(&Pk) -> Result<Q, FuncError>,
-        FPkh: FnMut(&Pk::Hash) -> Result<Q::Hash, FuncError>,
+        Fpk: FnMut(&Pk) -> Result<Q, FuncError>,
+        Fpkh: FnMut(&Pk::Hash) -> Result<Q::Hash, FuncError>,
         Q: MiniscriptKey,
         CtxQ: ScriptContext,
     {
-        let inner = self.node.real_translate_pk(translatefpk, translatefpkh)?;
+        let inner = self.node.real_translate_pk(fpk, fpkh)?;
         let ms = Miniscript {
             //directly copying the type and ext is safe because translating public
             //key should not change any properties

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -56,6 +56,7 @@ use std::sync::Arc;
 
 #[cfg(test)]
 mod ms_tests;
+
 /// Top-level script AST type
 #[derive(Clone, Hash)]
 pub struct Miniscript<Pk: MiniscriptKey, Ctx: ScriptContext> {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -185,15 +185,15 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// let expected_policy = Policy::from_str(&format!("and(pk({}),pk({}))", alice_key, bob_key)).unwrap();
     /// assert_eq!(real_policy, expected_policy);
     /// ```
-    pub fn translate_pk<Fpk, Q, E>(&self, mut translatefpk: Fpk) -> Result<Policy<Q>, E>
+    pub fn translate_pk<Fpk, Q, E>(&self, mut fpk: Fpk) -> Result<Policy<Q>, E>
     where
         Fpk: FnMut(&Pk) -> Result<Q, E>,
         Q: MiniscriptKey,
     {
-        self._translate_pk(&mut translatefpk)
+        self._translate_pk(&mut fpk)
     }
 
-    fn _translate_pk<Fpk, Q, E>(&self, translatefpk: &mut Fpk) -> Result<Policy<Q>, E>
+    fn _translate_pk<Fpk, Q, E>(&self, fpk: &mut Fpk) -> Result<Policy<Q>, E>
     where
         Fpk: FnMut(&Pk) -> Result<Q, E>,
         Q: MiniscriptKey,
@@ -201,7 +201,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         match *self {
             Policy::Unsatisfiable => Ok(Policy::Unsatisfiable),
             Policy::Trivial => Ok(Policy::Trivial),
-            Policy::Key(ref pk) => translatefpk(pk).map(Policy::Key),
+            Policy::Key(ref pk) => fpk(pk).map(Policy::Key),
             Policy::Sha256(ref h) => Ok(Policy::Sha256(h.clone())),
             Policy::Hash256(ref h) => Ok(Policy::Hash256(h.clone())),
             Policy::Ripemd160(ref h) => Ok(Policy::Ripemd160(h.clone())),
@@ -209,20 +209,18 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             Policy::After(n) => Ok(Policy::After(n)),
             Policy::Older(n) => Ok(Policy::Older(n)),
             Policy::Threshold(k, ref subs) => {
-                let new_subs: Result<Vec<Policy<Q>>, _> = subs
-                    .iter()
-                    .map(|sub| sub._translate_pk(translatefpk))
-                    .collect();
+                let new_subs: Result<Vec<Policy<Q>>, _> =
+                    subs.iter().map(|sub| sub._translate_pk(fpk)).collect();
                 new_subs.map(|ok| Policy::Threshold(k, ok))
             }
             Policy::And(ref subs) => Ok(Policy::And(
                 subs.iter()
-                    .map(|sub| sub._translate_pk(translatefpk))
+                    .map(|sub| sub._translate_pk(fpk))
                     .collect::<Result<Vec<Policy<Q>>, E>>()?,
             )),
             Policy::Or(ref subs) => Ok(Policy::Or(
                 subs.iter()
-                    .map(|&(ref prob, ref sub)| Ok((*prob, sub._translate_pk(translatefpk)?)))
+                    .map(|&(ref prob, ref sub)| Ok((*prob, sub._translate_pk(fpk)?)))
                     .collect::<Result<Vec<(usize, Policy<Q>)>, E>>()?,
             )),
         }


### PR DESCRIPTION
We recently refactored the `TranslatePk` traits but did not do _all_ the implementations.

- Patch 1 trivial cleanup.
- Patch 2 does the remaining implementations.
- Patch 3 shortens other instances of the `translatefpk[h]` identifier so as to be uniform.