### PR TITLE
Derive hash

### DIFF
--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -73,6 +73,7 @@ pub(super) fn verify_checksum(s: &str) -> Result<&str, Error> {
 }
 
 /// An engine to compute a checksum from a string
+#[derive(Hash)]
 pub struct Engine {
     c: u64,
     cls: u64,

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -391,7 +391,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Tr<Pk> {
 ///                                           D    E
 /// would yield (2, A), (2, B), (2,C), (3, D), (3, E).
 ///
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct TapTreeIter<'a, Pk: MiniscriptKey> {
     stack: Vec<(u8, &'a TapTree<Pk>)>,
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -8,7 +8,7 @@ use core::str::FromStr;
 use crate::prelude::*;
 use crate::{errstr, Error, MAX_RECURSION_DEPTH};
 
-#[derive(Debug)]
+#[derive(Debug, Hash)]
 /// A token of the form `x(...)` or `x`
 pub struct Tree<'a> {
     /// The name `x`
@@ -28,6 +28,7 @@ pub trait FromTree: Sized {
     fn from_tree(top: &Tree) -> Result<Self, Error>;
 }
 
+#[derive(Hash)]
 enum Found {
     Nothing,
     LBracket(usize), // Either a left ( or {

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -56,7 +56,7 @@ fn script_from_stack_elem<Ctx: ScriptContext>(
 }
 
 /// Helper type to indicate the origin of the bare pubkey that the interpereter uses
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum PubkeyType {
     Pk,
     Pkh,
@@ -66,7 +66,7 @@ pub enum PubkeyType {
 }
 
 /// Helper type to indicate the origin of the bare miniscript that the interpereter uses
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ScriptType {
     Bare,
     Sh,
@@ -76,7 +76,7 @@ pub enum ScriptType {
 }
 
 /// Structure representing a script under evaluation as a Miniscript
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub(super) enum Inner {
     /// The script being evaluated is a simple public key check (pay-to-pk,
     /// pay-to-pkhash or pay-to-witness-pkhash)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -29,6 +29,7 @@ use self::stack::Stack;
 use crate::MiniscriptKey;
 
 /// An iterable Miniscript-structured representation of the spending of a coin
+#[derive(Hash)]
 pub struct Interpreter<'txin> {
     inner: inner::Inner,
     stack: Stack<'txin>,
@@ -43,7 +44,7 @@ pub struct Interpreter<'txin> {
 // Ecdsa and Schnorr signatures
 
 /// A type for representing signatures supported as of bitcoin core 22.0
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum KeySigPair {
     /// A Full public key and corresponding Ecdsa signature
     Ecdsa(bitcoin::PublicKey, bitcoin::ecdsa::Signature),
@@ -452,7 +453,7 @@ impl<'txin> Interpreter<'txin> {
 }
 
 /// Type of HashLock used for SatisfiedConstraint structure
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum HashLockType {
     ///SHA 256 hashlock
     Sha256(sha256::Hash),
@@ -467,7 +468,7 @@ pub enum HashLockType {
 /// A satisfied Miniscript condition (Signature, Hashlock, Timelock)
 /// 'intp represents the lifetime of descriptor and `stack represents
 /// the lifetime of witness
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum SatisfiedConstraint {
     ///Public key and corresponding signature
     PublicKey {
@@ -506,6 +507,7 @@ pub enum SatisfiedConstraint {
 ///the top of the stack, we need to decide whether to execute right child or not.
 ///This is also useful for wrappers and thresholds which push a value on the stack
 ///depending on evaluation of the children.
+#[derive(Hash)]
 struct NodeEvaluationState<'intp> {
     ///The node which is being evaluated
     node: &'intp Miniscript<BitcoinKey, NoChecks>,

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -25,7 +25,7 @@ use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal};
 ///    guarantees are not satisfied.
 /// 4. It has repeated public keys
 /// 5. raw pkh fragments without the pk. This could be obtained when parsing miniscript from script
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
 pub struct ExtParams {
     /// Allow parsing of non-safe miniscripts
     pub top_unsafe: bool,

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -87,7 +87,7 @@ mod private {
     impl Sealed for super::bitcoin::secp256k1::XOnlyPublicKey {}
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash)]
 enum NonTerm {
     Expression,
     WExpression,

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -213,7 +213,7 @@ macro_rules! match_token {
 }
 
 ///Vec representing terminals stack while decoding.
-#[derive(Debug)]
+#[derive(Debug, Hash)]
 struct TerminalStack<Pk: MiniscriptKey, Ctx: ScriptContext>(Vec<Miniscript<Pk, Ctx>>);
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -109,6 +109,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 
 /// Iterator for traversing all [Miniscript] miniscript AST references starting from some specific
 /// node which constructs the iterator via [Miniscript::iter] method.
+#[derive(Hash)]
 pub struct Iter<'a, Pk: MiniscriptKey, Ctx: ScriptContext> {
     next: Option<&'a Miniscript<Pk, Ctx>>,
     // Here we store vec of path elements, where each element is a tuple, consisting of:

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -14,7 +14,7 @@ use super::Error;
 use crate::prelude::*;
 
 /// Atom of a tokenized version of a script
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Token<'s> {
     BoolAnd,

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -536,7 +536,7 @@ impl_tuple_satisfier!(A, B, C, D, E, F, G);
 impl_tuple_satisfier!(A, B, C, D, E, F, G, H);
 
 /// A witness, if available, for a Miniscript fragment
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Witness {
     /// Witness Available and the value of the witness
     Stack(Vec<Vec<u8>>),
@@ -708,7 +708,7 @@ impl Witness {
 }
 
 /// A (dis)satisfaction of a Miniscript fragment
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Satisfaction {
     /// The actual witness stack
     pub stack: Witness,

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -98,7 +98,7 @@ impl hash::Hash for OrdF64 {
 
 /// Compilation key: This represents the state of the best possible compilation
 /// of a given policy(implicitly keyed).
-#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
 struct CompilationKey {
     /// The type of the compilation result
     ty: Type,
@@ -536,7 +536,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> AstElemExt<Pk, Ctx> {
 }
 
 /// Different types of casts possible for each node.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Hash)]
 struct Cast<Pk: MiniscriptKey, Ctx: ScriptContext> {
     node: fn(Arc<Miniscript<Pk, Ctx>>) -> Terminal<Pk, Ctx>,
     ast_type: fn(types::Type) -> Result<types::Type, ErrorKind>,

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -257,6 +257,7 @@ impl From<bitcoin::key::Error> for InputError {
 /// the same psbt structure
 /// All operations on this structure will panic if index
 /// is more than number of inputs in pbst
+#[derive(Hash)]
 pub struct PsbtInputSatisfier<'psbt> {
     /// pbst
     pub psbt: &'psbt Psbt,


### PR DESCRIPTION
Derive `Hash` for all structs and enums (excl. error enums) that can.

Patch 2 is 'wip' because I'm not sure if it makes sense to derive `Hash` for the types in that patch but the issue says "do all of them"?

Draft still for feedback on patch 2. Also I did not re-check the whole codebase, the original PR was done a long time ago, well check it over before taking off draft.

Resolves: #226