### PR TITLE
Implement `is_empty` on `TokenIter`

### DIFF
--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -102,6 +102,11 @@ impl<'s> TokenIter<'s> {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+
+    /// Returns true if iterator is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl<'s> Iterator for TokenIter<'s> {


### PR DESCRIPTION
Clippy emits:

```
warning: struct `TokenIter` has a public `len` method, but no `is_empty` method
   --> src/miniscript/lex.rs:102:5
    |
102 |     pub fn len(&self) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::len_without_is_empty)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_without_is_empty
```

Iterators typically do not implement `is_empty` because there is often
no way for an iterator to know if there are more items without calling
`next`, however we use a `Vec` under the hood so `is_empty` is cheap.