### PR TITLE
Use KeySource instead of tuple

### DIFF
--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -528,8 +528,7 @@ impl FromStr for DescriptorSecretKey {
 impl<K: InnerXKey> DescriptorXKey<K> {
     fn parse_xkey_origin(
         s: &str,
-    ) -> Result<(&str, Option<(bip32::Fingerprint, bip32::DerivationPath)>), DescriptorKeyParseError>
-    {
+    ) -> Result<(&str, Option<bip32::KeySource>), DescriptorKeyParseError> {
         for ch in s.as_bytes() {
             if *ch < 20 || *ch > 127 {
                 return Err(DescriptorKeyParseError(


### PR DESCRIPTION
Clippy emits:

 warning: very complex type used. Consider factoring parts into `type` definitions

The type we return is more complex than needed because we do not use the `bip32::KeySource` alias but instead write the full tuple `(byp32::Fingerprint, bip32::DerivationPath)`.

To fix the clippy warning we have at least 3 options

1. Add an alias for the complex return type
2. Add a compiler directive to quieten clippy
3. Use `bip32::KeySource` instead of tuple

(1) seems like an overkill
(2) means we loose lint coverage for the whole function

Elect to do (3), the best of 3 imperfect solutions.