### PR TITLE
Move DummyKey to submodule

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -871,9 +871,10 @@ mod tests {
     use super::*;
     use crate::descriptor::key::Wildcard;
     use crate::descriptor::{DescriptorPublicKey, DescriptorSecretKey, DescriptorXKey, SinglePub};
+    use crate::dummy_key::DummyKey;
     #[cfg(feature = "compiler")]
     use crate::policy;
-    use crate::{hex_script, Descriptor, DummyKey, Error, Miniscript, Satisfier, TranslatePk2};
+    use crate::{hex_script, Descriptor, Error, Miniscript, Satisfier, TranslatePk2};
 
     type StdDescriptor = Descriptor<PublicKey>;
     const TEST_PK: &'static str =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,6 @@ pub mod psbt;
 
 mod util;
 
-use std::str::FromStr;
 use std::{error, fmt, hash, str};
 
 use bitcoin::blockdata::{opcodes, script};
@@ -244,78 +243,85 @@ impl ToPublicKey for bitcoin::secp256k1::XOnlyPublicKey {
     }
 }
 
-/// Dummy key which de/serializes to the empty string; useful sometimes for testing
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
-pub struct DummyKey;
+#[cfg(test)]
+pub mod dummy_key {
+    use std::str::FromStr;
 
-impl str::FromStr for DummyKey {
-    type Err = &'static str;
-    fn from_str(x: &str) -> Result<DummyKey, &'static str> {
-        if x.is_empty() {
-            Ok(DummyKey)
-        } else {
-            Err("non empty dummy key")
+    use super::*;
+
+    /// Dummy key which de/serializes to the empty string.
+    #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
+    pub struct DummyKey;
+
+    impl str::FromStr for DummyKey {
+        type Err = &'static str;
+        fn from_str(x: &str) -> Result<DummyKey, &'static str> {
+            if x.is_empty() {
+                Ok(DummyKey)
+            } else {
+                Err("non empty dummy key")
+            }
         }
     }
-}
 
-impl MiniscriptKey for DummyKey {
-    type Hash = DummyKeyHash;
+    impl MiniscriptKey for DummyKey {
+        type Hash = DummyKeyHash;
 
-    fn to_pubkeyhash(&self) -> Self::Hash {
-        DummyKeyHash
-    }
-}
-
-impl hash::Hash for DummyKey {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        "DummyKey".hash(state);
-    }
-}
-
-impl fmt::Display for DummyKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("")
-    }
-}
-
-impl ToPublicKey for DummyKey {
-    fn to_public_key(&self) -> bitcoin::PublicKey {
-        bitcoin::PublicKey::from_str(
-            "0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352",
-        )
-        .unwrap()
-    }
-
-    fn hash_to_hash160(_: &DummyKeyHash) -> hash160::Hash {
-        hash160::Hash::from_str("f54a5851e9372b87810a8e60cdd2e7cfd80b6e31").unwrap()
-    }
-}
-
-/// Dummy keyhash which de/serializes to the empty string; useful sometimes for testing
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
-pub struct DummyKeyHash;
-
-impl str::FromStr for DummyKeyHash {
-    type Err = &'static str;
-    fn from_str(x: &str) -> Result<DummyKeyHash, &'static str> {
-        if x.is_empty() {
-            Ok(DummyKeyHash)
-        } else {
-            Err("non empty dummy key")
+        fn to_pubkeyhash(&self) -> Self::Hash {
+            DummyKeyHash
         }
     }
-}
 
-impl fmt::Display for DummyKeyHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("")
+    impl hash::Hash for DummyKey {
+        fn hash<H: hash::Hasher>(&self, state: &mut H) {
+            "DummyKey".hash(state);
+        }
     }
-}
 
-impl hash::Hash for DummyKeyHash {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        "DummyKeyHash".hash(state);
+    impl fmt::Display for DummyKey {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("")
+        }
+    }
+
+    impl ToPublicKey for DummyKey {
+        fn to_public_key(&self) -> bitcoin::PublicKey {
+            bitcoin::PublicKey::from_str(
+                "0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352",
+            )
+            .unwrap()
+        }
+
+        fn hash_to_hash160(_: &DummyKeyHash) -> hash160::Hash {
+            hash160::Hash::from_str("f54a5851e9372b87810a8e60cdd2e7cfd80b6e31").unwrap()
+        }
+    }
+
+    /// Dummy keyhash which de/serializes to the empty string.
+    #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
+    pub struct DummyKeyHash;
+
+    impl str::FromStr for DummyKeyHash {
+        type Err = &'static str;
+        fn from_str(x: &str) -> Result<DummyKeyHash, &'static str> {
+            if x.is_empty() {
+                Ok(DummyKeyHash)
+            } else {
+                Err("non empty dummy key")
+            }
+        }
+    }
+
+    impl fmt::Display for DummyKeyHash {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("")
+        }
+    }
+
+    impl hash::Hash for DummyKeyHash {
+        fn hash<H: hash::Hasher>(&self, state: &mut H) {
+            "DummyKeyHash".hash(state);
+        }
     }
 }
 
@@ -773,6 +779,8 @@ fn hex_script(s: &str) -> bitcoin::Script {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -479,12 +479,12 @@ mod tests {
     use bitcoin::{self, secp256k1};
 
     use super::{Miniscript, ScriptContext, Segwitv0, Tap};
+    use crate::dummy_key::{DummyKey, DummyKeyHash};
     use crate::miniscript::types::{self, ExtData, Property, Type};
     use crate::miniscript::Terminal;
     use crate::policy::Liftable;
     use crate::{
-        hex_script, DummyKey, DummyKeyHash, MiniscriptKey, Satisfier, ToPublicKey, TranslatePk,
-        TranslatePk1, TranslatePk2,
+        hex_script, MiniscriptKey, Satisfier, ToPublicKey, TranslatePk, TranslatePk1, TranslatePk2,
     };
 
     type Segwitv0Script = Miniscript<bitcoin::PublicKey, Segwitv0>;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -231,7 +231,7 @@ mod tests {
     use super::super::miniscript::context::Segwitv0;
     use super::super::miniscript::Miniscript;
     use super::{Concrete, Liftable, Semantic};
-    use crate::DummyKey;
+    use crate::dummy_key::DummyKey;
 
     type ConcretePol = Concrete<DummyKey>;
     type SemanticPol = Semantic<DummyKey>;


### PR DESCRIPTION
The `DummyKey`, according to code comments is only useful for testing. Put it in a submodule and conditionally compile it in only for tests.