### PR TITLE
Remove use of ref keyword

### DIFF
--- a/integration_test/src/test_desc.rs
+++ b/integration_test/src/test_desc.rs
@@ -121,7 +121,7 @@ pub fn test_desc_satisfy(cl: &Client, testdata: &TestData, desc: &str) -> Witnes
 
     let mut sighash_cache = SighashCache::new(&psbt.unsigned_tx);
     match derived_desc {
-        Descriptor::Tr(ref tr) => {
+        Descriptor::Tr(tr) => {
             // Fixme: take a parameter
             let hash_ty = sighash::SchnorrSighashType::Default;
 
@@ -196,11 +196,11 @@ pub fn test_desc_satisfy(cl: &Client, testdata: &TestData, desc: &str) -> Witnes
                 Descriptor::Wpkh(pk) => find_sk_single_key(*pk.as_inner(), testdata),
                 Descriptor::Sh(sh) => match sh.as_inner() {
                     miniscript::descriptor::ShInner::Wsh(wsh) => match wsh.as_inner() {
-                        miniscript::descriptor::WshInner::SortedMulti(ref smv) => {
+                        miniscript::descriptor::WshInner::SortedMulti(smv) => {
                             let ms = Miniscript::from_ast(smv.sorted_node()).unwrap();
                             find_sks_ms(&ms, testdata)
                         }
-                        miniscript::descriptor::WshInner::Ms(ref ms) => find_sks_ms(&ms, testdata),
+                        miniscript::descriptor::WshInner::Ms(ms) => find_sks_ms(&ms, testdata),
                     },
                     miniscript::descriptor::ShInner::Wpkh(pk) => {
                         find_sk_single_key(*pk.as_inner(), testdata)
@@ -212,11 +212,11 @@ pub fn test_desc_satisfy(cl: &Client, testdata: &TestData, desc: &str) -> Witnes
                     miniscript::descriptor::ShInner::Ms(ms) => find_sks_ms(&ms, testdata),
                 },
                 Descriptor::Wsh(wsh) => match wsh.as_inner() {
-                    miniscript::descriptor::WshInner::SortedMulti(ref smv) => {
+                    miniscript::descriptor::WshInner::SortedMulti(smv) => {
                         let ms = Miniscript::from_ast(smv.sorted_node()).unwrap();
                         find_sks_ms(&ms, testdata)
                     }
-                    miniscript::descriptor::WshInner::Ms(ref ms) => find_sks_ms(&ms, testdata),
+                    miniscript::descriptor::WshInner::Ms(ms) => find_sks_ms(&ms, testdata),
                 },
                 Descriptor::Tr(_tr) => unreachable!("Tr checked earlier"),
             };

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -378,24 +378,24 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
 
     /// Get the [DescriptorType] of [Descriptor]
     pub fn desc_type(&self) -> DescriptorType {
-        match *self {
-            Descriptor::Bare(ref _bare) => DescriptorType::Bare,
-            Descriptor::Pkh(ref _pkh) => DescriptorType::Pkh,
-            Descriptor::Wpkh(ref _wpkh) => DescriptorType::Wpkh,
-            Descriptor::Sh(ref sh) => match sh.as_inner() {
-                ShInner::Wsh(ref wsh) => match wsh.as_inner() {
-                    WshInner::SortedMulti(ref _smv) => DescriptorType::ShWshSortedMulti,
-                    WshInner::Ms(ref _ms) => DescriptorType::ShWsh,
+        match self {
+            Descriptor::Bare(_bare) => DescriptorType::Bare,
+            Descriptor::Pkh(_pkh) => DescriptorType::Pkh,
+            Descriptor::Wpkh(_wpkh) => DescriptorType::Wpkh,
+            Descriptor::Sh(sh) => match sh.as_inner() {
+                ShInner::Wsh(wsh) => match wsh.as_inner() {
+                    WshInner::SortedMulti(_smv) => DescriptorType::ShWshSortedMulti,
+                    WshInner::Ms(_ms) => DescriptorType::ShWsh,
                 },
-                ShInner::Wpkh(ref _wpkh) => DescriptorType::ShWpkh,
-                ShInner::SortedMulti(ref _smv) => DescriptorType::ShSortedMulti,
-                ShInner::Ms(ref _ms) => DescriptorType::Sh,
+                ShInner::Wpkh(_wpkh) => DescriptorType::ShWpkh,
+                ShInner::SortedMulti(_smv) => DescriptorType::ShSortedMulti,
+                ShInner::Ms(_ms) => DescriptorType::Sh,
             },
-            Descriptor::Wsh(ref wsh) => match wsh.as_inner() {
-                WshInner::SortedMulti(ref _smv) => DescriptorType::WshSortedMulti,
-                WshInner::Ms(ref _ms) => DescriptorType::Wsh,
+            Descriptor::Wsh(wsh) => match wsh.as_inner() {
+                WshInner::SortedMulti(_smv) => DescriptorType::WshSortedMulti,
+                WshInner::Ms(_ms) => DescriptorType::Wsh,
             },
-            Descriptor::Tr(ref _tr) => DescriptorType::Tr,
+            Descriptor::Tr(_tr) => DescriptorType::Tr,
         }
     }
 
@@ -455,13 +455,13 @@ where
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
         Q: MiniscriptKey,
     {
-        let desc = match *self {
-            Descriptor::Bare(ref bare) => Descriptor::Bare(bare.translate_pk(&mut fpk, &mut fpkh)?),
-            Descriptor::Pkh(ref pk) => Descriptor::Pkh(pk.translate_pk(&mut fpk, &mut fpkh)?),
-            Descriptor::Wpkh(ref pk) => Descriptor::Wpkh(pk.translate_pk(&mut fpk, &mut fpkh)?),
-            Descriptor::Sh(ref sh) => Descriptor::Sh(sh.translate_pk(&mut fpk, &mut fpkh)?),
-            Descriptor::Wsh(ref wsh) => Descriptor::Wsh(wsh.translate_pk(&mut fpk, &mut fpkh)?),
-            Descriptor::Tr(ref tr) => Descriptor::Tr(tr.translate_pk(&mut fpk, &mut fpkh)?),
+        let desc = match self {
+            Descriptor::Bare(bare) => Descriptor::Bare(bare.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Pkh(pk) => Descriptor::Pkh(pk.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Wpkh(pk) => Descriptor::Wpkh(pk.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Sh(sh) => Descriptor::Sh(sh.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Wsh(wsh) => Descriptor::Wsh(wsh.translate_pk(&mut fpk, &mut fpkh)?),
+            Descriptor::Tr(tr) => Descriptor::Tr(tr.translate_pk(&mut fpk, &mut fpkh)?),
         };
         Ok(desc)
     }
@@ -477,13 +477,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
     /// All the analysis guarantees of miniscript only hold safe scripts.
     /// The signer may not be able to find satisfactions even if one exists
     fn sanity_check(&self) -> Result<(), Error> {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.sanity_check(),
-            Descriptor::Pkh(ref pkh) => pkh.sanity_check(),
-            Descriptor::Wpkh(ref wpkh) => wpkh.sanity_check(),
-            Descriptor::Wsh(ref wsh) => wsh.sanity_check(),
-            Descriptor::Sh(ref sh) => sh.sanity_check(),
-            Descriptor::Tr(ref tr) => tr.sanity_check(),
+        match self {
+            Descriptor::Bare(bare) => bare.sanity_check(),
+            Descriptor::Pkh(pkh) => pkh.sanity_check(),
+            Descriptor::Wpkh(wpkh) => wpkh.sanity_check(),
+            Descriptor::Wsh(wsh) => wsh.sanity_check(),
+            Descriptor::Sh(sh) => sh.sanity_check(),
+            Descriptor::Tr(tr) => tr.sanity_check(),
         }
     }
     /// Computes the Bitcoin address of the descriptor, if one exists
@@ -491,13 +491,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.address(network),
-            Descriptor::Pkh(ref pkh) => pkh.address(network),
-            Descriptor::Wpkh(ref wpkh) => wpkh.address(network),
-            Descriptor::Wsh(ref wsh) => wsh.address(network),
-            Descriptor::Sh(ref sh) => sh.address(network),
-            Descriptor::Tr(ref tr) => tr.address(network),
+        match self {
+            Descriptor::Bare(bare) => bare.address(network),
+            Descriptor::Pkh(pkh) => pkh.address(network),
+            Descriptor::Wpkh(wpkh) => wpkh.address(network),
+            Descriptor::Wsh(wsh) => wsh.address(network),
+            Descriptor::Sh(sh) => sh.address(network),
+            Descriptor::Tr(tr) => tr.address(network),
         }
     }
 
@@ -506,13 +506,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.script_pubkey(),
-            Descriptor::Pkh(ref pkh) => pkh.script_pubkey(),
-            Descriptor::Wpkh(ref wpkh) => wpkh.script_pubkey(),
-            Descriptor::Wsh(ref wsh) => wsh.script_pubkey(),
-            Descriptor::Sh(ref sh) => sh.script_pubkey(),
-            Descriptor::Tr(ref tr) => tr.script_pubkey(),
+        match self {
+            Descriptor::Bare(bare) => bare.script_pubkey(),
+            Descriptor::Pkh(pkh) => pkh.script_pubkey(),
+            Descriptor::Wpkh(wpkh) => wpkh.script_pubkey(),
+            Descriptor::Wsh(wsh) => wsh.script_pubkey(),
+            Descriptor::Sh(sh) => sh.script_pubkey(),
+            Descriptor::Tr(tr) => tr.script_pubkey(),
         }
     }
 
@@ -528,13 +528,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.unsigned_script_sig(),
-            Descriptor::Pkh(ref pkh) => pkh.unsigned_script_sig(),
-            Descriptor::Wpkh(ref wpkh) => wpkh.unsigned_script_sig(),
-            Descriptor::Wsh(ref wsh) => wsh.unsigned_script_sig(),
-            Descriptor::Sh(ref sh) => sh.unsigned_script_sig(),
-            Descriptor::Tr(ref tr) => tr.unsigned_script_sig(),
+        match self {
+            Descriptor::Bare(bare) => bare.unsigned_script_sig(),
+            Descriptor::Pkh(pkh) => pkh.unsigned_script_sig(),
+            Descriptor::Wpkh(wpkh) => wpkh.unsigned_script_sig(),
+            Descriptor::Wsh(wsh) => wsh.unsigned_script_sig(),
+            Descriptor::Sh(sh) => sh.unsigned_script_sig(),
+            Descriptor::Tr(tr) => tr.unsigned_script_sig(),
         }
     }
 
@@ -548,13 +548,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.explicit_script(),
-            Descriptor::Pkh(ref pkh) => pkh.explicit_script(),
-            Descriptor::Wpkh(ref wpkh) => wpkh.explicit_script(),
-            Descriptor::Wsh(ref wsh) => wsh.explicit_script(),
-            Descriptor::Sh(ref sh) => sh.explicit_script(),
-            Descriptor::Tr(ref tr) => tr.explicit_script(),
+        match self {
+            Descriptor::Bare(bare) => bare.explicit_script(),
+            Descriptor::Pkh(pkh) => pkh.explicit_script(),
+            Descriptor::Wpkh(wpkh) => wpkh.explicit_script(),
+            Descriptor::Wsh(wsh) => wsh.explicit_script(),
+            Descriptor::Sh(sh) => sh.explicit_script(),
+            Descriptor::Tr(tr) => tr.explicit_script(),
         }
     }
 
@@ -566,13 +566,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
         Pk: ToPublicKey,
         S: Satisfier<Pk>,
     {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.get_satisfaction(satisfier),
-            Descriptor::Pkh(ref pkh) => pkh.get_satisfaction(satisfier),
-            Descriptor::Wpkh(ref wpkh) => wpkh.get_satisfaction(satisfier),
-            Descriptor::Wsh(ref wsh) => wsh.get_satisfaction(satisfier),
-            Descriptor::Sh(ref sh) => sh.get_satisfaction(satisfier),
-            Descriptor::Tr(ref tr) => tr.get_satisfaction(satisfier),
+        match self {
+            Descriptor::Bare(bare) => bare.get_satisfaction(satisfier),
+            Descriptor::Pkh(pkh) => pkh.get_satisfaction(satisfier),
+            Descriptor::Wpkh(wpkh) => wpkh.get_satisfaction(satisfier),
+            Descriptor::Wsh(wsh) => wsh.get_satisfaction(satisfier),
+            Descriptor::Sh(sh) => sh.get_satisfaction(satisfier),
+            Descriptor::Tr(tr) => tr.get_satisfaction(satisfier),
         }
     }
 
@@ -584,13 +584,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
         Pk: ToPublicKey,
         S: Satisfier<Pk>,
     {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.get_satisfaction_mall(satisfier),
-            Descriptor::Pkh(ref pkh) => pkh.get_satisfaction_mall(satisfier),
-            Descriptor::Wpkh(ref wpkh) => wpkh.get_satisfaction_mall(satisfier),
-            Descriptor::Wsh(ref wsh) => wsh.get_satisfaction_mall(satisfier),
-            Descriptor::Sh(ref sh) => sh.get_satisfaction_mall(satisfier),
-            Descriptor::Tr(ref tr) => tr.get_satisfaction_mall(satisfier),
+        match self {
+            Descriptor::Bare(bare) => bare.get_satisfaction_mall(satisfier),
+            Descriptor::Pkh(pkh) => pkh.get_satisfaction_mall(satisfier),
+            Descriptor::Wpkh(wpkh) => wpkh.get_satisfaction_mall(satisfier),
+            Descriptor::Wsh(wsh) => wsh.get_satisfaction_mall(satisfier),
+            Descriptor::Sh(sh) => sh.get_satisfaction_mall(satisfier),
+            Descriptor::Tr(tr) => tr.get_satisfaction_mall(satisfier),
         }
     }
 
@@ -599,13 +599,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
     /// and sighash suffix. Includes the weight of the VarInts encoding the
     /// scriptSig and witness stack length.
     fn max_satisfaction_weight(&self) -> Result<usize, Error> {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.max_satisfaction_weight(),
-            Descriptor::Pkh(ref pkh) => pkh.max_satisfaction_weight(),
-            Descriptor::Wpkh(ref wpkh) => wpkh.max_satisfaction_weight(),
-            Descriptor::Wsh(ref wsh) => wsh.max_satisfaction_weight(),
-            Descriptor::Sh(ref sh) => sh.max_satisfaction_weight(),
-            Descriptor::Tr(ref tr) => tr.max_satisfaction_weight(),
+        match self {
+            Descriptor::Bare(bare) => bare.max_satisfaction_weight(),
+            Descriptor::Pkh(pkh) => pkh.max_satisfaction_weight(),
+            Descriptor::Wpkh(wpkh) => wpkh.max_satisfaction_weight(),
+            Descriptor::Wsh(wsh) => wsh.max_satisfaction_weight(),
+            Descriptor::Sh(sh) => sh.max_satisfaction_weight(),
+            Descriptor::Tr(tr) => tr.max_satisfaction_weight(),
         }
     }
 
@@ -618,13 +618,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Descriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.script_code(),
-            Descriptor::Pkh(ref pkh) => pkh.script_code(),
-            Descriptor::Wpkh(ref wpkh) => wpkh.script_code(),
-            Descriptor::Wsh(ref wsh) => wsh.script_code(),
-            Descriptor::Sh(ref sh) => sh.script_code(),
-            Descriptor::Tr(ref tr) => tr.script_code(),
+        match self {
+            Descriptor::Bare(bare) => bare.script_code(),
+            Descriptor::Pkh(pkh) => pkh.script_code(),
+            Descriptor::Wpkh(wpkh) => wpkh.script_code(),
+            Descriptor::Wsh(wsh) => wsh.script_code(),
+            Descriptor::Sh(sh) => sh.script_code(),
+            Descriptor::Tr(tr) => tr.script_code(),
         }
     }
 }
@@ -635,13 +635,13 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Descriptor<Pk> {
         Pk: 'a,
         Pk::Hash: 'a,
     {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.for_each_key(pred),
-            Descriptor::Pkh(ref pkh) => pkh.for_each_key(pred),
-            Descriptor::Wpkh(ref wpkh) => wpkh.for_each_key(pred),
-            Descriptor::Wsh(ref wsh) => wsh.for_each_key(pred),
-            Descriptor::Sh(ref sh) => sh.for_each_key(pred),
-            Descriptor::Tr(ref tr) => tr.for_each_key(pred),
+        match self {
+            Descriptor::Bare(bare) => bare.for_each_key(pred),
+            Descriptor::Pkh(pkh) => pkh.for_each_key(pred),
+            Descriptor::Wpkh(wpkh) => wpkh.for_each_key(pred),
+            Descriptor::Wsh(wsh) => wsh.for_each_key(pred),
+            Descriptor::Sh(sh) => sh.for_each_key(pred),
+            Descriptor::Tr(tr) => tr.for_each_key(pred),
         }
     }
 }
@@ -826,26 +826,26 @@ where
 
 impl<Pk: MiniscriptKey> fmt::Debug for Descriptor<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Descriptor::Bare(ref sub) => write!(f, "{:?}", sub),
-            Descriptor::Pkh(ref pkh) => write!(f, "{:?}", pkh),
-            Descriptor::Wpkh(ref wpkh) => write!(f, "{:?}", wpkh),
-            Descriptor::Sh(ref sub) => write!(f, "{:?}", sub),
-            Descriptor::Wsh(ref sub) => write!(f, "{:?}", sub),
-            Descriptor::Tr(ref tr) => write!(f, "{:?}", tr),
+        match self {
+            Descriptor::Bare(sub) => write!(f, "{:?}", sub),
+            Descriptor::Pkh(pkh) => write!(f, "{:?}", pkh),
+            Descriptor::Wpkh(wpkh) => write!(f, "{:?}", wpkh),
+            Descriptor::Sh(sub) => write!(f, "{:?}", sub),
+            Descriptor::Wsh(sub) => write!(f, "{:?}", sub),
+            Descriptor::Tr(tr) => write!(f, "{:?}", tr),
         }
     }
 }
 
 impl<Pk: MiniscriptKey> fmt::Display for Descriptor<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Descriptor::Bare(ref sub) => write!(f, "{}", sub),
-            Descriptor::Pkh(ref pkh) => write!(f, "{}", pkh),
-            Descriptor::Wpkh(ref wpkh) => write!(f, "{}", wpkh),
-            Descriptor::Sh(ref sub) => write!(f, "{}", sub),
-            Descriptor::Wsh(ref sub) => write!(f, "{}", sub),
-            Descriptor::Tr(ref tr) => write!(f, "{}", tr),
+        match self {
+            Descriptor::Bare(sub) => write!(f, "{}", sub),
+            Descriptor::Pkh(pkh) => write!(f, "{}", pkh),
+            Descriptor::Wpkh(wpkh) => write!(f, "{}", wpkh),
+            Descriptor::Sh(sub) => write!(f, "{}", sub),
+            Descriptor::Wsh(sub) => write!(f, "{}", sub),
+            Descriptor::Tr(tr) => write!(f, "{}", tr),
         }
     }
 }
@@ -882,10 +882,10 @@ mod tests {
     impl cmp::PartialEq for DescriptorSecretKey {
         fn eq(&self, other: &Self) -> bool {
             match (self, other) {
-                (&DescriptorSecretKey::Single(ref a), &DescriptorSecretKey::Single(ref b)) => {
+                (DescriptorSecretKey::Single(a), DescriptorSecretKey::Single(b)) => {
                     a.origin == b.origin && a.key == b.key
                 }
-                (&DescriptorSecretKey::XPrv(ref a), &DescriptorSecretKey::XPrv(ref b)) => {
+                (DescriptorSecretKey::XPrv(a), DescriptorSecretKey::XPrv(b)) => {
                     a.origin == b.origin
                         && a.xkey == b.xkey
                         && a.derivation_path == b.derivation_path

--- a/src/descriptor/pretaproot.rs
+++ b/src/descriptor/pretaproot.rs
@@ -32,12 +32,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
     /// All the analysis guarantees of miniscript only hold safe scripts.
     /// The signer may not be able to find satisfactions even if one exists
     fn sanity_check(&self) -> Result<(), Error> {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.sanity_check(),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.sanity_check(),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.sanity_check(),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.sanity_check(),
-            PreTaprootDescriptor::Sh(ref sh) => sh.sanity_check(),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.sanity_check(),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.sanity_check(),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.sanity_check(),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.sanity_check(),
+            PreTaprootDescriptor::Sh(sh) => sh.sanity_check(),
         }
     }
     /// Computes the Bitcoin address of the descriptor, if one exists
@@ -45,12 +45,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.address(network),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.address(network),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.address(network),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.address(network),
-            PreTaprootDescriptor::Sh(ref sh) => sh.address(network),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.address(network),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.address(network),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.address(network),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.address(network),
+            PreTaprootDescriptor::Sh(sh) => sh.address(network),
         }
     }
 
@@ -59,12 +59,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.script_pubkey(),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.script_pubkey(),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.script_pubkey(),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.script_pubkey(),
-            PreTaprootDescriptor::Sh(ref sh) => sh.script_pubkey(),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.script_pubkey(),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.script_pubkey(),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.script_pubkey(),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.script_pubkey(),
+            PreTaprootDescriptor::Sh(sh) => sh.script_pubkey(),
         }
     }
 
@@ -80,12 +80,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.unsigned_script_sig(),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.unsigned_script_sig(),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.unsigned_script_sig(),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.unsigned_script_sig(),
-            PreTaprootDescriptor::Sh(ref sh) => sh.unsigned_script_sig(),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.unsigned_script_sig(),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.unsigned_script_sig(),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.unsigned_script_sig(),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.unsigned_script_sig(),
+            PreTaprootDescriptor::Sh(sh) => sh.unsigned_script_sig(),
         }
     }
 
@@ -99,12 +99,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.explicit_script(),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.explicit_script(),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.explicit_script(),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.explicit_script(),
-            PreTaprootDescriptor::Sh(ref sh) => sh.explicit_script(),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.explicit_script(),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.explicit_script(),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.explicit_script(),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.explicit_script(),
+            PreTaprootDescriptor::Sh(sh) => sh.explicit_script(),
         }
     }
 
@@ -116,12 +116,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
         Pk: ToPublicKey,
         S: Satisfier<Pk>,
     {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.get_satisfaction(satisfier),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.get_satisfaction(satisfier),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.get_satisfaction(satisfier),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.get_satisfaction(satisfier),
-            PreTaprootDescriptor::Sh(ref sh) => sh.get_satisfaction(satisfier),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.get_satisfaction(satisfier),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.get_satisfaction(satisfier),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.get_satisfaction(satisfier),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.get_satisfaction(satisfier),
+            PreTaprootDescriptor::Sh(sh) => sh.get_satisfaction(satisfier),
         }
     }
 
@@ -133,12 +133,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
         Pk: ToPublicKey,
         S: Satisfier<Pk>,
     {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.get_satisfaction_mall(satisfier),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.get_satisfaction_mall(satisfier),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.get_satisfaction_mall(satisfier),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.get_satisfaction_mall(satisfier),
-            PreTaprootDescriptor::Sh(ref sh) => sh.get_satisfaction_mall(satisfier),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.get_satisfaction_mall(satisfier),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.get_satisfaction_mall(satisfier),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.get_satisfaction_mall(satisfier),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.get_satisfaction_mall(satisfier),
+            PreTaprootDescriptor::Sh(sh) => sh.get_satisfaction_mall(satisfier),
         }
     }
 
@@ -147,12 +147,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
     /// and sighash suffix. Includes the weight of the VarInts encoding the
     /// scriptSig and witness stack length.
     fn max_satisfaction_weight(&self) -> Result<usize, Error> {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.max_satisfaction_weight(),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.max_satisfaction_weight(),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.max_satisfaction_weight(),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.max_satisfaction_weight(),
-            PreTaprootDescriptor::Sh(ref sh) => sh.max_satisfaction_weight(),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.max_satisfaction_weight(),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.max_satisfaction_weight(),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.max_satisfaction_weight(),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.max_satisfaction_weight(),
+            PreTaprootDescriptor::Sh(sh) => sh.max_satisfaction_weight(),
         }
     }
 
@@ -165,12 +165,12 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for PreTaprootDescriptor<Pk> {
     where
         Pk: ToPublicKey,
     {
-        match *self {
-            PreTaprootDescriptor::Bare(ref bare) => bare.script_code(),
-            PreTaprootDescriptor::Pkh(ref pkh) => pkh.script_code(),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => wpkh.script_code(),
-            PreTaprootDescriptor::Wsh(ref wsh) => wsh.script_code(),
-            PreTaprootDescriptor::Sh(ref sh) => sh.script_code(),
+        match &self {
+            PreTaprootDescriptor::Bare(bare) => bare.script_code(),
+            PreTaprootDescriptor::Pkh(pkh) => pkh.script_code(),
+            PreTaprootDescriptor::Wpkh(wpkh) => wpkh.script_code(),
+            PreTaprootDescriptor::Wsh(wsh) => wsh.script_code(),
+            PreTaprootDescriptor::Sh(sh) => sh.script_code(),
         }
     }
 }
@@ -212,24 +212,24 @@ where
 
 impl<Pk: MiniscriptKey> fmt::Debug for PreTaprootDescriptor<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            PreTaprootDescriptor::Bare(ref sub) => write!(f, "{:?}", sub),
-            PreTaprootDescriptor::Pkh(ref pkh) => write!(f, "{:?}", pkh),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => write!(f, "{:?}", wpkh),
-            PreTaprootDescriptor::Sh(ref sub) => write!(f, "{:?}", sub),
-            PreTaprootDescriptor::Wsh(ref sub) => write!(f, "{:?}", sub),
+        match &self {
+            PreTaprootDescriptor::Bare(sub) => write!(f, "{:?}", sub),
+            PreTaprootDescriptor::Pkh(pkh) => write!(f, "{:?}", pkh),
+            PreTaprootDescriptor::Wpkh(wpkh) => write!(f, "{:?}", wpkh),
+            PreTaprootDescriptor::Sh(sub) => write!(f, "{:?}", sub),
+            PreTaprootDescriptor::Wsh(sub) => write!(f, "{:?}", sub),
         }
     }
 }
 
 impl<Pk: MiniscriptKey> fmt::Display for PreTaprootDescriptor<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            PreTaprootDescriptor::Bare(ref sub) => write!(f, "{}", sub),
-            PreTaprootDescriptor::Pkh(ref pkh) => write!(f, "{}", pkh),
-            PreTaprootDescriptor::Wpkh(ref wpkh) => write!(f, "{}", wpkh),
-            PreTaprootDescriptor::Sh(ref sub) => write!(f, "{}", sub),
-            PreTaprootDescriptor::Wsh(ref sub) => write!(f, "{}", sub),
+        match &self {
+            PreTaprootDescriptor::Bare(sub) => write!(f, "{}", sub),
+            PreTaprootDescriptor::Pkh(pkh) => write!(f, "{}", pkh),
+            PreTaprootDescriptor::Wpkh(wpkh) => write!(f, "{}", wpkh),
+            PreTaprootDescriptor::Sh(sub) => write!(f, "{}", sub),
+            PreTaprootDescriptor::Wsh(sub) => write!(f, "{}", sub),
         }
     }
 }

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -69,9 +69,9 @@ impl<Pk: MiniscriptKey> Wsh<Pk> {
 
     /// Get the descriptor without the checksum
     pub fn to_string_no_checksum(&self) -> String {
-        match self.inner {
-            WshInner::SortedMulti(ref smv) => format!("wsh({})", smv),
-            WshInner::Ms(ref ms) => format!("wsh({})", ms),
+        match &self.inner {
+            WshInner::SortedMulti(smv) => format!("wsh({})", smv),
+            WshInner::Ms(ms) => format!("wsh({})", ms),
         }
     }
 }
@@ -86,18 +86,18 @@ impl<Pk: MiniscriptKey + ToPublicKey> Wsh<Pk> {
     /// Obtain the corresponding script pubkey for this descriptor
     /// Non failing verion of [`DescriptorTrait::address`] for this descriptor
     pub fn addr(&self, network: bitcoin::Network) -> bitcoin::Address {
-        match self.inner {
-            WshInner::SortedMulti(ref smv) => bitcoin::Address::p2wsh(&smv.encode(), network),
-            WshInner::Ms(ref ms) => bitcoin::Address::p2wsh(&ms.encode(), network),
+        match &self.inner {
+            WshInner::SortedMulti(smv) => bitcoin::Address::p2wsh(&smv.encode(), network),
+            WshInner::Ms(ms) => bitcoin::Address::p2wsh(&ms.encode(), network),
         }
     }
 
     /// Obtain the underlying miniscript for this descriptor
     /// Non failing verion of [`DescriptorTrait::explicit_script`] for this descriptor
     pub fn inner_script(&self) -> Script {
-        match self.inner {
-            WshInner::SortedMulti(ref smv) => smv.encode(),
-            WshInner::Ms(ref ms) => ms.encode(),
+        match &self.inner {
+            WshInner::SortedMulti(smv) => smv.encode(),
+            WshInner::Ms(ms) => ms.encode(),
         }
     }
 
@@ -119,9 +119,9 @@ pub enum WshInner<Pk: MiniscriptKey> {
 
 impl<Pk: MiniscriptKey> Liftable<Pk> for Wsh<Pk> {
     fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
-        match self.inner {
-            WshInner::SortedMulti(ref smv) => smv.lift(),
-            WshInner::Ms(ref ms) => ms.lift(),
+        match &self.inner {
+            WshInner::SortedMulti(smv) => smv.lift(),
+            WshInner::Ms(ms) => ms.lift(),
         }
     }
 }
@@ -157,9 +157,9 @@ where
 }
 impl<Pk: MiniscriptKey> fmt::Debug for Wsh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.inner {
-            WshInner::SortedMulti(ref smv) => write!(f, "wsh({:?})", smv),
-            WshInner::Ms(ref ms) => write!(f, "wsh({:?})", ms),
+        match &self.inner {
+            WshInner::SortedMulti(smv) => write!(f, "wsh({:?})", smv),
+            WshInner::Ms(ms) => write!(f, "wsh({:?})", ms),
         }
     }
 }
@@ -190,9 +190,9 @@ where
 
 impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wsh<Pk> {
     fn sanity_check(&self) -> Result<(), Error> {
-        match self.inner {
-            WshInner::SortedMulti(ref smv) => smv.sanity_check()?,
-            WshInner::Ms(ref ms) => ms.sanity_check()?,
+        match &self.inner {
+            WshInner::SortedMulti(smv) => smv.sanity_check()?,
+            WshInner::Ms(ms) => ms.sanity_check()?,
         }
         Ok(())
     }
@@ -230,9 +230,9 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wsh<Pk> {
         Pk: ToPublicKey,
         S: Satisfier<Pk>,
     {
-        let mut witness = match self.inner {
-            WshInner::SortedMulti(ref smv) => smv.satisfy(satisfier)?,
-            WshInner::Ms(ref ms) => ms.satisfy(satisfier)?,
+        let mut witness = match &self.inner {
+            WshInner::SortedMulti(smv) => smv.satisfy(satisfier)?,
+            WshInner::Ms(ms) => ms.satisfy(satisfier)?,
         };
         let witness_script = self.inner_script();
         witness.push(witness_script.into_bytes());
@@ -245,9 +245,9 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wsh<Pk> {
         Pk: ToPublicKey,
         S: Satisfier<Pk>,
     {
-        let mut witness = match self.inner {
-            WshInner::SortedMulti(ref smv) => smv.satisfy(satisfier)?,
-            WshInner::Ms(ref ms) => ms.satisfy_malleable(satisfier)?,
+        let mut witness = match &self.inner {
+            WshInner::SortedMulti(smv) => smv.satisfy(satisfier)?,
+            WshInner::Ms(ms) => ms.satisfy_malleable(satisfier)?,
         };
         witness.push(self.inner_script().into_bytes());
         let script_sig = Script::new();
@@ -255,13 +255,13 @@ impl<Pk: MiniscriptKey> DescriptorTrait<Pk> for Wsh<Pk> {
     }
 
     fn max_satisfaction_weight(&self) -> Result<usize, Error> {
-        let (script_size, max_sat_elems, max_sat_size) = match self.inner {
-            WshInner::SortedMulti(ref smv) => (
+        let (script_size, max_sat_elems, max_sat_size) = match &self.inner {
+            WshInner::SortedMulti(smv) => (
                 smv.script_size(),
                 smv.max_satisfaction_witness_elements(),
                 smv.max_satisfaction_size(),
             ),
-            WshInner::Ms(ref ms) => (
+            WshInner::Ms(ms) => (
                 ms.script_size(),
                 ms.max_satisfaction_witness_elements()?,
                 ms.max_satisfaction_size()?,
@@ -288,9 +288,9 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Wsh<Pk> {
         Pk: 'a,
         Pk::Hash: 'a,
     {
-        match self.inner {
-            WshInner::SortedMulti(ref smv) => smv.for_each_key(pred),
-            WshInner::Ms(ref ms) => ms.for_each_key(pred),
+        match &self.inner {
+            WshInner::SortedMulti(smv) => smv.for_each_key(pred),
+            WshInner::Ms(ms) => ms.for_each_key(pred),
         }
     }
 }
@@ -307,9 +307,9 @@ where
         Fpk: FnMut(&P) -> Result<Q, E>,
         Fpkh: FnMut(&P::Hash) -> Result<Q::Hash, E>,
     {
-        let inner = match self.inner {
-            WshInner::SortedMulti(ref smv) => WshInner::SortedMulti(smv.translate_pk(&mut fpk)?),
-            WshInner::Ms(ref ms) => WshInner::Ms(ms.translate_pk(&mut fpk, &mut fpkh)?),
+        let inner = match &self.inner {
+            WshInner::SortedMulti(smv) => WshInner::SortedMulti(smv.translate_pk(&mut fpk)?),
+            WshInner::Ms(ms) => WshInner::Ms(ms.translate_pk(&mut fpk, &mut fpkh)?),
         };
         Ok(Wsh { inner })
     }

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -183,27 +183,27 @@ impl From<crate::Error> for Error {
 
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
+        match self {
             Error::Secp(ref err) => Some(err),
-            ref x => Some(x),
+            x => Some(x),
         }
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             Error::AbsoluteLocktimeNotMet(n) => write!(
                 f,
                 "required absolute locktime CLTV of {} blocks, not met",
                 n
             ),
             Error::CannotInferTrDescriptors => write!(f, "Cannot infer taproot descriptors"),
-            Error::ControlBlockParse(ref e) => write!(f, "Control block parse error {}", e),
+            Error::ControlBlockParse(e) => write!(f, "Control block parse error {}", e),
             Error::ControlBlockVerificationError => {
                 f.write_str("Control block verification failed")
             }
-            Error::EcdsaSig(ref s) => write!(f, "Ecdsa sig error: {}", s),
+            Error::EcdsaSig(s) => write!(f, "Ecdsa sig error: {}", s),
             Error::ExpectedPush => f.write_str("expected push in script"),
             Error::CouldNotEvaluate => f.write_str("Interpreter Error: Could not evaluate"),
             Error::HashPreimageLengthMismatch => f.write_str("Hash preimage should be 32 bytes"),
@@ -214,7 +214,7 @@ impl fmt::Display for Error {
             }
             Error::IncorrectWScriptHash => f.write_str("witness script did not match scriptpubkey"),
             Error::InsufficientSignaturesMultiSig => f.write_str("Insufficient signatures for CMS"),
-            Error::InvalidSchnorrSighashType(ref sig) => {
+            Error::InvalidSchnorrSighashType(sig) => {
                 write!(
                     f,
                     "Invalid sighash type for schnorr signature '{}'",
@@ -223,7 +223,7 @@ impl fmt::Display for Error {
             }
             Error::InvalidEcdsaSignature(pk) => write!(f, "bad ecdsa signature with pk {}", pk),
             Error::InvalidSchnorrSignature(pk) => write!(f, "bad schnorr signature with pk {}", pk),
-            Error::NonStandardSighash(ref sig) => {
+            Error::NonStandardSighash(sig) => {
                 write!(
                     f,
                     "Non standard sighash type for signature '{}'",
@@ -232,22 +232,22 @@ impl fmt::Display for Error {
             }
             Error::NonEmptyWitness => f.write_str("legacy spend had nonempty witness"),
             Error::NonEmptyScriptSig => f.write_str("segwit spend had nonempty scriptsig"),
-            Error::Miniscript(ref e) => write!(f, "parse error: {}", e),
+            Error::Miniscript(e) => write!(f, "parse error: {}", e),
             Error::MissingExtraZeroMultiSig => f.write_str("CMS missing extra zero"),
             Error::MultiSigEvaluationError => {
                 f.write_str("CMS script aborted, incorrect satisfaction/dissatisfaction")
             }
-            Error::PkEvaluationError(ref key) => write!(f, "Incorrect Signature for pk {}", key),
-            Error::PkHashVerifyFail(ref hash) => write!(f, "Pubkey Hash check failed {}", hash),
+            Error::PkEvaluationError(key) => write!(f, "Incorrect Signature for pk {}", key),
+            Error::PkHashVerifyFail(hash) => write!(f, "Pubkey Hash check failed {}", hash),
             Error::PubkeyParseError => f.write_str("could not parse pubkey"),
             Error::XOnlyPublicKeyParseError => f.write_str("could not parse x-only pubkey"),
             Error::RelativeLocktimeNotMet(n) => {
                 write!(f, "required relative locktime CSV of {} blocks, not met", n)
             }
             Error::ScriptSatisfactionError => f.write_str("Top level script must be satisfied"),
-            Error::Secp(ref e) => fmt::Display::fmt(e, f),
-            Error::SchnorrSig(ref s) => write!(f, "Schnorr sig error: {}", s),
-            Error::SighashError(ref e) => fmt::Display::fmt(e, f),
+            Error::Secp(e) => fmt::Display::fmt(&e, f),
+            Error::SchnorrSig(s) => write!(f, "Schnorr sig error: {}", s),
+            Error::SighashError(e) => fmt::Display::fmt(&e, f),
             Error::TapAnnexUnsupported => f.write_str("Encountered annex element"),
             Error::UncompressedPubkey => {
                 f.write_str("uncompressed pubkey in non-legacy descriptor")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -630,7 +630,7 @@ fn errstr(s: &str) -> Error {
 
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
+        match self {
             Error::BadPubkey(ref e) => Some(e),
             _ => None,
         }
@@ -644,26 +644,26 @@ const MAX_SCRIPT_SIZE: u32 = 10000;
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             Error::InvalidOpcode(op) => write!(f, "invalid opcode {}", op),
-            Error::NonMinimalVerify(ref tok) => write!(f, "{} VERIFY", tok),
-            Error::InvalidPush(ref push) => write!(f, "invalid push {:?}", push), // TODO hexify this
-            Error::Script(ref e) => fmt::Display::fmt(e, f),
-            Error::AddrError(ref e) => fmt::Display::fmt(e, f),
+            Error::NonMinimalVerify(tok) => write!(f, "{} VERIFY", tok),
+            Error::InvalidPush(push) => write!(f, "invalid push {:?}", push), // TODO hexify this
+            Error::Script(e) => fmt::Display::fmt(&e, f),
+            Error::AddrError(e) => fmt::Display::fmt(&e, f),
             Error::CmsTooManyKeys(n) => write!(f, "checkmultisig with {} keys", n),
             Error::Unprintable(x) => write!(f, "unprintable character 0x{:02x}", x),
             Error::ExpectedChar(c) => write!(f, "expected {}", c),
             Error::UnexpectedStart => f.write_str("unexpected start of script"),
-            Error::Unexpected(ref s) => write!(f, "unexpected «{}»", s),
-            Error::MultiColon(ref s) => write!(f, "«{}» has multiple instances of «:»", s),
-            Error::MultiAt(ref s) => write!(f, "«{}» has multiple instances of «@»", s),
-            Error::AtOutsideOr(ref s) => write!(f, "«{}» contains «@» in non-or() context", s),
+            Error::Unexpected(s) => write!(f, "unexpected «{}»", s),
+            Error::MultiColon(s) => write!(f, "«{}» has multiple instances of «:»", s),
+            Error::MultiAt(s) => write!(f, "«{}» has multiple instances of «@»", s),
+            Error::AtOutsideOr(s) => write!(f, "«{}» contains «@» in non-or() context", s),
             Error::LikelyFalse => write!(f, "0 is not very likely (use «u:0»)"),
             Error::UnknownWrapper(ch) => write!(f, "unknown wrapper «{}:»", ch),
-            Error::NonTopLevel(ref s) => write!(f, "non-T miniscript: {}", s),
-            Error::Trailing(ref s) => write!(f, "trailing tokens: {}", s),
-            Error::MissingHash(ref h) => write!(f, "missing preimage of hash {}", h),
-            Error::MissingSig(ref pk) => write!(f, "missing signature for key {:?}", pk),
+            Error::NonTopLevel(s) => write!(f, "non-T miniscript: {}", s),
+            Error::Trailing(s) => write!(f, "trailing tokens: {}", s),
+            Error::MissingHash(h) => write!(f, "missing preimage of hash {}", h),
+            Error::MissingSig(pk) => write!(f, "missing signature for key {:?}", pk),
             Error::RelativeLocktimeNotMet(n) => {
                 write!(f, "required relative locktime CSV of {} blocks, not met", n)
             }
@@ -673,15 +673,15 @@ impl fmt::Display for Error {
                 n
             ),
             Error::CouldNotSatisfy => f.write_str("could not satisfy"),
-            Error::BadPubkey(ref e) => fmt::Display::fmt(e, f),
-            Error::TypeCheck(ref e) => write!(f, "typecheck: {}", e),
-            Error::BadDescriptor(ref e) => write!(f, "Invalid descriptor: {}", e),
-            Error::Secp(ref e) => fmt::Display::fmt(e, f),
-            Error::ContextError(ref e) => fmt::Display::fmt(e, f),
+            Error::BadPubkey(e) => fmt::Display::fmt(&e, f),
+            Error::TypeCheck(e) => write!(f, "typecheck: {}", e),
+            Error::BadDescriptor(e) => write!(f, "Invalid descriptor: {}", e),
+            Error::Secp(e) => fmt::Display::fmt(&e, f),
+            Error::ContextError(e) => fmt::Display::fmt(&e, f),
             #[cfg(feature = "compiler")]
-            Error::CompilerError(ref e) => fmt::Display::fmt(e, f),
-            Error::PolicyError(ref e) => fmt::Display::fmt(e, f),
-            Error::LiftError(ref e) => fmt::Display::fmt(e, f),
+            Error::CompilerError(e) => fmt::Display::fmt(e, f),
+            Error::PolicyError(e) => fmt::Display::fmt(&e, f),
+            Error::LiftError(e) => fmt::Display::fmt(&e, f),
             Error::MaxRecursiveDepthExceeded => write!(
                 f,
                 "Recursive depth over {} not permitted",
@@ -698,10 +698,10 @@ impl fmt::Display for Error {
                 up to n=3 is invalid by standardness (bare).
                 "
             ),
-            Error::AnalysisError(ref e) => e.fmt(f),
+            Error::AnalysisError(e) => e.fmt(f),
             Error::ImpossibleSatisfaction => write!(f, "Impossible to satisfy Miniscript"),
             Error::BareDescriptorAddr => write!(f, "Bare descriptors don't have address"),
-            Error::PubKeyCtxError(ref pk, ref ctx) => {
+            Error::PubKeyCtxError(pk, ctx) => {
                 write!(f, "Pubkey error: {} under {} scriptcontext", pk, ctx)
             }
             Error::MultiATooManyKeys(k) => {

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -55,27 +55,27 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Enumerates all child nodes of the current AST node (`self`) and returns a `Vec` referencing
     /// them.
     pub fn branches(&self) -> Vec<&Miniscript<Pk, Ctx>> {
-        match self.node {
+        match &self.node {
             Terminal::PkK(_) | Terminal::PkH(_) | Terminal::Multi(_, _) => vec![],
 
-            Terminal::Alt(ref node)
-            | Terminal::Swap(ref node)
-            | Terminal::Check(ref node)
-            | Terminal::DupIf(ref node)
-            | Terminal::Verify(ref node)
-            | Terminal::NonZero(ref node)
-            | Terminal::ZeroNotEqual(ref node) => vec![node],
+            Terminal::Alt(node)
+            | Terminal::Swap(node)
+            | Terminal::Check(node)
+            | Terminal::DupIf(node)
+            | Terminal::Verify(node)
+            | Terminal::NonZero(node)
+            | Terminal::ZeroNotEqual(node) => vec![&node],
 
-            Terminal::AndV(ref node1, ref node2)
-            | Terminal::AndB(ref node1, ref node2)
-            | Terminal::OrB(ref node1, ref node2)
-            | Terminal::OrD(ref node1, ref node2)
-            | Terminal::OrC(ref node1, ref node2)
-            | Terminal::OrI(ref node1, ref node2) => vec![node1, node2],
+            Terminal::AndV(node1, node2)
+            | Terminal::AndB(node1, node2)
+            | Terminal::OrB(node1, node2)
+            | Terminal::OrD(node1, node2)
+            | Terminal::OrC(node1, node2)
+            | Terminal::OrI(node1, node2) => vec![&node1, &node2],
 
-            Terminal::AndOr(ref node1, ref node2, ref node3) => vec![node1, node2, node3],
+            Terminal::AndOr(node1, node2, node3) => vec![&node1, &node2, &node3],
 
-            Terminal::Thresh(_, ref node_vec) => node_vec.iter().map(Arc::deref).collect(),
+            Terminal::Thresh(_, node_vec) => node_vec.iter().map(Arc::deref).collect(),
 
             _ => vec![],
         }
@@ -84,30 +84,30 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Returns child node with given index, if any
     pub fn get_nth_child(&self, n: usize) -> Option<&Miniscript<Pk, Ctx>> {
         match (n, &self.node) {
-            (0, &Terminal::Alt(ref node))
-            | (0, &Terminal::Swap(ref node))
-            | (0, &Terminal::Check(ref node))
-            | (0, &Terminal::DupIf(ref node))
-            | (0, &Terminal::Verify(ref node))
-            | (0, &Terminal::NonZero(ref node))
-            | (0, &Terminal::ZeroNotEqual(ref node))
-            | (0, &Terminal::AndV(ref node, _))
-            | (0, &Terminal::AndB(ref node, _))
-            | (0, &Terminal::OrB(ref node, _))
-            | (0, &Terminal::OrD(ref node, _))
-            | (0, &Terminal::OrC(ref node, _))
-            | (0, &Terminal::OrI(ref node, _))
-            | (1, &Terminal::AndV(_, ref node))
-            | (1, &Terminal::AndB(_, ref node))
-            | (1, &Terminal::OrB(_, ref node))
-            | (1, &Terminal::OrD(_, ref node))
-            | (1, &Terminal::OrC(_, ref node))
-            | (1, &Terminal::OrI(_, ref node))
-            | (0, &Terminal::AndOr(ref node, _, _))
-            | (1, &Terminal::AndOr(_, ref node, _))
-            | (2, &Terminal::AndOr(_, _, ref node)) => Some(node),
+            (0, Terminal::Alt(node))
+            | (0, Terminal::Swap(node))
+            | (0, Terminal::Check(node))
+            | (0, Terminal::DupIf(node))
+            | (0, Terminal::Verify(node))
+            | (0, Terminal::NonZero(node))
+            | (0, Terminal::ZeroNotEqual(node))
+            | (0, Terminal::AndV(node, _))
+            | (0, Terminal::AndB(node, _))
+            | (0, Terminal::OrB(node, _))
+            | (0, Terminal::OrD(node, _))
+            | (0, Terminal::OrC(node, _))
+            | (0, Terminal::OrI(node, _))
+            | (1, Terminal::AndV(_, node))
+            | (1, Terminal::AndB(_, node))
+            | (1, Terminal::OrB(_, node))
+            | (1, Terminal::OrD(_, node))
+            | (1, Terminal::OrC(_, node))
+            | (1, Terminal::OrI(_, node))
+            | (0, Terminal::AndOr(node, _, _))
+            | (1, Terminal::AndOr(_, node, _))
+            | (2, Terminal::AndOr(_, _, node)) => Some(&node),
 
-            (n, &Terminal::Thresh(_, ref node_vec)) => node_vec.get(n).map(|x| &**x),
+            (n, Terminal::Thresh(_, node_vec)) => node_vec.get(n).map(|x| &**x),
 
             _ => None,
         }
@@ -120,9 +120,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// To obtain a list of all public keys within AST use [Miniscript::iter_pk()] function, for example
     /// `miniscript.iter_pubkeys().collect()`.
     pub fn get_leaf_pk(&self) -> Vec<Pk> {
-        match self.node {
-            Terminal::PkK(ref key) => vec![key.clone()],
-            Terminal::Multi(_, ref keys) | Terminal::MultiA(_, ref keys) => keys.clone(),
+        match &self.node {
+            Terminal::PkK(key) => vec![key.clone()],
+            Terminal::Multi(_, keys) | Terminal::MultiA(_, keys) => keys.clone(),
             _ => vec![],
         }
     }
@@ -137,10 +137,10 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// To obtain a list of all public key hashes within AST use [Miniscript::iter_pkh()] function,
     /// for example `miniscript.iter_pubkey_hashes().collect()`.
     pub fn get_leaf_pkh(&self) -> Vec<Pk::Hash> {
-        match self.node {
-            Terminal::PkH(ref hash) => vec![hash.clone()],
-            Terminal::PkK(ref key) => vec![key.to_pubkeyhash()],
-            Terminal::Multi(_, ref keys) | Terminal::MultiA(_, ref keys) => {
+        match &self.node {
+            Terminal::PkH(hash) => vec![hash.clone()],
+            Terminal::PkK(key) => vec![key.to_pubkeyhash()],
+            Terminal::Multi(_, keys) | Terminal::MultiA(_, keys) => {
                 keys.iter().map(Pk::to_pubkeyhash).collect()
             }
             _ => vec![],
@@ -155,10 +155,10 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// To obtain a list of all public keys or hashes within AST use [Miniscript::iter_pk_pkh()]
     /// function, for example `miniscript.iter_pubkeys_and_hashes().collect()`.
     pub fn get_leaf_pk_pkh(&self) -> Vec<PkPkh<Pk>> {
-        match self.node {
-            Terminal::PkH(ref hash) => vec![PkPkh::HashedPubkey(hash.clone())],
-            Terminal::PkK(ref key) => vec![PkPkh::PlainPubkey(key.clone())],
-            Terminal::Multi(_, ref keys) | Terminal::MultiA(_, ref keys) => keys
+        match &self.node {
+            Terminal::PkH(hash) => vec![PkPkh::HashedPubkey(hash.clone())],
+            Terminal::PkK(key) => vec![PkPkh::PlainPubkey(key.clone())],
+            Terminal::Multi(_, keys) | Terminal::MultiA(_, keys) => keys
                 .iter()
                 .map(|key| PkPkh::PlainPubkey(key.clone()))
                 .collect(),
@@ -171,11 +171,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     ///
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
     pub fn get_nth_pk(&self, n: usize) -> Option<Pk> {
-        match (&self.node, n) {
-            (&Terminal::PkK(ref key), 0) => Some(key.clone()),
-            (&Terminal::Multi(_, ref keys), _) | (&Terminal::MultiA(_, ref keys), _) => {
-                keys.get(n).cloned()
-            }
+        match &(&self.node, n) {
+            (Terminal::PkK(key), 0) => Some(key.clone()),
+            (Terminal::Multi(_, keys), _) | (Terminal::MultiA(_, keys), _) => keys.get(n).cloned(),
             _ => None,
         }
     }
@@ -189,9 +187,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
     pub fn get_nth_pkh(&self, n: usize) -> Option<Pk::Hash> {
         match (&self.node, n) {
-            (&Terminal::PkH(ref hash), 0) => Some(hash.clone()),
-            (&Terminal::PkK(ref key), 0) => Some(key.to_pubkeyhash()),
-            (&Terminal::Multi(_, ref keys), _) | (&Terminal::MultiA(_, ref keys), _) => {
+            (Terminal::PkH(hash), 0) => Some(hash.clone()),
+            (Terminal::PkK(key), 0) => Some(key.to_pubkeyhash()),
+            (Terminal::Multi(_, keys), _) | (Terminal::MultiA(_, keys), _) => {
                 keys.get(n).map(Pk::to_pubkeyhash)
             }
             _ => None,
@@ -204,9 +202,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
     pub fn get_nth_pk_pkh(&self, n: usize) -> Option<PkPkh<Pk>> {
         match (&self.node, n) {
-            (&Terminal::PkH(ref hash), 0) => Some(PkPkh::HashedPubkey(hash.clone())),
-            (&Terminal::PkK(ref key), 0) => Some(PkPkh::PlainPubkey(key.clone())),
-            (&Terminal::Multi(_, ref keys), _) | (&Terminal::MultiA(_, ref keys), _) => {
+            (Terminal::PkH(hash), 0) => Some(PkPkh::HashedPubkey(hash.clone())),
+            (Terminal::PkK(key), 0) => Some(PkPkh::PlainPubkey(key.clone())),
+            (Terminal::Multi(_, keys), _) | (Terminal::MultiA(_, keys), _) => {
                 keys.get(n).map(|key| PkPkh::PlainPubkey(key.clone()))
             }
             _ => None,

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -900,27 +900,27 @@ impl Property for ExtData {
             })
         };
 
-        let ret = match *fragment {
+        let ret = match fragment {
             Terminal::True => Ok(Self::from_true()),
             Terminal::False => Ok(Self::from_false()),
             Terminal::PkK(..) => Ok(Self::from_pk_k()),
             Terminal::PkH(..) => Ok(Self::from_pk_h()),
-            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
-                if k == 0 {
+            Terminal::Multi(k, pks) | Terminal::MultiA(k, pks) => {
+                if *k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::ZeroThreshold,
                     });
                 }
-                if k > pks.len() {
+                if *k > pks.len() {
                     return Err(Error {
                         fragment: fragment.clone(),
-                        error: ErrorKind::OverThreshold(k, pks.len()),
+                        error: ErrorKind::OverThreshold(*k, pks.len()),
                     });
                 }
                 match *fragment {
-                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
-                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
+                    Terminal::Multi(..) => Ok(Self::from_multi(*k, pks.len())),
+                    Terminal::MultiA(..) => Ok(Self::from_multi_a(*k, pks.len())),
                     _ => unreachable!(),
                 }
             }
@@ -928,85 +928,85 @@ impl Property for ExtData {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
                 // number on the stack would be a 5 bytes signed integer but Miniscript's B type
                 // only consumes 4 bytes from the stack.
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
+                if *t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_after(t))
+                Ok(Self::from_after(*t))
             }
             Terminal::Older(t) => {
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
+                if *t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_older(t))
+                Ok(Self::from_older(*t))
             }
             Terminal::Sha256(..) => Ok(Self::from_sha256()),
             Terminal::Hash256(..) => Ok(Self::from_hash256()),
             Terminal::Ripemd160(..) => Ok(Self::from_ripemd160()),
             Terminal::Hash160(..) => Ok(Self::from_hash160()),
-            Terminal::Alt(ref sub) => wrap_err(Self::cast_alt(sub.ext)),
-            Terminal::Swap(ref sub) => wrap_err(Self::cast_swap(sub.ext)),
-            Terminal::Check(ref sub) => wrap_err(Self::cast_check(sub.ext)),
-            Terminal::DupIf(ref sub) => wrap_err(Self::cast_dupif(sub.ext)),
-            Terminal::Verify(ref sub) => wrap_err(Self::cast_verify(sub.ext)),
-            Terminal::NonZero(ref sub) => wrap_err(Self::cast_nonzero(sub.ext)),
-            Terminal::ZeroNotEqual(ref sub) => wrap_err(Self::cast_zeronotequal(sub.ext)),
-            Terminal::AndB(ref l, ref r) => {
+            Terminal::Alt(sub) => wrap_err(Self::cast_alt(sub.ext)),
+            Terminal::Swap(sub) => wrap_err(Self::cast_swap(sub.ext)),
+            Terminal::Check(sub) => wrap_err(Self::cast_check(sub.ext)),
+            Terminal::DupIf(sub) => wrap_err(Self::cast_dupif(sub.ext)),
+            Terminal::Verify(sub) => wrap_err(Self::cast_verify(sub.ext)),
+            Terminal::NonZero(sub) => wrap_err(Self::cast_nonzero(sub.ext)),
+            Terminal::ZeroNotEqual(sub) => wrap_err(Self::cast_zeronotequal(sub.ext)),
+            Terminal::AndB(l, r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
                 wrap_err(Self::and_b(ltype, rtype))
             }
-            Terminal::AndV(ref l, ref r) => {
+            Terminal::AndV(l, r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
                 wrap_err(Self::and_v(ltype, rtype))
             }
-            Terminal::OrB(ref l, ref r) => {
+            Terminal::OrB(l, r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
                 wrap_err(Self::or_b(ltype, rtype))
             }
-            Terminal::OrD(ref l, ref r) => {
+            Terminal::OrD(l, r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
                 wrap_err(Self::or_d(ltype, rtype))
             }
-            Terminal::OrC(ref l, ref r) => {
+            Terminal::OrC(l, r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
                 wrap_err(Self::or_c(ltype, rtype))
             }
-            Terminal::OrI(ref l, ref r) => {
+            Terminal::OrI(l, r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
                 wrap_err(Self::or_i(ltype, rtype))
             }
-            Terminal::AndOr(ref a, ref b, ref c) => {
+            Terminal::AndOr(a, b, c) => {
                 let atype = a.ext;
                 let btype = b.ext;
                 let ctype = c.ext;
                 wrap_err(Self::and_or(atype, btype, ctype))
             }
-            Terminal::Thresh(k, ref subs) => {
-                if k == 0 {
+            Terminal::Thresh(k, subs) => {
+                if *k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::ZeroThreshold,
                     });
                 }
-                if k > subs.len() {
+                if *k > subs.len() {
                     return Err(Error {
                         fragment: fragment.clone(),
-                        error: ErrorKind::OverThreshold(k, subs.len()),
+                        error: ErrorKind::OverThreshold(*k, subs.len()),
                     });
                 }
 
-                let res = Self::threshold(k, subs.len(), |n| Ok(subs[n].ext));
+                let res = Self::threshold(*k, subs.len(), |n| Ok(subs[n].ext));
 
                 res.map_err(|kind| Error {
                     fragment: fragment.clone(),
@@ -1014,7 +1014,7 @@ impl Property for ExtData {
                 })
             }
         };
-        if let Ok(ref ret) = ret {
+        if let Ok(ret) = ret {
             ret.sanity_checks()
         }
         ret

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -410,27 +410,27 @@ pub trait Property: Sized {
             })
         };
 
-        let ret = match *fragment {
+        let ret = match fragment {
             Terminal::True => Ok(Self::from_true()),
             Terminal::False => Ok(Self::from_false()),
             Terminal::PkK(..) => Ok(Self::from_pk_k()),
             Terminal::PkH(..) => Ok(Self::from_pk_h()),
-            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
-                if k == 0 {
+            Terminal::Multi(k, pks) | Terminal::MultiA(k, pks) => {
+                if *k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::ZeroThreshold,
                     });
                 }
-                if k > pks.len() {
+                if *k > pks.len() {
                     return Err(Error {
                         fragment: fragment.clone(),
-                        error: ErrorKind::OverThreshold(k, pks.len()),
+                        error: ErrorKind::OverThreshold(*k, pks.len()),
                     });
                 }
                 match *fragment {
-                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
-                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
+                    Terminal::Multi(..) => Ok(Self::from_multi(*k, pks.len())),
+                    Terminal::MultiA(..) => Ok(Self::from_multi_a(*k, pks.len())),
                     _ => unreachable!(),
                 }
             }
@@ -438,88 +438,88 @@ pub trait Property: Sized {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
                 // number on the stack would be a 5 bytes signed integer but Miniscript's B type
                 // only consumes 4 bytes from the stack.
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
+                if *t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_after(t))
+                Ok(Self::from_after(*t))
             }
             Terminal::Older(t) => {
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
+                if *t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_older(t))
+                Ok(Self::from_older(*t))
             }
             Terminal::Sha256(..) => Ok(Self::from_sha256()),
             Terminal::Hash256(..) => Ok(Self::from_hash256()),
             Terminal::Ripemd160(..) => Ok(Self::from_ripemd160()),
             Terminal::Hash160(..) => Ok(Self::from_hash160()),
-            Terminal::Alt(ref sub) => wrap_err(Self::cast_alt(get_child(&sub.node, 0)?)),
-            Terminal::Swap(ref sub) => wrap_err(Self::cast_swap(get_child(&sub.node, 0)?)),
-            Terminal::Check(ref sub) => wrap_err(Self::cast_check(get_child(&sub.node, 0)?)),
-            Terminal::DupIf(ref sub) => wrap_err(Self::cast_dupif(get_child(&sub.node, 0)?)),
-            Terminal::Verify(ref sub) => wrap_err(Self::cast_verify(get_child(&sub.node, 0)?)),
-            Terminal::NonZero(ref sub) => wrap_err(Self::cast_nonzero(get_child(&sub.node, 0)?)),
-            Terminal::ZeroNotEqual(ref sub) => {
+            Terminal::Alt(sub) => wrap_err(Self::cast_alt(get_child(&sub.node, 0)?)),
+            Terminal::Swap(sub) => wrap_err(Self::cast_swap(get_child(&sub.node, 0)?)),
+            Terminal::Check(sub) => wrap_err(Self::cast_check(get_child(&sub.node, 0)?)),
+            Terminal::DupIf(sub) => wrap_err(Self::cast_dupif(get_child(&sub.node, 0)?)),
+            Terminal::Verify(sub) => wrap_err(Self::cast_verify(get_child(&sub.node, 0)?)),
+            Terminal::NonZero(sub) => wrap_err(Self::cast_nonzero(get_child(&sub.node, 0)?)),
+            Terminal::ZeroNotEqual(sub) => {
                 wrap_err(Self::cast_zeronotequal(get_child(&sub.node, 0)?))
             }
-            Terminal::AndB(ref l, ref r) => {
+            Terminal::AndB(l, r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::and_b(ltype, rtype))
             }
-            Terminal::AndV(ref l, ref r) => {
+            Terminal::AndV(l, r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::and_v(ltype, rtype))
             }
-            Terminal::OrB(ref l, ref r) => {
+            Terminal::OrB(l, r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::or_b(ltype, rtype))
             }
-            Terminal::OrD(ref l, ref r) => {
+            Terminal::OrD(l, r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::or_d(ltype, rtype))
             }
-            Terminal::OrC(ref l, ref r) => {
+            Terminal::OrC(l, r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::or_c(ltype, rtype))
             }
-            Terminal::OrI(ref l, ref r) => {
+            Terminal::OrI(l, r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
                 wrap_err(Self::or_i(ltype, rtype))
             }
-            Terminal::AndOr(ref a, ref b, ref c) => {
+            Terminal::AndOr(a, b, c) => {
                 let atype = get_child(&a.node, 0)?;
                 let btype = get_child(&b.node, 1)?;
                 let ctype = get_child(&c.node, 2)?;
                 wrap_err(Self::and_or(atype, btype, ctype))
             }
-            Terminal::Thresh(k, ref subs) => {
-                if k == 0 {
+            Terminal::Thresh(k, subs) => {
+                if *k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::ZeroThreshold,
                     });
                 }
-                if k > subs.len() {
+                if *k > subs.len() {
                     return Err(Error {
                         fragment: fragment.clone(),
-                        error: ErrorKind::OverThreshold(k, subs.len()),
+                        error: ErrorKind::OverThreshold(*k, subs.len()),
                     });
                 }
 
                 let mut last_err_frag = None;
-                let res = Self::threshold(k, subs.len(), |n| match get_child(&subs[n].node, n) {
+                let res = Self::threshold(*k, subs.len(), |n| match get_child(&subs[n].node, n) {
                     Ok(x) => Ok(x),
                     Err(e) => {
                         last_err_frag = Some(e.fragment);
@@ -533,7 +533,7 @@ pub trait Property: Sized {
                 })
             }
         };
-        if let Ok(ref ret) = ret {
+        if let Ok(ret) = &ret {
             ret.sanity_checks()
         }
         ret
@@ -793,27 +793,27 @@ impl Property for Type {
             })
         };
 
-        let ret = match *fragment {
+        let ret = match fragment {
             Terminal::True => Ok(Self::from_true()),
             Terminal::False => Ok(Self::from_false()),
             Terminal::PkK(..) => Ok(Self::from_pk_k()),
             Terminal::PkH(..) => Ok(Self::from_pk_h()),
-            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
-                if k == 0 {
+            Terminal::Multi(k, pks) | Terminal::MultiA(k, pks) => {
+                if *k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::ZeroThreshold,
                     });
                 }
-                if k > pks.len() {
+                if *k > pks.len() {
                     return Err(Error {
                         fragment: fragment.clone(),
-                        error: ErrorKind::OverThreshold(k, pks.len()),
+                        error: ErrorKind::OverThreshold(*k, pks.len()),
                     });
                 }
                 match *fragment {
-                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
-                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
+                    Terminal::Multi(..) => Ok(Self::from_multi(*k, pks.len())),
+                    Terminal::MultiA(..) => Ok(Self::from_multi_a(*k, pks.len())),
                     _ => unreachable!(),
                 }
             }
@@ -821,85 +821,85 @@ impl Property for Type {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
                 // number on the stack would be a 5 bytes signed integer but Miniscript's B type
                 // only consumes 4 bytes from the stack.
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
+                if *t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_after(t))
+                Ok(Self::from_after(*t))
             }
             Terminal::Older(t) => {
-                if t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
+                if *t == 0 || (t & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_older(t))
+                Ok(Self::from_older(*t))
             }
             Terminal::Sha256(..) => Ok(Self::from_sha256()),
             Terminal::Hash256(..) => Ok(Self::from_hash256()),
             Terminal::Ripemd160(..) => Ok(Self::from_ripemd160()),
             Terminal::Hash160(..) => Ok(Self::from_hash160()),
-            Terminal::Alt(ref sub) => wrap_err(Self::cast_alt(sub.ty)),
-            Terminal::Swap(ref sub) => wrap_err(Self::cast_swap(sub.ty)),
-            Terminal::Check(ref sub) => wrap_err(Self::cast_check(sub.ty)),
-            Terminal::DupIf(ref sub) => wrap_err(Self::cast_dupif(sub.ty)),
-            Terminal::Verify(ref sub) => wrap_err(Self::cast_verify(sub.ty)),
-            Terminal::NonZero(ref sub) => wrap_err(Self::cast_nonzero(sub.ty)),
-            Terminal::ZeroNotEqual(ref sub) => wrap_err(Self::cast_zeronotequal(sub.ty)),
-            Terminal::AndB(ref l, ref r) => {
+            Terminal::Alt(sub) => wrap_err(Self::cast_alt(sub.ty)),
+            Terminal::Swap(sub) => wrap_err(Self::cast_swap(sub.ty)),
+            Terminal::Check(sub) => wrap_err(Self::cast_check(sub.ty)),
+            Terminal::DupIf(sub) => wrap_err(Self::cast_dupif(sub.ty)),
+            Terminal::Verify(sub) => wrap_err(Self::cast_verify(sub.ty)),
+            Terminal::NonZero(sub) => wrap_err(Self::cast_nonzero(sub.ty)),
+            Terminal::ZeroNotEqual(sub) => wrap_err(Self::cast_zeronotequal(sub.ty)),
+            Terminal::AndB(l, r) => {
                 let ltype = l.ty;
                 let rtype = r.ty;
                 wrap_err(Self::and_b(ltype, rtype))
             }
-            Terminal::AndV(ref l, ref r) => {
+            Terminal::AndV(l, r) => {
                 let ltype = l.ty;
                 let rtype = r.ty;
                 wrap_err(Self::and_v(ltype, rtype))
             }
-            Terminal::OrB(ref l, ref r) => {
+            Terminal::OrB(l, r) => {
                 let ltype = l.ty;
                 let rtype = r.ty;
                 wrap_err(Self::or_b(ltype, rtype))
             }
-            Terminal::OrD(ref l, ref r) => {
+            Terminal::OrD(l, r) => {
                 let ltype = l.ty;
                 let rtype = r.ty;
                 wrap_err(Self::or_d(ltype, rtype))
             }
-            Terminal::OrC(ref l, ref r) => {
+            Terminal::OrC(l, r) => {
                 let ltype = l.ty;
                 let rtype = r.ty;
                 wrap_err(Self::or_c(ltype, rtype))
             }
-            Terminal::OrI(ref l, ref r) => {
+            Terminal::OrI(l, r) => {
                 let ltype = l.ty;
                 let rtype = r.ty;
                 wrap_err(Self::or_i(ltype, rtype))
             }
-            Terminal::AndOr(ref a, ref b, ref c) => {
+            Terminal::AndOr(a, b, c) => {
                 let atype = a.ty;
                 let btype = b.ty;
                 let ctype = c.ty;
                 wrap_err(Self::and_or(atype, btype, ctype))
             }
-            Terminal::Thresh(k, ref subs) => {
-                if k == 0 {
+            Terminal::Thresh(k, subs) => {
+                if *k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::ZeroThreshold,
                     });
                 }
-                if k > subs.len() {
+                if *k > subs.len() {
                     return Err(Error {
                         fragment: fragment.clone(),
-                        error: ErrorKind::OverThreshold(k, subs.len()),
+                        error: ErrorKind::OverThreshold(*k, subs.len()),
                     });
                 }
 
-                let res = Self::threshold(k, subs.len(), |n| Ok(subs[n].ty));
+                let res = Self::threshold(*k, subs.len(), |n| Ok(subs[n].ty));
 
                 res.map_err(|kind| Error {
                     fragment: fragment.clone(),
@@ -907,7 +907,7 @@ impl Property for Type {
                 })
             }
         };
-        if let Ok(ref ret) = ret {
+        if let Ok(ret) = ret {
             ret.sanity_checks()
         }
         ret

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -130,31 +130,30 @@ pub enum Error {
 
 impl fmt::Display for InputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            InputError::InvalidSignature {
-                ref pubkey,
-                ref sig,
-            } => write!(f, "PSBT: bad signature {} for key {:?}", pubkey, sig),
-            InputError::KeyErr(ref e) => write!(f, "Key Err: {}", e),
-            InputError::Interpreter(ref e) => write!(f, "Interpreter: {}", e),
-            InputError::SecpErr(ref e) => write!(f, "Secp Err: {}", e),
+        match self {
+            InputError::InvalidSignature { pubkey, sig } => {
+                write!(f, "PSBT: bad signature {} for key {:?}", pubkey, sig)
+            }
+            InputError::KeyErr(e) => write!(f, "Key Err: {}", e),
+            InputError::Interpreter(e) => write!(f, "Interpreter: {}", e),
+            InputError::SecpErr(e) => write!(f, "Secp Err: {}", e),
             InputError::InvalidRedeemScript {
-                ref redeem,
-                ref p2sh_expected,
+                redeem,
+                p2sh_expected,
             } => write!(
                 f,
                 "Redeem script {} does not match the p2sh script {}",
                 redeem, p2sh_expected
             ),
             InputError::InvalidWitnessScript {
-                ref witness_script,
-                ref p2wsh_expected,
+                witness_script,
+                p2wsh_expected,
             } => write!(
                 f,
                 "Witness script {} does not match the p2wsh script {}",
                 witness_script, p2wsh_expected
             ),
-            InputError::MiniscriptError(ref e) => write!(f, "Miniscript Error: {}", e),
+            InputError::MiniscriptError(e) => write!(f, "Miniscript Error: {}", e),
             InputError::MissingWitness => write!(f, "PSBT is missing witness"),
             InputError::MissingRedeemScript => write!(f, "PSBT is Redeem script"),
             InputError::MissingUtxo => {
@@ -212,8 +211,8 @@ impl error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::InputError(ref inp_err, index) => write!(f, "{} at index {}", inp_err, index),
+        match self {
+            Error::InputError(inp_err, index) => write!(f, "{} at index {}", inp_err, index),
             Error::WrongInputCount { in_tx, in_map } => write!(
                 f,
                 "PSBT had {} inputs in transaction but {} inputs in map",


### PR DESCRIPTION
This one smells like code churn, raising as draft for comments.

We currently use `ref` _a lot_. This patch falls victim to 'if you only have a hammer everything looks like a nail' - I did a search and replace  `s/ref //g` on every source file then fixed the build errors. This almost certainly means I removed 'good' uses of `ref`.

An example of a code improvement is:

Before this patch is applied we had:

```rust
    pub fn into_pre_taproot_desc(self) -> Result<pretaproot::PreTaprootDescriptor<Pk>, Self> {
        match *self {
            Descriptor::Bare(ref bare) => Ok(pretaproot::PreTaprootDescriptor::Bare(bare)),
            Descriptor::Pkh(ref pkh) => Ok(pretaproot::PreTaprootDescriptor::Pkh(pkh)),
            Descriptor::Wpkh(ref wpkh) => Ok(pretaproot::PreTaprootDescriptor::Wpkh(wpkh)),
            Descriptor::Sh(ref sh) => Ok(pretaproot::PreTaprootDescriptor::Sh(sh)),
            Descriptor::Wsh(ref wsh) => Ok(pretaproot::PreTaprootDescriptor::Wsh(wsh)),
            Descriptor::Tr(ref tr) => Err(Descriptor::Tr(tr)),
        }
    }
```
All these `ref`s are not required if we remove the dereference from `self`.

A not so good result of this patch is having to write `*k` in a bunch of places instead of `k`.

Please note patch includes such things as:
```rust
	WshInner::Ms(_ms) => DescriptorType::Wsh,
```

The `_ms` could become `_`, will do if this work is deemed valuable.