### PR TITLE
Implement `source` for error types

### DIFF
--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -219,7 +219,11 @@ impl fmt::Display for DescriptorKeyParseError {
     }
 }
 
-impl error::Error for DescriptorKeyParseError {}
+impl error::Error for DescriptorKeyParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
 
 impl fmt::Display for DescriptorPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -369,7 +373,15 @@ impl fmt::Display for ConversionError {
     }
 }
 
-impl error::Error for ConversionError {}
+impl error::Error for ConversionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use self::ConversionError::*;
+
+        match self {
+            Wildcard | HardenedChild | HardenedWildcard => None,
+        }
+    }
+}
 
 impl DescriptorPublicKey {
     /// The fingerprint of the master key associated with this key, `0x00000000` if none.

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -194,9 +194,46 @@ impl fmt::Display for Error {
 
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Secp(ref err) => Some(err),
-            ref x => Some(x),
+        use self::Error::*;
+
+        match self {
+            AbsoluteLocktimeNotMet(_)
+            | CannotInferTrDescriptors
+            | ControlBlockVerificationError
+            | CouldNotEvaluate
+            | ExpectedPush
+            | HashPreimageLengthMismatch
+            | IncorrectPubkeyHash
+            | IncorrectScriptHash
+            | IncorrectWPubkeyHash
+            | IncorrectWScriptHash
+            | InsufficientSignaturesMultiSig
+            | InvalidEcdsaSignature(_)
+            | InvalidSchnorrSignature(_)
+            | InvalidSchnorrSighashType(_)
+            | NonStandardSighash(_)
+            | MissingExtraZeroMultiSig
+            | MultiSigEvaluationError
+            | NonEmptyWitness
+            | NonEmptyScriptSig
+            | PubkeyParseError
+            | XOnlyPublicKeyParseError
+            | PkEvaluationError(_)
+            | PkHashVerifyFail(_)
+            | RelativeLocktimeNotMet(_)
+            | ScriptSatisfactionError
+            | TapAnnexUnsupported
+            | UncompressedPubkey
+            | UnexpectedStackBoolean
+            | UnexpectedStackEnd
+            | UnexpectedStackElementPush
+            | VerifyFailed => None,
+            ControlBlockParse(e) => Some(e),
+            EcdsaSig(e) => Some(e),
+            Miniscript(e) => Some(e),
+            Secp(e) => Some(e),
+            SchnorrSig(e) => Some(e),
+            SighashError(e) => Some(e),
         }
     }
 }

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -118,78 +118,6 @@ pub enum Error {
     VerifyFailed,
 }
 
-/// A type of representing which keys errored during interpreter checksig evaluation
-// Note that we can't use BitcoinKey because it is not public
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum PkEvalErrInner {
-    /// Full Key
-    FullKey(bitcoin::PublicKey),
-    /// XOnly Key
-    XOnlyKey(bitcoin::XOnlyPublicKey),
-}
-
-impl From<BitcoinKey> for PkEvalErrInner {
-    fn from(pk: BitcoinKey) -> Self {
-        match pk {
-            BitcoinKey::Fullkey(pk) => PkEvalErrInner::FullKey(pk),
-            BitcoinKey::XOnlyPublicKey(xpk) => PkEvalErrInner::XOnlyKey(xpk),
-        }
-    }
-}
-
-impl fmt::Display for PkEvalErrInner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PkEvalErrInner::FullKey(pk) => pk.fmt(f),
-            PkEvalErrInner::XOnlyKey(xpk) => xpk.fmt(f),
-        }
-    }
-}
-
-#[doc(hidden)]
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error {
-        Error::Secp(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<bitcoin::util::sighash::Error> for Error {
-    fn from(e: bitcoin::util::sighash::Error) -> Error {
-        Error::SighashError(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<bitcoin::EcdsaSigError> for Error {
-    fn from(e: bitcoin::EcdsaSigError) -> Error {
-        Error::EcdsaSig(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<bitcoin::SchnorrSigError> for Error {
-    fn from(e: bitcoin::SchnorrSigError) -> Error {
-        Error::SchnorrSig(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<crate::Error> for Error {
-    fn from(e: crate::Error) -> Error {
-        Error::Miniscript(e)
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Secp(ref err) => Some(err),
-            ref x => Some(x),
-        }
-    }
-}
-
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -260,6 +188,78 @@ impl fmt::Display for Error {
             Error::VerifyFailed => {
                 f.write_str("Expected Satisfied Boolean at stack top for VERIFY")
             }
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        match *self {
+            Error::Secp(ref err) => Some(err),
+            ref x => Some(x),
+        }
+    }
+}
+
+#[doc(hidden)]
+impl From<secp256k1::Error> for Error {
+    fn from(e: secp256k1::Error) -> Error {
+        Error::Secp(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<bitcoin::util::sighash::Error> for Error {
+    fn from(e: bitcoin::util::sighash::Error) -> Error {
+        Error::SighashError(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<bitcoin::EcdsaSigError> for Error {
+    fn from(e: bitcoin::EcdsaSigError) -> Error {
+        Error::EcdsaSig(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<bitcoin::SchnorrSigError> for Error {
+    fn from(e: bitcoin::SchnorrSigError) -> Error {
+        Error::SchnorrSig(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<crate::Error> for Error {
+    fn from(e: crate::Error) -> Error {
+        Error::Miniscript(e)
+    }
+}
+
+/// A type of representing which keys errored during interpreter checksig evaluation
+// Note that we can't use BitcoinKey because it is not public
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PkEvalErrInner {
+    /// Full Key
+    FullKey(bitcoin::PublicKey),
+    /// XOnly Key
+    XOnlyKey(bitcoin::XOnlyPublicKey),
+}
+
+impl From<BitcoinKey> for PkEvalErrInner {
+    fn from(pk: BitcoinKey) -> Self {
+        match pk {
+            BitcoinKey::Fullkey(pk) => PkEvalErrInner::FullKey(pk),
+            BitcoinKey::XOnlyPublicKey(xpk) => PkEvalErrInner::XOnlyKey(xpk),
+        }
+    }
+}
+
+impl fmt::Display for PkEvalErrInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PkEvalErrInner::FullKey(pk) => pk.fmt(f),
+            PkEvalErrInner::XOnlyKey(xpk) => xpk.fmt(f),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,9 +660,51 @@ impl fmt::Display for Error {
 
 impl error::Error for Error {
     fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::BadPubkey(ref e) => Some(e),
-            _ => None,
+        use self::Error::*;
+
+        match self {
+            InvalidOpcode(_)
+            | NonMinimalVerify(_)
+            | InvalidPush(_)
+            | CmsTooManyKeys(_)
+            | MultiATooManyKeys(_)
+            | Unprintable(_)
+            | ExpectedChar(_)
+            | UnexpectedStart
+            | Unexpected(_)
+            | MultiColon(_)
+            | MultiAt(_)
+            | AtOutsideOr(_)
+            | LikelyFalse
+            | UnknownWrapper(_)
+            | NonTopLevel(_)
+            | Trailing(_)
+            | MissingHash(_)
+            | MissingSig(_)
+            | RelativeLocktimeNotMet(_)
+            | AbsoluteLocktimeNotMet(_)
+            | CouldNotSatisfy
+            | TypeCheck(_)
+            | BadDescriptor(_)
+            | MaxRecursiveDepthExceeded
+            | ScriptSizeTooLarge
+            | NonStandardBareScript
+            | ImpossibleSatisfaction
+            | BareDescriptorAddr
+            | TaprootSpendInfoUnavialable
+            | TrNoScriptCode
+            | TrNoExplicitScript => None,
+            Script(e) => Some(e),
+            AddrError(e) => Some(e),
+            BadPubkey(e) => Some(e),
+            Secp(e) => Some(e),
+            #[cfg(feature = "compiler")]
+            CompilerError(e) => Some(e),
+            PolicyError(e) => Some(e),
+            LiftError(e) => Some(e),
+            ContextError(e) => Some(e),
+            AnalysisError(e) => Some(e),
+            PubKeyCtxError(e, _) => Some(e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,65 +575,6 @@ pub enum Error {
     TrNoExplicitScript,
 }
 
-#[doc(hidden)]
-impl<Pk, Ctx> From<miniscript::types::Error<Pk, Ctx>> for Error
-where
-    Pk: MiniscriptKey,
-    Ctx: ScriptContext,
-{
-    fn from(e: miniscript::types::Error<Pk, Ctx>) -> Error {
-        Error::TypeCheck(e.to_string())
-    }
-}
-
-#[doc(hidden)]
-impl From<policy::LiftError> for Error {
-    fn from(e: policy::LiftError) -> Error {
-        Error::LiftError(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<miniscript::context::ScriptContextError> for Error {
-    fn from(e: miniscript::context::ScriptContextError) -> Error {
-        Error::ContextError(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<miniscript::analyzable::AnalysisError> for Error {
-    fn from(e: miniscript::analyzable::AnalysisError) -> Error {
-        Error::AnalysisError(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<bitcoin::secp256k1::Error> for Error {
-    fn from(e: bitcoin::secp256k1::Error) -> Error {
-        Error::Secp(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<bitcoin::util::address::Error> for Error {
-    fn from(e: bitcoin::util::address::Error) -> Error {
-        Error::AddrError(e)
-    }
-}
-
-fn errstr(s: &str) -> Error {
-    Error::Unexpected(s.to_owned())
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::BadPubkey(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
 // https://github.com/sipa/miniscript/pull/5 for discussion on this number
 const MAX_RECURSION_DEPTH: u32 = 402;
 // https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
@@ -717,6 +658,61 @@ impl fmt::Display for Error {
     }
 }
 
+impl error::Error for Error {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        match *self {
+            Error::BadPubkey(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+#[doc(hidden)]
+impl<Pk, Ctx> From<miniscript::types::Error<Pk, Ctx>> for Error
+where
+    Pk: MiniscriptKey,
+    Ctx: ScriptContext,
+{
+    fn from(e: miniscript::types::Error<Pk, Ctx>) -> Error {
+        Error::TypeCheck(e.to_string())
+    }
+}
+
+#[doc(hidden)]
+impl From<policy::LiftError> for Error {
+    fn from(e: policy::LiftError) -> Error {
+        Error::LiftError(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<miniscript::context::ScriptContextError> for Error {
+    fn from(e: miniscript::context::ScriptContextError) -> Error {
+        Error::ContextError(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<miniscript::analyzable::AnalysisError> for Error {
+    fn from(e: miniscript::analyzable::AnalysisError) -> Error {
+        Error::AnalysisError(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<bitcoin::secp256k1::Error> for Error {
+    fn from(e: bitcoin::secp256k1::Error) -> Error {
+        Error::Secp(e)
+    }
+}
+
+#[doc(hidden)]
+impl From<bitcoin::util::address::Error> for Error {
+    fn from(e: bitcoin::util::address::Error) -> Error {
+        Error::AddrError(e)
+    }
+}
+
 #[doc(hidden)]
 #[cfg(feature = "compiler")]
 impl From<crate::policy::compiler::CompilerError> for Error {
@@ -730,6 +726,10 @@ impl From<policy::concrete::PolicyError> for Error {
     fn from(e: policy::concrete::PolicyError) -> Error {
         Error::PolicyError(e)
     }
+}
+
+fn errstr(s: &str) -> Error {
+    Error::Unexpected(s.to_owned())
 }
 
 /// The size of an encoding of a number in Script

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -66,7 +66,19 @@ impl fmt::Display for AnalysisError {
     }
 }
 
-impl error::Error for AnalysisError {}
+impl error::Error for AnalysisError {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        use self::AnalysisError::*;
+
+        match self {
+            SiglessBranch
+            | RepeatedPubkeys
+            | BranchExceedResouceLimits
+            | HeightTimelockCombination
+            | Malleable => None,
+        }
+    }
+}
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Whether all spend paths of miniscript require a signature

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -75,14 +75,6 @@ pub enum ScriptContextError {
     MultiANotAllowed,
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SigType {
-    /// Ecdsa signature
-    Ecdsa,
-    /// Schnorr Signature
-    Schnorr,
-}
-
 impl fmt::Display for ScriptContextError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -310,6 +302,14 @@ where
 
     /// Local helper function to display error messages with context
     fn name_str() -> &'static str;
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SigType {
+    /// Ecdsa signature
+    Ecdsa,
+    /// Schnorr Signature
+    Schnorr,
 }
 
 /// Legacy ScriptContext

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use std::{fmt, hash};
+use std::{error, fmt, hash};
 
 use bitcoin;
 use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
@@ -73,6 +73,31 @@ pub enum ScriptContextError {
     CheckMultiSigLimitExceeded,
     /// MultiA is only allowed in post tapscript
     MultiANotAllowed,
+}
+
+impl error::Error for ScriptContextError {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        use self::ScriptContextError::*;
+
+        match self {
+            MalleablePkH
+            | MalleableOrI
+            | MalleableDupIf
+            | CompressedOnly(_)
+            | XOnlyKeysNotAllowed(_, _)
+            | UncompressedKeysNotAllowed
+            | MaxWitnessItemssExceeded { .. }
+            | MaxOpCountExceeded
+            | MaxWitnessScriptSizeExceeded
+            | MaxRedeemScriptSizeExceeded
+            | MaxScriptSigSizeExceeded
+            | ImpossibleSatisfaction
+            | TaprootMultiDisabled
+            | StackSizeLimitExceeded { .. }
+            | CheckMultiSigLimitExceeded
+            | MultiANotAllowed => None,
+        }
+    }
 }
 
 impl fmt::Display for ScriptContextError {

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -41,15 +41,6 @@ pub trait ParseableKey: Sized + ToPublicKey + private::Sealed {
     fn from_slice(sl: &[u8]) -> Result<Self, KeyParseError>;
 }
 
-/// Decoding error while parsing keys
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum KeyParseError {
-    /// Bitcoin PublicKey parse error
-    FullKeyParseError(bitcoin::util::key::Error),
-    /// Xonly key parse Error
-    XonlyKeyParseError(bitcoin::secp256k1::Error),
-}
-
 impl ParseableKey for bitcoin::PublicKey {
     fn from_slice(sl: &[u8]) -> Result<Self, KeyParseError> {
         bitcoin::PublicKey::from_slice(sl).map_err(KeyParseError::FullKeyParseError)
@@ -63,13 +54,13 @@ impl ParseableKey for bitcoin::secp256k1::XOnlyPublicKey {
     }
 }
 
-impl error::Error for KeyParseError {
-    fn cause(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            KeyParseError::FullKeyParseError(e) => Some(e),
-            KeyParseError::XonlyKeyParseError(e) => Some(e),
-        }
-    }
+/// Decoding error while parsing keys
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum KeyParseError {
+    /// Bitcoin PublicKey parse error
+    FullKeyParseError(bitcoin::util::key::Error),
+    /// Xonly key parse Error
+    XonlyKeyParseError(bitcoin::secp256k1::Error),
 }
 
 impl fmt::Display for KeyParseError {
@@ -77,6 +68,15 @@ impl fmt::Display for KeyParseError {
         match self {
             KeyParseError::FullKeyParseError(_e) => write!(f, "FullKey Parse Error"),
             KeyParseError::XonlyKeyParseError(_e) => write!(f, "XonlyKey Parse Error"),
+        }
+    }
+}
+
+impl error::Error for KeyParseError {
+    fn cause(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            KeyParseError::FullKeyParseError(e) => Some(e),
+            KeyParseError::XonlyKeyParseError(e) => Some(e),
         }
     }
 }

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -104,12 +104,6 @@ pub struct Error<Pk: MiniscriptKey, Ctx: ScriptContext> {
     pub error: ErrorKind,
 }
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> error::Error for Error<Pk, Ctx> {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
-
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Error<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.error {
@@ -216,6 +210,12 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Error<Pk, Ctx> {
                 n_strong,
             ),
         }
+    }
+}
+
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> error::Error for Error<Pk, Ctx> {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        None
     }
 }
 

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -108,10 +108,6 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> error::Error for Error<Pk, Ctx> {
     fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
-
-    fn description(&self) -> &str {
-        "description() is deprecated; use Display"
-    }
 }
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Error<Pk, Ctx> {

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -62,8 +62,6 @@ pub enum CompilerError {
     PolicyError(policy::concrete::PolicyError),
 }
 
-impl error::Error for CompilerError {}
-
 impl fmt::Display for CompilerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -80,6 +78,8 @@ impl fmt::Display for CompilerError {
         }
     }
 }
+
+impl error::Error for CompilerError {}
 
 #[doc(hidden)]
 impl From<policy::concrete::PolicyError> for CompilerError {

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -79,7 +79,16 @@ impl fmt::Display for CompilerError {
     }
 }
 
-impl error::Error for CompilerError {}
+impl error::Error for CompilerError {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        use self::CompilerError::*;
+
+        match self {
+            TopLevelNonSafe | ImpossibleNonMalleableCompilation | LimitsExceeded => None,
+            PolicyError(e) => Some(e),
+        }
+    }
+}
 
 #[doc(hidden)]
 impl From<policy::concrete::PolicyError> for CompilerError {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -132,7 +132,24 @@ impl fmt::Display for PolicyError {
     }
 }
 
-impl error::Error for PolicyError {}
+impl error::Error for PolicyError {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        use self::PolicyError::*;
+
+        match self {
+            NonBinaryArgAnd
+            | NonBinaryArgOr
+            | IncorrectThresh
+            | ZeroTime
+            | TimeTooFar
+            | InsufficientArgsforAnd
+            | InsufficientArgsforOr
+            | EntailmentMaxTerminals
+            | HeightTimelockCombination
+            | DuplicatePubKeys => None,
+        }
+    }
+}
 
 impl<Pk: MiniscriptKey> Policy<Pk> {
     /// Flatten the [`Policy`] tree structure into a Vector of tuple `(leaf script, leaf probability)`

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -99,8 +99,6 @@ pub enum PolicyError {
     DuplicatePubKeys,
 }
 
-impl error::Error for PolicyError {}
-
 impl fmt::Display for PolicyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -133,6 +131,8 @@ impl fmt::Display for PolicyError {
         }
     }
 }
+
+impl error::Error for PolicyError {}
 
 impl<Pk: MiniscriptKey> Policy<Pk> {
     /// Flatten the [`Policy`] tree structure into a Vector of tuple `(leaf script, leaf probability)`

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -67,9 +67,6 @@ pub enum LiftError {
 }
 
 impl error::Error for LiftError {
-    fn description(&self) -> &str {
-        ""
-    }
     fn cause(&self) -> Option<&dyn error::Error> {
         None
     }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -66,12 +66,6 @@ pub enum LiftError {
     BranchExceedResourceLimits,
 }
 
-impl error::Error for LiftError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
-
 impl fmt::Display for LiftError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -82,6 +76,12 @@ impl fmt::Display for LiftError {
                 "Cannot lift policies containing one branch that exceeds resource limits",
             ),
         }
+    }
+}
+
+impl error::Error for LiftError {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        None
     }
 }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -81,7 +81,11 @@ impl fmt::Display for LiftError {
 
 impl error::Error for LiftError {
     fn cause(&self) -> Option<&dyn error::Error> {
-        None
+        use self::LiftError::*;
+
+        match self {
+            HeightTimelockCombination | BranchExceedResourceLimits => None,
+        }
     }
 }
 


### PR DESCRIPTION
Now we have MSRV of 1.41.1 we can implement `source` for improved error handling.

Patches 1-3 are preparatory cleanup, patch 4 adds all the `source` impls.

Resolves: #273 