### PR TITLE
Fix up mixup of age/height

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -605,7 +605,7 @@ where
                 Terminal::After(ref n) => {
                     debug_assert_eq!(node_state.n_evaluated, 0);
                     debug_assert_eq!(node_state.n_satisfied, 0);
-                    let res = self.stack.evaluate_after(n, self.age);
+                    let res = self.stack.evaluate_after(n, self.height);
                     if res.is_some() {
                         return res;
                     }
@@ -613,7 +613,7 @@ where
                 Terminal::Older(ref n) => {
                     debug_assert_eq!(node_state.n_evaluated, 0);
                     debug_assert_eq!(node_state.n_satisfied, 0);
-                    let res = self.stack.evaluate_older(n, self.height);
+                    let res = self.stack.evaluate_older(n, self.age);
                     if res.is_some() {
                         return res;
                     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -169,8 +169,8 @@ impl<'txin> Interpreter<'txin> {
         spk: &bitcoin::Script,
         script_sig: &'txin bitcoin::Script,
         witness: &'txin Witness,
-        age: u32,
-        height: u32,
+        age: u32,    // CSV, relative lock time.
+        height: u32, // CLTV, absolute lock time.
     ) -> Result<Self, Error> {
         let (inner, stack, script_code) = inner::from_txdata(spk, script_sig, witness)?;
         Ok(Interpreter {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -49,7 +49,7 @@ pub struct Interpreter<'txin> {
     /// is the leaf script; for key-spends it is `None`.
     script_code: Option<bitcoin::Script>,
     age: u32,
-    height: u32,
+    lock_time: u32,
 }
 
 // A type representing functions for checking signatures that accept both
@@ -169,8 +169,8 @@ impl<'txin> Interpreter<'txin> {
         spk: &bitcoin::Script,
         script_sig: &'txin bitcoin::Script,
         witness: &'txin Witness,
-        age: u32,    // CSV, relative lock time.
-        height: u32, // CLTV, absolute lock time.
+        age: u32,       // CSV, relative lock time.
+        lock_time: u32, // CLTV, absolute lock time.
     ) -> Result<Self, Error> {
         let (inner, stack, script_code) = inner::from_txdata(spk, script_sig, witness)?;
         Ok(Interpreter {
@@ -178,7 +178,7 @@ impl<'txin> Interpreter<'txin> {
             stack,
             script_code,
             age,
-            height,
+            lock_time,
         })
     }
 
@@ -209,7 +209,7 @@ impl<'txin> Interpreter<'txin> {
             // call interpreter.iter() without mutating interpreter
             stack: self.stack.clone(),
             age: self.age,
-            height: self.height,
+            lock_time: self.lock_time,
             has_errored: false,
         }
     }
@@ -528,7 +528,7 @@ pub struct Iter<'intp, 'txin: 'intp> {
     state: Vec<NodeEvaluationState<'intp>>,
     stack: Stack<'txin>,
     age: u32,
-    height: u32,
+    lock_time: u32,
     has_errored: bool,
 }
 
@@ -605,7 +605,7 @@ where
                 Terminal::After(ref n) => {
                     debug_assert_eq!(node_state.n_evaluated, 0);
                     debug_assert_eq!(node_state.n_satisfied, 0);
-                    let res = self.stack.evaluate_after(n, self.height);
+                    let res = self.stack.evaluate_after(n, self.lock_time);
                     if res.is_some() {
                         return res;
                     }
@@ -1131,7 +1131,7 @@ mod tests {
                     n_satisfied: 0,
                 }],
                 age: 1002,
-                height: 1002,
+                lock_time: 1002,
                 has_errored: false,
             }
         }

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -232,9 +232,9 @@ impl<'txin> Stack<'txin> {
     pub(super) fn evaluate_after(
         &mut self,
         n: &u32,
-        age: u32,
+        lock_time: u32,
     ) -> Option<Result<SatisfiedConstraint, Error>> {
-        if age >= *n {
+        if lock_time >= *n {
             self.push(Element::Satisfied);
             Some(Ok(SatisfiedConstraint::AbsoluteTimelock { time: *n }))
         } else {
@@ -251,9 +251,9 @@ impl<'txin> Stack<'txin> {
     pub(super) fn evaluate_older(
         &mut self,
         n: &u32,
-        height: u32,
+        age: u32,
     ) -> Option<Result<SatisfiedConstraint, Error>> {
-        if height >= *n {
+        if age >= *n {
             self.push(Element::Satisfied);
             Some(Ok(SatisfiedConstraint::RelativeTimelock { time: *n }))
         } else {

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -521,18 +521,18 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     }
 
     /// Filter a policy by eliminating relative timelock constraints
-    /// that are not satisfied at the given age.
-    pub fn at_age(mut self, time: u32) -> Policy<Pk> {
+    /// that are not satisfied at the given `age`.
+    pub fn at_age(mut self, age: u32) -> Policy<Pk> {
         self = match self {
             Policy::Older(t) => {
-                if t > time {
+                if t > age {
                     Policy::Unsatisfiable
                 } else {
                     Policy::Older(t)
                 }
             }
             Policy::Threshold(k, subs) => {
-                Policy::Threshold(k, subs.into_iter().map(|sub| sub.at_age(time)).collect())
+                Policy::Threshold(k, subs.into_iter().map(|sub| sub.at_age(age)).collect())
             }
             x => x,
         };

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -295,7 +295,7 @@ fn interpreter_inp_check<C: secp256k1::Verification, T: Borrow<TxOut>>(
         let cltv = psbt.unsigned_tx.lock_time;
         let csv = psbt.unsigned_tx.input[index].sequence;
         let interpreter =
-            interpreter::Interpreter::from_txdata(spk, script_sig, witness, cltv, csv)
+            interpreter::Interpreter::from_txdata(spk, script_sig, witness, csv, cltv)
                 .map_err(|e| Error::InputError(InputError::Interpreter(e), index))?;
         let iter = interpreter.iter(secp, &psbt.unsigned_tx, index, utxos);
         if let Some(error) = iter.filter_map(Result::err).next() {


### PR DESCRIPTION
We currently use age/height as identifiers for values related to CLTV and CSV. However we get them mixed up in the function call to `from_txdata`. Do a few improvements to fix the mixup and improve the overall situation.

- Patch 2 is a breaking change, changes a public method name. 
- Patch 1 an 4 are bug fixes.

(This description and PR are totally re-written, the comment directly below is now stale.)