### PR TITLE
Add Hash256 associated type

### DIFF
--- a/examples/taproot.rs
+++ b/examples/taproot.rs
@@ -6,7 +6,7 @@ use bitcoin::util::address::WitnessVersion;
 use bitcoin::Network;
 use miniscript::descriptor::DescriptorType;
 use miniscript::policy::Concrete;
-use miniscript::{Descriptor, Miniscript, Tap, TranslatePk, Translator};
+use miniscript::{hash256, Descriptor, Miniscript, Tap, TranslatePk, Translator};
 use secp256k1::{rand, KeyPair};
 
 // Refer to https://github.com/sanket1729/adv_btc_workshop/blob/master/workshop.md#creating-a-taproot-descriptor
@@ -27,6 +27,10 @@ impl Translator<String, bitcoin::XOnlyPublicKey, ()> for StrPkTranslator {
 
     fn sha256(&mut self, _sha256: &String) -> Result<sha256::Hash, ()> {
         unreachable!("Policy does not contain any sha256 fragment");
+    }
+
+    fn hash256(&mut self, _sha256: &String) -> Result<hash256::Hash, ()> {
+        unreachable!("Policy does not contain any hash256 fragment");
     }
 }
 

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -167,7 +167,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Bare<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         self.ms.for_each_key(pred)
     }
@@ -329,7 +329,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Pkh<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         pred(&self.pk)
     }

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -10,7 +10,7 @@ use bitcoin::util::bip32;
 use bitcoin::{self, XOnlyPublicKey, XpubIdentifier};
 
 use crate::prelude::*;
-use crate::{MiniscriptKey, ToPublicKey};
+use crate::{hash256, MiniscriptKey, ToPublicKey};
 
 /// The descriptor pubkey, either a single pubkey or an xpub.
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
@@ -737,7 +737,8 @@ impl<K: InnerXKey> DescriptorXKey<K> {
 impl MiniscriptKey for DescriptorPublicKey {
     // This allows us to be able to derive public keys even for PkH s
     type Hash = Self;
-    type Sha256 = bitcoin::hashes::sha256::Hash;
+    type Sha256 = sha256::Hash;
+    type Hash256 = hash256::Hash;
 
     fn is_uncompressed(&self) -> bool {
         match self {
@@ -803,7 +804,8 @@ impl fmt::Display for DerivedDescriptorKey {
 impl MiniscriptKey for DerivedDescriptorKey {
     // This allows us to be able to derive public keys even for PkH s
     type Hash = Self;
-    type Sha256 = bitcoin::hashes::sha256::Hash;
+    type Sha256 = sha256::Hash;
+    type Hash256 = hash256::Hash;
 
     fn is_uncompressed(&self) -> bool {
         self.key.is_uncompressed()
@@ -829,6 +831,10 @@ impl ToPublicKey for DerivedDescriptorKey {
     }
 
     fn to_sha256(hash: &sha256::Hash) -> sha256::Hash {
+        *hash
+    }
+
+    fn to_hash256(hash: &hash256::Hash) -> hash256::Hash {
         *hash
     }
 }

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -736,7 +736,7 @@ impl<K: InnerXKey> DescriptorXKey<K> {
 
 impl MiniscriptKey for DescriptorPublicKey {
     // This allows us to be able to derive public keys even for PkH s
-    type Hash = Self;
+    type RawPkHash = Self;
     type Sha256 = sha256::Hash;
     type Hash256 = hash256::Hash;
 
@@ -803,7 +803,7 @@ impl fmt::Display for DerivedDescriptorKey {
 
 impl MiniscriptKey for DerivedDescriptorKey {
     // This allows us to be able to derive public keys even for PkH s
-    type Hash = Self;
+    type RawPkHash = Self;
     type Sha256 = sha256::Hash;
     type Hash256 = hash256::Hash;
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -37,8 +37,8 @@ use self::checksum::verify_checksum;
 use crate::miniscript::{Legacy, Miniscript, Segwitv0};
 use crate::prelude::*;
 use crate::{
-    expression, miniscript, BareCtx, Error, ForEachKey, MiniscriptKey, PkTranslator, Satisfier,
-    ToPublicKey, TranslatePk, Translator,
+    expression, hash256, miniscript, BareCtx, Error, ForEachKey, MiniscriptKey, PkTranslator,
+    Satisfier, ToPublicKey, TranslatePk, Translator,
 };
 
 mod bare;
@@ -646,6 +646,12 @@ impl Descriptor<DescriptorPublicKey> {
                     sha256::Hash::from_str(sha256).map_err(|e| Error::Unexpected(e.to_string()))?;
                 Ok(hash)
             }
+
+            fn hash256(&mut self, hash256: &String) -> Result<hash256::Hash, Error> {
+                let hash = hash256::Hash::from_str(hash256)
+                    .map_err(|e| Error::Unexpected(e.to_string()))?;
+                Ok(hash)
+            }
         }
 
         let descriptor = Descriptor::<String>::from_str(s)?;
@@ -671,6 +677,10 @@ impl Descriptor<DescriptorPublicKey> {
 
             fn sha256(&mut self, sha256: &sha256::Hash) -> Result<String, ()> {
                 Ok(sha256.to_string())
+            }
+
+            fn hash256(&mut self, hash256: &hash256::Hash) -> Result<String, ()> {
+                Ok(hash256.to_string())
             }
         }
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -498,7 +498,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Descriptor<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         match *self {
             Descriptor::Bare(ref bare) => bare.for_each_key(pred),

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -249,7 +249,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Wsh<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         match self.inner {
             WshInner::SortedMulti(ref smv) => smv.for_each_key(pred),
@@ -442,7 +442,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Wpkh<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         pred(&self.pk)
     }

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -380,7 +380,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Sh<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         match self.inner {
             ShInner::Wsh(ref wsh) => wsh.for_each_key(pred),

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -115,7 +115,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for SortedMultiVec<Pk
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         self.pks.iter().all(|key| pred(key))
     }

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -581,7 +581,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Tr<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         let script_keys_res = self
             .iter_scripts()

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -148,11 +148,11 @@ impl TypedHash160 {
 }
 
 impl MiniscriptKey for BitcoinKey {
-    type Hash = TypedHash160;
+    type RawPkHash = TypedHash160;
     type Sha256 = sha256::Hash;
     type Hash256 = hash256::Hash;
 
-    fn to_pubkeyhash(&self) -> Self::Hash {
+    fn to_pubkeyhash(&self) -> Self::RawPkHash {
         match self {
             BitcoinKey::Fullkey(pk) => TypedHash160::FullKey(pk.to_pubkeyhash()),
             BitcoinKey::XOnlyPublicKey(pk) => TypedHash160::XonlyKey(pk.to_pubkeyhash()),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -23,14 +23,14 @@ use core::fmt;
 use core::str::FromStr;
 
 use bitcoin::blockdata::witness::Witness;
-use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
+use bitcoin::hashes::{hash160, ripemd160, sha256};
 use bitcoin::util::{sighash, taproot};
 use bitcoin::{self, secp256k1, TxOut};
 
 use crate::miniscript::context::NoChecks;
 use crate::miniscript::ScriptContext;
 use crate::prelude::*;
-use crate::{Descriptor, Miniscript, Terminal, ToPublicKey};
+use crate::{hash256, Descriptor, Miniscript, Terminal, ToPublicKey};
 
 mod error;
 mod inner;
@@ -149,7 +149,8 @@ impl TypedHash160 {
 
 impl MiniscriptKey for BitcoinKey {
     type Hash = TypedHash160;
-    type Sha256 = bitcoin::hashes::sha256::Hash;
+    type Sha256 = sha256::Hash;
+    type Hash256 = hash256::Hash;
 
     fn to_pubkeyhash(&self) -> Self::Hash {
         match self {
@@ -454,7 +455,7 @@ pub enum HashLockType {
     ///SHA 256 hashlock
     Sha256(sha256::Hash),
     ///Hash 256 hashlock
-    Hash256(sha256d::Hash),
+    Hash256(hash256::Hash),
     ///Hash160 hashlock
     Hash160(hash160::Hash),
     ///Ripemd160 hashlock
@@ -1040,7 +1041,7 @@ fn verify_sersig<'txin>(
 mod tests {
 
     use bitcoin;
-    use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+    use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
     use bitcoin::secp256k1::{self, Secp256k1};
 
     use super::inner::ToNoChecks;
@@ -1156,11 +1157,8 @@ mod tests {
         let preimage = [0xab as u8; 32];
         let sha256_hash = sha256::Hash::hash(&preimage);
         let sha256 = no_checks_ms(&format!("sha256({})", sha256_hash));
-        let sha256d_hash_rev = sha256d::Hash::hash(&preimage);
-        let mut sha256d_hash_bytes = sha256d_hash_rev.clone().into_inner();
-        sha256d_hash_bytes.reverse();
-        let sha256d_hash = sha256d::Hash::from_inner(sha256d_hash_bytes);
-        let hash256 = no_checks_ms(&format!("hash256({})", sha256d_hash));
+        let hash256_hash = hash256::Hash::hash(&preimage);
+        let hash256 = no_checks_ms(&format!("hash256({})", hash256_hash));
         let hash160_hash = hash160::Hash::hash(&preimage);
         let hash160 = no_checks_ms(&format!("hash160({})", hash160_hash));
         let ripemd160_hash = ripemd160::Hash::hash(&preimage);
@@ -1242,7 +1240,7 @@ mod tests {
         assert_eq!(
             sha256d_satisfied.unwrap(),
             vec![SatisfiedConstraint::HashLock {
-                hash: HashLockType::Hash256(sha256d_hash_rev),
+                hash: HashLockType::Hash256(hash256_hash),
                 preimage: preimage,
             }]
         );

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -16,12 +16,13 @@
 
 use bitcoin;
 use bitcoin::blockdata::{opcodes, script};
-use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 
 use super::error::PkEvalErrInner;
 use super::{
     verify_sersig, BitcoinKey, Error, HashLockType, KeySigPair, SatisfiedConstraint, TypedHash160,
 };
+use crate::hash256;
 use crate::prelude::*;
 
 /// Definition of Stack Element of the Stack used for interpretation of Miniscript.
@@ -288,13 +289,13 @@ impl<'txin> Stack<'txin> {
     /// `SIZE 32 EQUALVERIFY HASH256 h EQUAL`
     pub(super) fn evaluate_hash256(
         &mut self,
-        hash: &sha256d::Hash,
+        hash: &hash256::Hash,
     ) -> Option<Result<SatisfiedConstraint, Error>> {
         if let Some(Element::Push(preimage)) = self.pop() {
             if preimage.len() != 32 {
                 return Some(Err(Error::HashPreimageLengthMismatch));
             }
-            if sha256d::Hash::hash(preimage) == *hash {
+            if hash256::Hash::hash(preimage) == *hash {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
                     hash: HashLockType::Hash256(*hash),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub use crate::interpreter::Interpreter;
 pub use crate::miniscript::context::{BareCtx, Legacy, ScriptContext, Segwitv0, Tap};
 pub use crate::miniscript::decode::Terminal;
 pub use crate::miniscript::satisfy::{Preimage32, Satisfier};
-pub use crate::miniscript::Miniscript;
+pub use crate::miniscript::{hash256, Miniscript};
 use crate::prelude::*;
 
 ///Public key trait which can be converted to Hash type

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,9 +29,11 @@ macro_rules! impl_from_tree {
             Pk: MiniscriptKey + core::str::FromStr,
             Pk::Hash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
+            Pk::Hash256: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Hash as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
             {
 
@@ -57,9 +59,11 @@ macro_rules! impl_from_str {
             Pk: MiniscriptKey + core::str::FromStr,
             Pk::Hash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
+            Pk::Hash256: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Hash as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
             {
                 type Err = $err_ty;
@@ -85,9 +89,11 @@ macro_rules! impl_block_str {
             Pk: MiniscriptKey + core::str::FromStr,
             Pk::Hash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
+            Pk::Hash256: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Hash as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
             {
                 $(#[$meta])*
@@ -108,10 +114,13 @@ macro_rules! serde_string_impl_pk {
             Pk: $crate::MiniscriptKey + core::str::FromStr,
             Pk::Hash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
+            Pk::Hash256: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: core::fmt::Display,
             <<Pk as $crate::MiniscriptKey>::Hash as core::str::FromStr>::Err:
                 core::fmt::Display,
             <<Pk as $crate::MiniscriptKey>::Sha256 as core::str::FromStr>::Err:
+                core::fmt::Display,
+            <<Pk as $crate::MiniscriptKey>::Hash256 as core::str::FromStr>::Err:
                 core::fmt::Display,
             $($gen : $gen_con,)*
         {
@@ -130,10 +139,13 @@ macro_rules! serde_string_impl_pk {
                     Pk: $crate::MiniscriptKey + core::str::FromStr,
                     Pk::Hash: core::str::FromStr,
                     Pk::Sha256: core::str::FromStr,
+                    Pk::Hash256: core::str::FromStr,
                     <Pk as core::str::FromStr>::Err: core::fmt::Display,
                     <<Pk as $crate::MiniscriptKey>::Hash as core::str::FromStr>::Err:
                         core::fmt::Display,
                     <<Pk as $crate::MiniscriptKey>::Sha256 as core::str::FromStr>::Err:
+                        core::fmt::Display,
+                    <<Pk as $crate::MiniscriptKey>::Hash256 as core::str::FromStr>::Err:
                         core::fmt::Display,
                     $($gen: $gen_con,)*
                 {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,11 +27,11 @@ macro_rules! impl_from_tree {
         impl<Pk $(, $gen)*> $crate::expression::FromTree for $name
         where
             Pk: MiniscriptKey + core::str::FromStr,
-            Pk::Hash: core::str::FromStr,
+            Pk::RawPkHash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
             Pk::Hash256: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as MiniscriptKey>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
@@ -57,11 +57,11 @@ macro_rules! impl_from_str {
         impl<Pk $(, $gen)*> core::str::FromStr for $name
         where
             Pk: MiniscriptKey + core::str::FromStr,
-            Pk::Hash: core::str::FromStr,
+            Pk::RawPkHash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
             Pk::Hash256: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as MiniscriptKey>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
@@ -87,11 +87,11 @@ macro_rules! impl_block_str {
         impl<Pk $(, $gen)*> $name
         where
             Pk: MiniscriptKey + core::str::FromStr,
-            Pk::Hash: core::str::FromStr,
+            Pk::RawPkHash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
             Pk::Hash256: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: $crate::prelude::ToString,
-            <<Pk as MiniscriptKey>::Hash as core::str::FromStr>::Err: $crate::prelude::ToString,
+            <<Pk as MiniscriptKey>::RawPkHash as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Sha256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             <<Pk as MiniscriptKey>::Hash256 as core::str::FromStr>::Err: $crate::prelude::ToString,
             $($gen : $gen_con,)*
@@ -112,11 +112,11 @@ macro_rules! serde_string_impl_pk {
         impl<'de, Pk $(, $gen)*> $crate::serde::Deserialize<'de> for $name<Pk $(, $gen)*>
         where
             Pk: $crate::MiniscriptKey + core::str::FromStr,
-            Pk::Hash: core::str::FromStr,
+            Pk::RawPkHash: core::str::FromStr,
             Pk::Sha256: core::str::FromStr,
             Pk::Hash256: core::str::FromStr,
             <Pk as core::str::FromStr>::Err: core::fmt::Display,
-            <<Pk as $crate::MiniscriptKey>::Hash as core::str::FromStr>::Err:
+            <<Pk as $crate::MiniscriptKey>::RawPkHash as core::str::FromStr>::Err:
                 core::fmt::Display,
             <<Pk as $crate::MiniscriptKey>::Sha256 as core::str::FromStr>::Err:
                 core::fmt::Display,
@@ -137,11 +137,11 @@ macro_rules! serde_string_impl_pk {
                 impl<'de, Pk $(, $gen)*> $crate::serde::de::Visitor<'de> for Visitor<Pk $(, $gen)*>
                 where
                     Pk: $crate::MiniscriptKey + core::str::FromStr,
-                    Pk::Hash: core::str::FromStr,
+                    Pk::RawPkHash: core::str::FromStr,
                     Pk::Sha256: core::str::FromStr,
                     Pk::Hash256: core::str::FromStr,
                     <Pk as core::str::FromStr>::Err: core::fmt::Display,
-                    <<Pk as $crate::MiniscriptKey>::Hash as core::str::FromStr>::Err:
+                    <<Pk as $crate::MiniscriptKey>::RawPkHash as core::str::FromStr>::Err:
                         core::fmt::Display,
                     <<Pk as $crate::MiniscriptKey>::Sha256 as core::str::FromStr>::Err:
                         core::fmt::Display,

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -79,7 +79,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
     pub(super) fn real_for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: &mut F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         match *self {
             Terminal::PkK(ref p) => pred(p),
@@ -200,7 +200,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for Terminal<Pk, Ctx>
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         self.real_for_each_key(&mut pred)
     }

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -24,7 +24,7 @@ use core::str::FromStr;
 
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::hex::FromHex;
-use bitcoin::hashes::{hash160, ripemd160, sha256d, Hash};
+use bitcoin::hashes::{hash160, ripemd160};
 use sync::Arc;
 
 use crate::miniscript::context::SigType;
@@ -133,7 +133,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             Terminal::After(n) => Terminal::After(n),
             Terminal::Older(n) => Terminal::Older(n),
             Terminal::Sha256(ref x) => Terminal::Sha256(t.sha256(&x)?),
-            Terminal::Hash256(x) => Terminal::Hash256(x),
+            Terminal::Hash256(ref x) => Terminal::Hash256(t.hash256(&x)?),
             Terminal::Ripemd160(x) => Terminal::Ripemd160(x),
             Terminal::Hash160(x) => Terminal::Hash160(x),
             Terminal::True => Terminal::True,
@@ -259,11 +259,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
                 Terminal::After(t) => write!(f, "after({})", t),
                 Terminal::Older(t) => write!(f, "older({})", t),
                 Terminal::Sha256(ref h) => write!(f, "sha256({})", h),
-                Terminal::Hash256(h) => {
-                    let mut x = h.into_inner();
-                    x.reverse();
-                    write!(f, "hash256({})", sha256d::Hash::from_inner(x))
-                }
+                Terminal::Hash256(ref h) => write!(f, "hash256({})", h),
                 Terminal::Ripemd160(h) => write!(f, "ripemd160({})", h),
                 Terminal::Hash160(h) => write!(f, "hash160({})", h),
                 Terminal::True => f.write_str("1"),
@@ -317,11 +313,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Terminal<Pk, Ctx> {
             Terminal::After(t) => write!(f, "after({})", t),
             Terminal::Older(t) => write!(f, "older({})", t),
             Terminal::Sha256(ref h) => write!(f, "sha256({})", h),
-            Terminal::Hash256(h) => {
-                let mut x = h.into_inner();
-                x.reverse();
-                write!(f, "hash256({})", sha256d::Hash::from_inner(x))
-            }
+            Terminal::Hash256(ref h) => write!(f, "hash256({})", h),
             Terminal::Ripemd160(h) => write!(f, "ripemd160({})", h),
             Terminal::Hash160(h) => write!(f, "hash160({})", h),
             Terminal::True => f.write_str("1"),
@@ -478,13 +470,7 @@ impl_from_tree!(
                 Pk::Sha256::from_str(x).map(Terminal::Sha256)
             }),
             ("hash256", 1) => expression::terminal(&top.args[0], |x| {
-                sha256d::Hash::from_hex(x)
-                    .map(|x| x.into_inner())
-                    .map(|mut x| {
-                        x.reverse();
-                        x
-                    })
-                    .map(|x| Terminal::Hash256(sha256d::Hash::from_inner(x)))
+                Pk::Hash256::from_str(x).map(Terminal::Hash256)
             }),
             ("ripemd160", 1) => expression::terminal(&top.args[0], |x| {
                 ripemd160::Hash::from_hex(x).map(Terminal::Ripemd160)
@@ -646,12 +632,12 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
                 .push_opcode(opcodes::all::OP_SHA256)
                 .push_slice(&Pk::to_sha256(&h))
                 .push_opcode(opcodes::all::OP_EQUAL),
-            Terminal::Hash256(h) => builder
+            Terminal::Hash256(ref h) => builder
                 .push_opcode(opcodes::all::OP_SIZE)
                 .push_int(32)
                 .push_opcode(opcodes::all::OP_EQUALVERIFY)
                 .push_opcode(opcodes::all::OP_HASH256)
-                .push_slice(&h[..])
+                .push_slice(&Pk::to_hash256(&h))
                 .push_opcode(opcodes::all::OP_EQUAL),
             Terminal::Ripemd160(h) => builder
                 .push_opcode(opcodes::all::OP_SIZE)

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -18,6 +18,7 @@ use std::error;
 
 use bitcoin;
 use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
+use bitcoin::hashes::{hash160, sha256};
 
 use super::decode::ParseableKey;
 use crate::miniscript::limits::{
@@ -28,7 +29,7 @@ use crate::miniscript::limits::{
 use crate::miniscript::types;
 use crate::prelude::*;
 use crate::util::witness_to_scriptsig;
-use crate::{Error, Miniscript, MiniscriptKey, Terminal};
+use crate::{hash256, Error, Miniscript, MiniscriptKey, Terminal};
 
 /// Error for Script Context
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -190,8 +191,9 @@ impl fmt::Display for ScriptContextError {
 pub trait ScriptContext:
     fmt::Debug + Clone + Ord + PartialOrd + Eq + PartialEq + hash::Hash + private::Sealed
 where
-    Self::Key: MiniscriptKey<Hash = bitcoin::hashes::hash160::Hash>,
-    Self::Key: MiniscriptKey<Sha256 = bitcoin::hashes::sha256::Hash>,
+    Self::Key: MiniscriptKey<Hash = hash160::Hash>,
+    Self::Key: MiniscriptKey<Sha256 = sha256::Hash>,
+    Self::Key: MiniscriptKey<Hash256 = hash256::Hash>,
 {
     /// The consensus key associated with the type. Must be a parseable key
     type Key: ParseableKey;

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -191,7 +191,7 @@ impl fmt::Display for ScriptContextError {
 pub trait ScriptContext:
     fmt::Debug + Clone + Ord + PartialOrd + Eq + PartialEq + hash::Hash + private::Sealed
 where
-    Self::Key: MiniscriptKey<Hash = hash160::Hash>,
+    Self::Key: MiniscriptKey<RawPkHash = hash160::Hash>,
     Self::Key: MiniscriptKey<Sha256 = sha256::Hash>,
     Self::Key: MiniscriptKey<Hash256 = hash256::Hash>,
 {

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -136,7 +136,7 @@ pub enum Terminal<Pk: MiniscriptKey, Ctx: ScriptContext> {
     /// `DUP HASH160 <keyhash> EQUALVERIFY`
     PkH(Pk),
     /// Only for parsing PkH for Script
-    RawPkH(Pk::Hash),
+    RawPkH(Pk::RawPkHash),
     // timelocks
     /// `n CHECKLOCKTIMEVERIFY`
     After(u32),

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -23,7 +23,7 @@ use core::marker::PhantomData;
 use std::error;
 
 use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
-use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 use sync::Arc;
 
 use crate::miniscript::lex::{Token as Tk, TokenIter};
@@ -32,7 +32,7 @@ use crate::miniscript::types::extra_props::ExtData;
 use crate::miniscript::types::{Property, Type};
 use crate::miniscript::ScriptContext;
 use crate::prelude::*;
-use crate::{bitcoin, Error, Miniscript, MiniscriptKey, ToPublicKey};
+use crate::{bitcoin, hash256, Error, Miniscript, MiniscriptKey, ToPublicKey};
 
 fn return_none<T>(_: usize) -> Option<T> {
     None
@@ -146,7 +146,7 @@ pub enum Terminal<Pk: MiniscriptKey, Ctx: ScriptContext> {
     /// `SIZE 32 EQUALVERIFY SHA256 <hash> EQUAL`
     Sha256(Pk::Sha256),
     /// `SIZE 32 EQUALVERIFY HASH256 <hash> EQUAL`
-    Hash256(sha256d::Hash),
+    Hash256(Pk::Hash256),
     /// `SIZE 32 EQUALVERIFY RIPEMD160 <hash> EQUAL`
     Ripemd160(ripemd160::Hash),
     /// `SIZE 32 EQUALVERIFY HASH160 <hash> EQUAL`
@@ -368,7 +368,7 @@ pub fn parse<Ctx: ScriptContext>(
                                 Tk::Hash256, Tk::Verify, Tk::Equal, Tk::Num(32), Tk::Size => {
                                     non_term.push(NonTerm::Verify);
                                     term.reduce0(Terminal::Hash256(
-                                        sha256d::Hash::from_slice(hash).expect("valid size")
+                                        hash256::Hash::from_slice(hash).expect("valid size")
                                     ))?
                                 },
                             ),
@@ -412,7 +412,7 @@ pub fn parse<Ctx: ScriptContext>(
                             Tk::Equal,
                             Tk::Num(32),
                             Tk::Size => term.reduce0(Terminal::Hash256(
-                                sha256d::Hash::from_slice(hash).expect("valid size")
+                                hash256::Hash::from_slice(hash).expect("valid size")
                             ))?,
                         ),
                         Tk::Hash20(hash) => match_token!(

--- a/src/miniscript/hash256.rs
+++ b/src/miniscript/hash256.rs
@@ -1,0 +1,88 @@
+// Miniscript
+// Written in 2022 by
+//     Sanket Kanjalkar <sanket1729@gmail.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Hash256 type
+//!
+//! This module is _identical_ in functionality to the `bitcoin_hashes::sha256d` hash type
+//! but the `FromHex/FromStr` and `ToHex/Display` implementations use `DISPLAY_BACKWARDS = false`.
+//!
+use core::str;
+
+use bitcoin::hashes::{
+    self, borrow_slice_impl, hex, hex_fmt_impl, index_impl, serde_impl, sha256, Hash as HashTrait,
+};
+
+/// Output of the SHA256d hash function
+#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct Hash([u8; 32]);
+
+hex_fmt_impl!(Debug, Hash);
+hex_fmt_impl!(Display, Hash);
+hex_fmt_impl!(LowerHex, Hash);
+index_impl!(Hash);
+serde_impl!(Hash, 32);
+borrow_slice_impl!(Hash);
+
+impl str::FromStr for Hash {
+    type Err = hex::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        hex::FromHex::from_hex(s)
+    }
+}
+
+impl HashTrait for Hash {
+    type Engine = sha256::HashEngine;
+    type Inner = [u8; 32];
+
+    fn engine() -> sha256::HashEngine {
+        sha256::Hash::engine()
+    }
+
+    fn from_engine(e: sha256::HashEngine) -> Hash {
+        let sha2 = sha256::Hash::from_engine(e);
+        let sha2d = sha256::Hash::hash(&sha2[..]);
+
+        let mut ret = [0; 32];
+        ret.copy_from_slice(&sha2d[..]);
+        Hash(ret)
+    }
+
+    const LEN: usize = 32;
+
+    fn from_slice(sl: &[u8]) -> Result<Hash, hashes::Error> {
+        if sl.len() != 32 {
+            Err(hashes::Error::InvalidLength(Self::LEN, sl.len()))
+        } else {
+            let mut ret = [0; 32];
+            ret.copy_from_slice(sl);
+            Ok(Hash(ret))
+        }
+    }
+
+    /// sha256d has DISPLAY_BACKWARD as true
+    const DISPLAY_BACKWARD: bool = false;
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
+    fn from_inner(inner: Self::Inner) -> Self {
+        Hash(inner)
+    }
+}

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -140,7 +140,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
     /// To obtain a list of all public key hashes within AST use [Miniscript::iter_pkh()] function,
     /// for example `miniscript.iter_pubkey_hashes().collect()`.
-    pub fn get_leapkh(&self) -> Vec<Pk::Hash> {
+    pub fn get_leapkh(&self) -> Vec<Pk::RawPkHash> {
         match self.node {
             Terminal::RawPkH(ref hash) => vec![hash.clone()],
             Terminal::PkK(ref key) | Terminal::PkH(ref key) => vec![key.to_pubkeyhash()],
@@ -193,7 +193,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// returns it cloned copy.
     ///
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
-    pub fn get_nth_pkh(&self, n: usize) -> Option<Pk::Hash> {
+    pub fn get_nth_pkh(&self, n: usize) -> Option<Pk::RawPkHash> {
         match (&self.node, n) {
             (&Terminal::RawPkH(ref hash), 0) => Some(hash.clone()),
             (&Terminal::PkK(ref key), 0) | (&Terminal::PkH(ref key), 0) => {
@@ -348,7 +348,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> PkhIter<'a, Pk, Ctx> {
 }
 
 impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkhIter<'a, Pk, Ctx> {
-    type Item = Pk::Hash;
+    type Item = Pk::RawPkHash;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -376,10 +376,10 @@ pub enum PkPkh<Pk: MiniscriptKey> {
     /// Plain public key
     PlainPubkey(Pk),
     /// Hashed public key
-    HashedPubkey(Pk::Hash),
+    HashedPubkey(Pk::RawPkHash),
 }
 
-impl<Pk: MiniscriptKey<Hash = Pk>> PkPkh<Pk> {
+impl<Pk: MiniscriptKey<RawPkHash = Pk>> PkPkh<Pk> {
     /// Convenience method to avoid distinguishing between keys and hashes when these are the same type
     pub fn as_key(self) -> Pk {
         match self {

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -273,7 +273,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> ForEachKey<Pk> for Miniscript<Pk, Ct
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         self.real_for_each_key(&mut pred)
     }
@@ -301,7 +301,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     fn real_for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: &mut F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         self.node.real_for_each_key(pred)
     }

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -37,6 +37,7 @@ pub mod analyzable;
 pub mod astelem;
 pub(crate) mod context;
 pub mod decode;
+pub mod hash256;
 pub mod iter;
 pub mod lex;
 pub mod limits;

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -849,7 +849,9 @@ where
             insert_wrap!(AstElemExt::terminal(Terminal::Sha256(hash.clone())))
         }
         // Satisfaction-cost + script-cost
-        Concrete::Hash256(hash) => insert_wrap!(AstElemExt::terminal(Terminal::Hash256(hash))),
+        Concrete::Hash256(ref hash) => {
+            insert_wrap!(AstElemExt::terminal(Terminal::Hash256(hash.clone())))
+        }
         Concrete::Ripemd160(hash) => insert_wrap!(AstElemExt::terminal(Terminal::Ripemd160(hash))),
         Concrete::Hash160(hash) => insert_wrap!(AstElemExt::terminal(Terminal::Hash160(hash))),
         Concrete::And(ref subs) => {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -20,7 +20,7 @@ use core::{fmt, str};
 use std::error;
 
 use bitcoin::hashes::hex::FromHex;
-use bitcoin::hashes::{hash160, ripemd160, sha256d};
+use bitcoin::hashes::{hash160, ripemd160};
 #[cfg(feature = "compiler")]
 use {
     crate::descriptor::TapTree,
@@ -60,7 +60,7 @@ pub enum Policy<Pk: MiniscriptKey> {
     /// A SHA256 whose preimage must be provided to satisfy the descriptor
     Sha256(Pk::Sha256),
     /// A SHA256d whose preimage must be provided to satisfy the descriptor
-    Hash256(sha256d::Hash),
+    Hash256(Pk::Hash256),
     /// A RIPEMD160 whose preimage must be provided to satisfy the descriptor
     Ripemd160(ripemd160::Hash),
     /// A HASH160 whose preimage must be provided to satisfy the descriptor
@@ -371,7 +371,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// # Example
     ///
     /// ```
-    /// use miniscript::{bitcoin::PublicKey, policy::concrete::Policy, Translator};
+    /// use miniscript::{bitcoin::PublicKey, policy::concrete::Policy, Translator, hash256};
     /// use std::str::FromStr;
     /// use std::collections::HashMap;
     /// use miniscript::bitcoin::hashes::{sha256, hash160};
@@ -400,6 +400,11 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     ///
     ///     // If our policy also contained other fragments, we could provide the translation here.
     ///     fn sha256(&mut self, sha256: &String) -> Result<sha256::Hash, ()> {
+    ///         unreachable!("Policy does not contain any sha256 fragment");
+    ///     }
+    ///
+    ///     // If our policy also contained other fragments, we could provide the translation here.
+    ///     fn hash256(&mut self, sha256: &String) -> Result<hash256::Hash, ()> {
     ///         unreachable!("Policy does not contain any sha256 fragment");
     ///     }
     /// }
@@ -432,7 +437,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             Policy::Trivial => Ok(Policy::Trivial),
             Policy::Key(ref pk) => t.pk(pk).map(Policy::Key),
             Policy::Sha256(ref h) => t.sha256(h).map(Policy::Sha256),
-            Policy::Hash256(ref h) => Ok(Policy::Hash256(*h)),
+            Policy::Hash256(ref h) => t.hash256(h).map(Policy::Hash256),
             Policy::Ripemd160(ref h) => Ok(Policy::Ripemd160(*h)),
             Policy::Hash160(ref h) => Ok(Policy::Hash160(*h)),
             Policy::After(n) => Ok(Policy::After(n)),
@@ -675,7 +680,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
             Policy::After(n) => write!(f, "after({})", n),
             Policy::Older(n) => write!(f, "older({})", n),
             Policy::Sha256(ref h) => write!(f, "sha256({})", h),
-            Policy::Hash256(h) => write!(f, "hash256({})", h),
+            Policy::Hash256(ref h) => write!(f, "hash256({})", h),
             Policy::Ripemd160(h) => write!(f, "ripemd160({})", h),
             Policy::Hash160(h) => write!(f, "hash160({})", h),
             Policy::And(ref subs) => {
@@ -718,7 +723,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
             Policy::After(n) => write!(f, "after({})", n),
             Policy::Older(n) => write!(f, "older({})", n),
             Policy::Sha256(ref h) => write!(f, "sha256({})", h),
-            Policy::Hash256(h) => write!(f, "hash256({})", h),
+            Policy::Hash256(ref h) => write!(f, "hash256({})", h),
             Policy::Ripemd160(h) => write!(f, "ripemd160({})", h),
             Policy::Hash160(h) => write!(f, "hash160({})", h),
             Policy::And(ref subs) => {
@@ -828,7 +833,7 @@ impl_block_str!(
                 <Pk::Sha256 as core::str::FromStr>::from_str(x).map(Policy::Sha256)
             }),
             ("hash256", 1) => expression::terminal(&top.args[0], |x| {
-                sha256d::Hash::from_hex(x).map(Policy::Hash256)
+                <Pk::Hash256 as core::str::FromStr>::from_str(x).map(Policy::Hash256)
             }),
             ("ripemd160", 1) => expression::terminal(&top.args[0], |x| {
                 ripemd160::Hash::from_hex(x).map(Policy::Ripemd160)

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -345,7 +345,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         match *self {
             Policy::Unsatisfiable | Policy::Trivial => true,

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -129,7 +129,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
             Terminal::After(t) => Semantic::After(t),
             Terminal::Older(t) => Semantic::Older(t),
             Terminal::Sha256(ref h) => Semantic::Sha256(h.clone()),
-            Terminal::Hash256(h) => Semantic::Hash256(h),
+            Terminal::Hash256(ref h) => Semantic::Hash256(h.clone()),
             Terminal::Ripemd160(h) => Semantic::Ripemd160(h),
             Terminal::Hash160(h) => Semantic::Hash160(h),
             Terminal::True => Semantic::Trivial,
@@ -204,7 +204,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
             Concrete::After(t) => Semantic::After(t),
             Concrete::Older(t) => Semantic::Older(t),
             Concrete::Sha256(ref h) => Semantic::Sha256(h.clone()),
-            Concrete::Hash256(h) => Semantic::Hash256(h),
+            Concrete::Hash256(ref h) => Semantic::Hash256(h.clone()),
             Concrete::Ripemd160(h) => Semantic::Ripemd160(h),
             Concrete::Hash160(h) => Semantic::Hash160(h),
             Concrete::And(ref subs) => {

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -38,7 +38,7 @@ pub enum Policy<Pk: MiniscriptKey> {
     /// Trivially satisfiable
     Trivial,
     /// Signature and public key matching a given hash is required
-    KeyHash(Pk::Hash),
+    KeyHash(Pk::RawPkHash),
     /// An absolute locktime restriction
     After(u32),
     /// A relative locktime restriction
@@ -59,7 +59,7 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
     where
         Pk: 'a,
-        Pk::Hash: 'a,
+        Pk::RawPkHash: 'a,
     {
         match *self {
             Policy::Unsatisfiable | Policy::Trivial => true,
@@ -336,7 +336,8 @@ impl_from_tree!(
             ("UNSATISFIABLE", 0) => Ok(Policy::Unsatisfiable),
             ("TRIVIAL", 0) => Ok(Policy::Trivial),
             ("pkh", 1) => expression::terminal(&top.args[0], |pk| {
-                Pk::Hash::from_str(pk).map(Policy::KeyHash)
+                // TODO: This will be fixed up in a later commit that changes semantic policy to Pk from Pk::Hash
+                Pk::RawPkHash::from_str(pk).map(Policy::KeyHash)
             }),
             ("after", 1) => expression::terminal(&top.args[0], |x| {
                 expression::parse_num(x).map(Policy::After)

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -18,7 +18,7 @@ use core::str::FromStr;
 use core::{fmt, str};
 
 use bitcoin::hashes::hex::FromHex;
-use bitcoin::hashes::{hash160, ripemd160, sha256d};
+use bitcoin::hashes::{hash160, ripemd160};
 
 use super::concrete::PolicyError;
 use super::ENTAILMENT_MAX_TERMINALS;
@@ -46,7 +46,7 @@ pub enum Policy<Pk: MiniscriptKey> {
     /// A SHA256 whose preimage must be provided to satisfy the descriptor
     Sha256(Pk::Sha256),
     /// A SHA256d whose preimage must be provided to satisfy the descriptor
-    Hash256(sha256d::Hash),
+    Hash256(Pk::Hash256),
     /// A RIPEMD160 whose preimage must be provided to satisfy the descriptor
     Ripemd160(ripemd160::Hash),
     /// A HASH160 whose preimage must be provided to satisfy the descriptor
@@ -82,7 +82,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// # Example
     ///
     /// ```
-    /// use miniscript::{bitcoin::{hashes::hash160, PublicKey}, policy::semantic::Policy, Translator};
+    /// use miniscript::{bitcoin::{hashes::hash160, PublicKey}, policy::semantic::Policy, Translator, hash256};
     /// use std::str::FromStr;
     /// use std::collections::HashMap;
     /// use miniscript::bitcoin::hashes::sha256;
@@ -111,6 +111,11 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     ///
     ///     // If our policy also contained other fragments, we could provide the translation here.
     ///     fn sha256(&mut self, sha256: &String) -> Result<sha256::Hash, ()> {
+    ///         unreachable!("Policy does not contain any sha256 fragment");
+    ///     }
+    ///
+    ///     // If our policy also contained other fragments, we could provide the translation here.
+    ///     fn hash256(&mut self, sha256: &String) -> Result<hash256::Hash, ()> {
     ///         unreachable!("Policy does not contain any sha256 fragment");
     ///     }
     /// }
@@ -143,7 +148,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             Policy::Trivial => Ok(Policy::Trivial),
             Policy::KeyHash(ref pkh) => t.pkh(pkh).map(Policy::KeyHash),
             Policy::Sha256(ref h) => t.sha256(h).map(Policy::Sha256),
-            Policy::Hash256(ref h) => Ok(Policy::Hash256(*h)),
+            Policy::Hash256(ref h) => t.hash256(h).map(Policy::Hash256),
             Policy::Ripemd160(ref h) => Ok(Policy::Ripemd160(*h)),
             Policy::Hash160(ref h) => Ok(Policy::Hash160(*h)),
             Policy::After(n) => Ok(Policy::After(n)),
@@ -250,7 +255,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
             Policy::After(n) => write!(f, "after({})", n),
             Policy::Older(n) => write!(f, "older({})", n),
             Policy::Sha256(ref h) => write!(f, "sha256({})", h),
-            Policy::Hash256(h) => write!(f, "hash256({})", h),
+            Policy::Hash256(ref h) => write!(f, "hash256({})", h),
             Policy::Ripemd160(h) => write!(f, "ripemd160({})", h),
             Policy::Hash160(h) => write!(f, "hash160({})", h),
             Policy::Threshold(k, ref subs) => {
@@ -283,7 +288,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
             Policy::After(n) => write!(f, "after({})", n),
             Policy::Older(n) => write!(f, "older({})", n),
             Policy::Sha256(ref h) => write!(f, "sha256({})", h),
-            Policy::Hash256(h) => write!(f, "hash256({})", h),
+            Policy::Hash256(ref h) => write!(f, "hash256({})", h),
             Policy::Ripemd160(h) => write!(f, "ripemd160({})", h),
             Policy::Hash160(h) => write!(f, "hash160({})", h),
             Policy::Threshold(k, ref subs) => {
@@ -343,7 +348,7 @@ impl_from_tree!(
                 Pk::Sha256::from_str(x).map(Policy::Sha256)
             }),
             ("hash256", 1) => expression::terminal(&top.args[0], |x| {
-                sha256d::Hash::from_hex(x).map(Policy::Hash256)
+                Pk::Hash256::from_str(x).map(Policy::Hash256)
             }),
             ("ripemd160", 1) => expression::terminal(&top.args[0], |x| {
                 ripemd160::Hash::from_hex(x).map(Policy::Ripemd160)

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -305,7 +305,7 @@ impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfie
 
     fn lookup_pkh_tap_leaf_script_sig(
         &self,
-        pkh: &(Pk::Hash, TapLeafHash),
+        pkh: &(Pk::RawPkHash, TapLeafHash),
     ) -> Option<(bitcoin::secp256k1::XOnlyPublicKey, bitcoin::SchnorrSig)> {
         self.psbt.inputs[self.index]
             .tap_script_sigs
@@ -325,7 +325,7 @@ impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfie
 
     fn lookup_pkh_ecdsa_sig(
         &self,
-        pkh: &Pk::Hash,
+        pkh: &Pk::RawPkHash,
     ) -> Option<(bitcoin::PublicKey, bitcoin::EcdsaSig)> {
         self.psbt.inputs[self.index]
             .partial_sigs

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -24,7 +24,7 @@ use core::ops::Deref;
 #[cfg(feature = "std")]
 use std::error;
 
-use bitcoin::hashes::{hash160, ripemd160, sha256d};
+use bitcoin::hashes::{hash160, ripemd160, sha256d, Hash};
 use bitcoin::secp256k1::{self, Secp256k1, VerifyOnly};
 use bitcoin::util::psbt::{self, PartiallySignedTransaction as Psbt};
 use bitcoin::util::sighash::SighashCache;
@@ -375,10 +375,10 @@ impl<'psbt, Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfie
             .and_then(try_vec_as_preimage32)
     }
 
-    fn lookup_hash256(&self, h: sha256d::Hash) -> Option<Preimage32> {
+    fn lookup_hash256(&self, h: &Pk::Hash256) -> Option<Preimage32> {
         self.psbt.inputs[self.index]
             .hash256_preimages
-            .get(&h)
+            .get(&sha256d::Hash::from_inner(Pk::to_hash256(h).into_inner())) // upstream psbt operates on hash256
             .and_then(try_vec_as_preimage32)
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use bitcoin::hashes::{hash160, sha256};
 use bitcoin::secp256k1;
 
-use crate::{MiniscriptKey, Translator};
+use crate::{hash256, MiniscriptKey, Translator};
 
 /// Translate from a String MiniscriptKey type to bitcoin::PublicKey
 /// If the hashmap is populated, this will lookup for keys in HashMap
@@ -43,6 +43,15 @@ impl Translator<String, bitcoin::PublicKey, ()> for StrKeyTranslator {
         .unwrap();
         Ok(hash)
     }
+
+    fn hash256(&mut self, _hash256: &String) -> Result<hash256::Hash, ()> {
+        // hard coded value
+        let hash = hash256::Hash::from_str(
+            "4ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+        )
+        .unwrap();
+        Ok(hash)
+    }
 }
 
 /// Same as [`StrKeyTranslator`], but for [`bitcoin::XOnlyPublicKey`]
@@ -73,6 +82,14 @@ impl Translator<String, bitcoin::XOnlyPublicKey, ()> for StrXOnlyKeyTranslator {
 
     fn sha256(&mut self, _sha256: &String) -> Result<sha256::Hash, ()> {
         let hash = sha256::Hash::from_str(
+            "4ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
+        )
+        .unwrap();
+        Ok(hash)
+    }
+
+    fn hash256(&mut self, _hash256: &String) -> Result<hash256::Hash, ()> {
+        let hash = hash256::Hash::from_str(
             "4ae81572f06e1b88fd5ced7a1a000945432e83e1551e6f721ee9c00b8cc33260",
         )
         .unwrap();

--- a/tests/setup/test_util.rs
+++ b/tests/setup/test_util.rs
@@ -21,11 +21,12 @@ use std::str::FromStr;
 
 use actual_rand as rand;
 use bitcoin::hashes::hex::ToHex;
-use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
+use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 use bitcoin::secp256k1;
 use miniscript::descriptor::{SinglePub, SinglePubKey};
 use miniscript::{
-    Descriptor, DescriptorPublicKey, Error, Miniscript, ScriptContext, TranslatePk, Translator,
+    hash256, Descriptor, DescriptorPublicKey, Error, Miniscript, ScriptContext, TranslatePk,
+    Translator,
 };
 use rand::RngCore;
 #[derive(Clone, Debug)]
@@ -33,7 +34,7 @@ pub struct PubData {
     pub pks: Vec<bitcoin::PublicKey>,
     pub x_only_pks: Vec<bitcoin::XOnlyPublicKey>,
     pub sha256: sha256::Hash,
-    pub hash256: sha256d::Hash,
+    pub hash256: hash256::Hash,
     pub ripemd160: ripemd160::Hash,
     pub hash160: hash160::Hash,
 }
@@ -99,7 +100,7 @@ impl TestData {
         let sha256_pre = [0x12 as u8; 32];
         let sha256 = sha256::Hash::hash(&sha256_pre);
         let hash256_pre = [0x34 as u8; 32];
-        let hash256 = sha256d::Hash::hash(&hash256_pre);
+        let hash256 = hash256::Hash::hash(&hash256_pre);
         let hash160_pre = [0x56 as u8; 32];
         let hash160 = hash160::Hash::hash(&hash160_pre);
         let ripemd160_pre = [0x78 as u8; 32];
@@ -197,6 +198,11 @@ impl<'a> Translator<String, DescriptorPublicKey, ()> for StrDescPubKeyTranslator
         let sha = sha256::Hash::from_str(sha256).unwrap();
         Ok(sha)
     }
+
+    fn hash256(&mut self, hash256: &String) -> Result<hash256::Hash, ()> {
+        let hash256 = hash256::Hash::from_str(hash256).unwrap();
+        Ok(hash256)
+    }
 }
 
 // Translate Str to DescriptorPublicKey
@@ -242,6 +248,11 @@ impl<'a> Translator<String, DescriptorPublicKey, ()> for StrTranslatorLoose<'a> 
     fn sha256(&mut self, sha256: &String) -> Result<sha256::Hash, ()> {
         let sha = sha256::Hash::from_str(sha256).unwrap();
         Ok(sha)
+    }
+
+    fn hash256(&mut self, hash256: &String) -> Result<hash256::Hash, ()> {
+        let hash256 = hash256::Hash::from_str(hash256).unwrap();
+        Ok(hash256)
     }
 }
 

--- a/tests/test_cpp.rs
+++ b/tests/test_cpp.rs
@@ -9,6 +9,7 @@ use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::Path;
 
+use bitcoin::hashes::{sha256d, Hash};
 use bitcoin::secp256k1::{self, Secp256k1};
 use bitcoin::util::psbt;
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
@@ -197,7 +198,7 @@ pub fn test_from_cpp_ms(cl: &Client, testdata: &TestData) {
             testdata.secretdata.sha256_pre.to_vec(),
         );
         psbts[i].inputs[0].hash256_preimages.insert(
-            testdata.pubdata.hash256,
+            sha256d::Hash::from_inner(testdata.pubdata.hash256.into_inner()),
             testdata.secretdata.hash256_pre.to_vec(),
         );
         println!("{}", ms);

--- a/tests/test_desc.rs
+++ b/tests/test_desc.rs
@@ -9,6 +9,7 @@ use std::{error, fmt};
 
 use actual_rand as rand;
 use bitcoin::blockdata::witness::Witness;
+use bitcoin::hashes::{sha256d, Hash};
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::util::sighash::SighashCache;
 use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
@@ -282,7 +283,7 @@ pub fn test_desc_satisfy(
         testdata.secretdata.sha256_pre.to_vec(),
     );
     psbt.inputs[0].hash256_preimages.insert(
-        testdata.pubdata.hash256,
+        sha256d::Hash::from_inner(testdata.pubdata.hash256.into_inner()),
         testdata.secretdata.hash256_pre.to_vec(),
     );
     psbt.inputs[0].hash160_preimages.insert(


### PR DESCRIPTION
- Implement a new hash type that does not display/FromStr with `DISPLAY_BACKWARD`. Should we make this type upstream in bitcoin-hashes?
- Remove the PkTranslator trait as it was causing conflicting implementations downstream. 
- Replace the above with more macros :(  
