### PR TITLE
Explicitly do not support 16 bit architectures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,11 @@
 #![deny(unused_imports)]
 #![deny(missing_docs)]
 
+#[cfg(target_pointer_width = "16")]
+compile_error!(
+    "rust-miniscript currently only supports architectures with pointers wider than 16 bits"
+);
+
 pub use bitcoin;
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
We cast `u32` to `usize` in a bunch of places, this will cause strange behaviour because of truncation on 16 bit architectures.

Add a compile time check to explicitly not support 16 bit architectures.