### PR TITLE
Create configuration conditional bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ std = ["bitcoin/std", "bitcoin/secp-recovery"]
 no-std = ["hashbrown", "bitcoin/no-std"]
 compiler = []
 trace = []
-unstable = []
 serde = ["actual-serde", "bitcoin/use-serde"]
 rand = ["bitcoin/rand"]
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ architectural mismatches. If you have any questions or ideas you want to discuss
 please join us in
 [##miniscript](https://web.libera.chat/?channels=##miniscript) on Libera.
 
+### Benchmarks
+
+We use a custom Rust compiler configuration conditional to guard the bench mark code. To run the
+bench marks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench --features=compiler`.
+
 # Release Notes
 
 See [CHANGELOG.md](CHANGELOG.md).

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -77,10 +77,10 @@ then
   done
 fi
 
-# Bench if told to (this only works with the nightly toolchain)
+# Bench if told to, only works with non-stable toolchain (nightly, beta).
 if [ "$DO_BENCH" = true ]
 then
-    cargo bench --features="unstable compiler"
+    RUSTFLAGS='--cfg=bench' cargo bench --features=compiler
 fi
 
 # Build the docs if told to (this only works with the nightly toolchain)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(all(test, feature = "unstable"), feature(test))]
+
 // Coding conventions
 #![deny(unsafe_code)]
 #![deny(non_upper_case_globals)]
@@ -89,6 +89,9 @@
 #![deny(dead_code)]
 #![deny(unused_imports)]
 #![deny(missing_docs)]
+
+// Experimental features we need.
+#![cfg_attr(bench, feature(test))]
 
 #[cfg(target_pointer_width = "16")]
 compile_error!(
@@ -109,7 +112,8 @@ extern crate core;
 
 #[cfg(feature = "serde")]
 pub use actual_serde as serde;
-#[cfg(all(test, feature = "unstable"))]
+
+#[cfg(bench)]
 extern crate test;
 
 #[macro_use]

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1608,7 +1608,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 mod benches {
     use std::str::FromStr;
 


### PR DESCRIPTION
Draft because this won't work until we merge and release: https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/244

As we did in rust-bitcoin [0] create a configuration conditional bench that we can use to guard bench mark code. This has the benefit of making our features additive i.e., we can now test with --all-features with a stable toolchain (currently this fails because of our use of the test crate).

Maintains the use of `--features=compiler` in `test.sh` and in the suggested incantation in `README.md`.

[0] - rust-bitcoin/rust-bitcoin#1092