### PR TITLE
DerivedDescriptor unfinished business

### DIFF
--- a/examples/xpub_descriptors.rs
+++ b/examples/xpub_descriptors.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 
 use miniscript::bitcoin::secp256k1::{Secp256k1, Verification};
 use miniscript::bitcoin::{Address, Network};
-use miniscript::{DerivedDescriptorKey, Descriptor, DescriptorPublicKey};
+use miniscript::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey};
 
 const XPUB_1: &str = "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB";
 const XPUB_2: &str = "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH";
@@ -40,7 +40,7 @@ fn p2wsh<C: Verification>(secp: &Secp256k1<C>) -> Address {
     let s = format!("wsh(sortedmulti(1,{},{}))", XPUB_1, XPUB_2);
     // let s = format!("wsh(sortedmulti(1,{},{}))", XPUB_2, XPUB_1);
 
-    let address = Descriptor::<DerivedDescriptorKey>::from_str(&s)
+    let address = Descriptor::<DefiniteDescriptorKey>::from_str(&s)
         .unwrap()
         .derived_descriptor(&secp)
         .unwrap()

--- a/examples/xpub_descriptors.rs
+++ b/examples/xpub_descriptors.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 
 use miniscript::bitcoin::secp256k1::{Secp256k1, Verification};
 use miniscript::bitcoin::{Address, Network};
-use miniscript::{Descriptor, DescriptorPublicKey};
+use miniscript::{DerivedDescriptorKey, Descriptor, DescriptorPublicKey};
 
 const XPUB_1: &str = "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB";
 const XPUB_2: &str = "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH";
@@ -40,9 +40,9 @@ fn p2wsh<C: Verification>(secp: &Secp256k1<C>) -> Address {
     let s = format!("wsh(sortedmulti(1,{},{}))", XPUB_1, XPUB_2);
     // let s = format!("wsh(sortedmulti(1,{},{}))", XPUB_2, XPUB_1);
 
-    let address = Descriptor::<DescriptorPublicKey>::from_str(&s)
+    let address = Descriptor::<DerivedDescriptorKey>::from_str(&s)
         .unwrap()
-        .derived_descriptor(&secp, 0) // dummy index value if it not a wildcard
+        .derived_descriptor(&secp)
         .unwrap()
         .address(Network::Bitcoin)
         .unwrap();

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -58,7 +58,7 @@ mod checksum;
 mod key;
 
 pub use self::key::{
-    ConversionError, DerivedDescriptorKey, DescriptorKeyParseError, DescriptorPublicKey,
+    ConversionError, DefiniteDescriptorKey, DescriptorKeyParseError, DescriptorPublicKey,
     DescriptorSecretKey, DescriptorXKey, InnerXKey, SinglePriv, SinglePub, SinglePubKey, Wildcard,
 };
 
@@ -513,30 +513,42 @@ impl<Pk: MiniscriptKey> ForEachKey<Pk> for Descriptor<Pk> {
 
 impl Descriptor<DescriptorPublicKey> {
     /// Whether or not the descriptor has any wildcards
+    #[deprecated(note = "use has_wildcards instead")]
     pub fn is_deriveable(&self) -> bool {
-        self.for_any_key(|key| key.is_deriveable())
+        self.has_wildcard()
     }
 
-    /// Derives all wildcard keys in the descriptor using the supplied index
+    /// Whether or not the descriptor has any wildcards i.e. `/*`.
+    pub fn has_wildcard(&self) -> bool {
+        self.for_any_key(|key| key.has_wildcard())
+    }
+
+    /// Replaces all wildcards (i.e. `/*`) in the descriptor with a particular derivation index,
+    /// turning it into a *definite* descriptor.
     ///
-    /// Panics if given an index ≥ 2^31
+    /// # Panics
     ///
-    /// In most cases, you would want to use [`Self::derived_descriptor`] directly to obtain
-    /// a [`Descriptor<bitcoin::PublicKey>`]
-    pub fn derive(&self, index: u32) -> Descriptor<DerivedDescriptorKey> {
+    /// If index ≥ 2^31
+    pub fn at_derivation_index(&self, index: u32) -> Descriptor<DefiniteDescriptorKey> {
         struct Derivator(u32);
 
-        impl PkTranslator<DescriptorPublicKey, DerivedDescriptorKey, ()> for Derivator {
-            fn pk(&mut self, pk: &DescriptorPublicKey) -> Result<DerivedDescriptorKey, ()> {
-                Ok(pk.clone().derive(self.0))
+        impl PkTranslator<DescriptorPublicKey, DefiniteDescriptorKey, ()> for Derivator {
+            fn pk(&mut self, pk: &DescriptorPublicKey) -> Result<DefiniteDescriptorKey, ()> {
+                Ok(pk.clone().at_derivation_index(self.0))
             }
 
-            fn pkh(&mut self, pkh: &DescriptorPublicKey) -> Result<DerivedDescriptorKey, ()> {
-                Ok(pkh.clone().derive(self.0))
+            fn pkh(&mut self, pkh: &DescriptorPublicKey) -> Result<DefiniteDescriptorKey, ()> {
+                Ok(pkh.clone().at_derivation_index(self.0))
             }
         }
         self.translate_pk(&mut Derivator(index))
             .expect("BIP 32 key index substitution cannot fail")
+    }
+
+    #[deprecated(note = "use at_derivation_index instead")]
+    /// Deprecated name for [`at_derivation_index`].
+    pub fn derive(&self, index: u32) -> Descriptor<DefiniteDescriptorKey> {
+        self.at_derivation_index(index)
     }
 
     /// Convert all the public keys in the descriptor to [`bitcoin::PublicKey`] by deriving them or
@@ -552,14 +564,14 @@ impl Descriptor<DescriptorPublicKey> {
     ///     .expect("Valid ranged descriptor");
     /// # let index = 42;
     /// # let secp = Secp256k1::verification_only();
-    /// let derived_descriptor = descriptor.derive(index).derived_descriptor(&secp);
+    /// let derived_descriptor = descriptor.at_derivation_index(index).derived_descriptor(&secp);
     /// # assert_eq!(descriptor.derived_descriptor(&secp, index), derived_descriptor);
     /// ```
     ///
     /// and is only here really here for backwards compatbility.
-    /// See [`derive`] and `[derived_descriptor`] for more documentation.
+    /// See [`at_derivation_index`] and `[derived_descriptor`] for more documentation.
     ///
-    /// [`derive`]: Self::derive
+    /// [`at_derivation_index`]: Self::at_derivation_index
     /// [`derived_descriptor`]: crate::DerivedDescriptor::derived_descriptor
     ///
     /// # Errors
@@ -570,7 +582,7 @@ impl Descriptor<DescriptorPublicKey> {
         secp: &secp256k1::Secp256k1<C>,
         index: u32,
     ) -> Result<Descriptor<bitcoin::PublicKey>, ConversionError> {
-        self.derive(index).derived_descriptor(&secp)
+        self.at_derivation_index(index).derived_descriptor(&secp)
     }
 
     /// Parse a descriptor that may contain secret keys
@@ -711,7 +723,7 @@ impl Descriptor<DescriptorPublicKey> {
         script_pubkey: &Script,
         range: Range<u32>,
     ) -> Result<Option<(u32, Descriptor<bitcoin::PublicKey>)>, ConversionError> {
-        let range = if self.is_deriveable() { range } else { 0..1 };
+        let range = if self.has_wildcard() { range } else { 0..1 };
 
         for i in range {
             let concrete = self.derived_descriptor(secp, i)?;
@@ -724,7 +736,7 @@ impl Descriptor<DescriptorPublicKey> {
     }
 }
 
-impl Descriptor<DerivedDescriptorKey> {
+impl Descriptor<DefiniteDescriptorKey> {
     /// Convert all the public keys in the descriptor to [`bitcoin::PublicKey`] by deriving them or
     /// otherwise converting them. All [`bitcoin::XOnlyPublicKey`]s are converted to by adding a
     /// default(0x02) y-coordinate.
@@ -740,7 +752,7 @@ impl Descriptor<DerivedDescriptorKey> {
     /// let secp = secp256k1::Secp256k1::verification_only();
     /// let descriptor = Descriptor::<DescriptorPublicKey>::from_str("tr(xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ/0/*)")
     ///     .expect("Valid ranged descriptor");
-    /// let result = descriptor.derive(0).derived_descriptor(&secp).expect("Non-hardened derivation");
+    /// let result = descriptor.at_derivation_index(0).derived_descriptor(&secp).expect("Non-hardened derivation");
     /// assert_eq!(result.to_string(), "tr(03cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115)#6qm9h8ym");
     /// ```
     ///
@@ -754,19 +766,19 @@ impl Descriptor<DerivedDescriptorKey> {
         struct Derivator<'a, C: secp256k1::Verification>(&'a secp256k1::Secp256k1<C>);
 
         impl<'a, C: secp256k1::Verification>
-            PkTranslator<DerivedDescriptorKey, bitcoin::PublicKey, ConversionError>
+            PkTranslator<DefiniteDescriptorKey, bitcoin::PublicKey, ConversionError>
             for Derivator<'a, C>
         {
             fn pk(
                 &mut self,
-                pk: &DerivedDescriptorKey,
+                pk: &DefiniteDescriptorKey,
             ) -> Result<bitcoin::PublicKey, ConversionError> {
                 pk.derive_public_key(&self.0)
             }
 
             fn pkh(
                 &mut self,
-                pkh: &DerivedDescriptorKey,
+                pkh: &DefiniteDescriptorKey,
             ) -> Result<bitcoin::hashes::hash160::Hash, ConversionError> {
                 Ok(pkh.derive_public_key(&self.0)?.to_pubkeyhash())
             }
@@ -1597,13 +1609,13 @@ mod tests {
 
             // Same address
             let addr_one = desc_one
-                .derive(index)
+                .at_derivation_index(index)
                 .derived_descriptor(&secp_ctx)
                 .unwrap()
                 .address(bitcoin::Network::Bitcoin)
                 .unwrap();
             let addr_two = desc_two
-                .derive(index)
+                .at_derivation_index(index)
                 .derived_descriptor(&secp_ctx)
                 .unwrap()
                 .address(bitcoin::Network::Bitcoin)
@@ -1681,7 +1693,7 @@ pk(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHW
 pk(03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8))";
         let policy: policy::concrete::Policy<DescriptorPublicKey> = descriptor_str.parse().unwrap();
         let descriptor = Descriptor::new_sh(policy.compile().unwrap()).unwrap();
-        let derived_descriptor = descriptor.derive(42);
+        let definite_descriptor = descriptor.at_derivation_index(42);
 
         let res_descriptor_str = "thresh(2,\
 pk([d34db33f/44'/0'/0']xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/42),\
@@ -1691,7 +1703,7 @@ pk(03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8))";
             res_descriptor_str.parse().unwrap();
         let res_descriptor = Descriptor::new_sh(res_policy.compile().unwrap()).unwrap();
 
-        assert_eq!(res_descriptor.to_string(), derived_descriptor.to_string());
+        assert_eq!(res_descriptor.to_string(), definite_descriptor.to_string());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ use std::error;
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 
-pub use crate::descriptor::{Descriptor, DescriptorPublicKey};
+pub use crate::descriptor::{DerivedDescriptorKey, Descriptor, DescriptorPublicKey};
 pub use crate::interpreter::Interpreter;
 pub use crate::miniscript::context::{BareCtx, Legacy, ScriptContext, Segwitv0, Tap};
 pub use crate::miniscript::decode::Terminal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ use std::error;
 use bitcoin::blockdata::{opcodes, script};
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 
-pub use crate::descriptor::{DerivedDescriptorKey, Descriptor, DescriptorPublicKey};
+pub use crate::descriptor::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey};
 pub use crate::interpreter::Interpreter;
 pub use crate::miniscript::context::{BareCtx, Legacy, ScriptContext, Segwitv0, Tap};
 pub use crate::miniscript::decode::Terminal;

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -31,13 +31,14 @@ use bitcoin::util::sighash::SighashCache;
 use bitcoin::util::taproot::{self, ControlBlock, LeafVersion, TapLeafHash};
 use bitcoin::{self, EcdsaSighashType, SchnorrSighashType, Script};
 
+use crate::descriptor::DerivedDescriptorKey;
 use crate::miniscript::iter::PkPkh;
 use crate::miniscript::limits::SEQUENCE_LOCKTIME_DISABLE_FLAG;
 use crate::miniscript::satisfy::{After, Older};
 use crate::prelude::*;
 use crate::{
-    descriptor, interpreter, Descriptor, DescriptorPublicKey, MiniscriptKey, PkTranslator,
-    Preimage32, Satisfier, ToPublicKey, TranslatePk,
+    descriptor, interpreter, Descriptor, MiniscriptKey, PkTranslator, Preimage32, Satisfier,
+    ToPublicKey, TranslatePk,
 };
 
 mod finalizer;
@@ -568,7 +569,7 @@ pub trait PsbtExt {
     fn update_input_with_descriptor(
         &mut self,
         input_index: usize,
-        descriptor: &Descriptor<DescriptorPublicKey>,
+        descriptor: &Descriptor<DerivedDescriptorKey>,
     ) -> Result<(), UtxoUpdateError>;
 
     /// Get the sighash message(data to sign) at input index `idx` based on the sighash
@@ -735,7 +736,7 @@ impl PsbtExt for Psbt {
     fn update_input_with_descriptor(
         &mut self,
         input_index: usize,
-        desc: &Descriptor<DescriptorPublicKey>,
+        desc: &Descriptor<DerivedDescriptorKey>,
     ) -> Result<(), UtxoUpdateError> {
         let n_inputs = self.inputs.len();
         let input = self
@@ -916,14 +917,14 @@ pub trait PsbtInputExt {
     /// [`update_input_with_descriptor`]: PsbtExt::update_input_with_descriptor
     fn update_with_descriptor_unchecked(
         &mut self,
-        descriptor: &Descriptor<DescriptorPublicKey>,
+        descriptor: &Descriptor<DerivedDescriptorKey>,
     ) -> Result<Descriptor<bitcoin::PublicKey>, descriptor::ConversionError>;
 }
 
 impl PsbtInputExt for psbt::Input {
     fn update_with_descriptor_unchecked(
         &mut self,
-        descriptor: &Descriptor<DescriptorPublicKey>,
+        descriptor: &Descriptor<DerivedDescriptorKey>,
     ) -> Result<Descriptor<bitcoin::PublicKey>, descriptor::ConversionError> {
         let (derived, _) = update_input_with_descriptor_helper(self, descriptor, None)?;
         Ok(derived)
@@ -937,19 +938,19 @@ struct XOnlyHashLookUp(
     pub secp256k1::Secp256k1<VerifyOnly>,
 );
 
-impl PkTranslator<DescriptorPublicKey, bitcoin::PublicKey, descriptor::ConversionError>
+impl PkTranslator<DerivedDescriptorKey, bitcoin::PublicKey, descriptor::ConversionError>
     for XOnlyHashLookUp
 {
     fn pk(
         &mut self,
-        xpk: &DescriptorPublicKey,
+        xpk: &DerivedDescriptorKey,
     ) -> Result<bitcoin::PublicKey, descriptor::ConversionError> {
         xpk.derive_public_key(&self.1)
     }
 
     fn pkh(
         &mut self,
-        xpk: &DescriptorPublicKey,
+        xpk: &DerivedDescriptorKey,
     ) -> Result<hash160::Hash, descriptor::ConversionError> {
         let pk = xpk.derive_public_key(&self.1)?;
         let xonly = pk.to_x_only_pubkey();
@@ -966,12 +967,12 @@ struct KeySourceLookUp(
     pub secp256k1::Secp256k1<VerifyOnly>,
 );
 
-impl PkTranslator<DescriptorPublicKey, bitcoin::PublicKey, descriptor::ConversionError>
+impl PkTranslator<DerivedDescriptorKey, bitcoin::PublicKey, descriptor::ConversionError>
     for KeySourceLookUp
 {
     fn pk(
         &mut self,
-        xpk: &DescriptorPublicKey,
+        xpk: &DerivedDescriptorKey,
     ) -> Result<bitcoin::PublicKey, descriptor::ConversionError> {
         let derived = xpk.derive_public_key(&self.1)?;
         self.0.insert(
@@ -983,7 +984,7 @@ impl PkTranslator<DescriptorPublicKey, bitcoin::PublicKey, descriptor::Conversio
 
     fn pkh(
         &mut self,
-        xpk: &DescriptorPublicKey,
+        xpk: &DerivedDescriptorKey,
     ) -> Result<hash160::Hash, descriptor::ConversionError> {
         Ok(self.pk(xpk)?.to_pubkeyhash())
     }
@@ -991,7 +992,7 @@ impl PkTranslator<DescriptorPublicKey, bitcoin::PublicKey, descriptor::Conversio
 
 fn update_input_with_descriptor_helper(
     input: &mut psbt::Input,
-    descriptor: &Descriptor<DescriptorPublicKey>,
+    descriptor: &Descriptor<DerivedDescriptorKey>,
     check_script: Option<Script>,
     // the return value is a tuple here since the two internal calls to it require different info.
     // One needs the derived descriptor and the other needs to know whether the script_pubkey check
@@ -1071,7 +1072,6 @@ fn update_input_with_descriptor_helper(
 
         derived
     } else {
-        // have to use a RefCell because we can't pass FnMut to translate_pk2
         let mut bip32_derivation = KeySourceLookUp(BTreeMap::new(), Secp256k1::verification_only());
         let derived = descriptor.translate_pk(&mut bip32_derivation)?;
 
@@ -1439,7 +1439,7 @@ mod tests {
     #[test]
     fn test_update_input_checks() {
         let desc = format!("tr([73c5da0a/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ/0/0)");
-        let desc = Descriptor::<DescriptorPublicKey>::from_str(&desc).unwrap();
+        let desc = Descriptor::<DerivedDescriptorKey>::from_str(&desc).unwrap();
 
         let mut non_witness_utxo = bitcoin::Transaction {
             version: 1,

--- a/tests/test_desc.rs
+++ b/tests/test_desc.rs
@@ -85,8 +85,9 @@ pub fn test_desc_satisfy(
 
     let desc = test_util::parse_test_desc(&descriptor, &testdata.pubdata);
     let desc = desc.map_err(|_x| DescError::DescParseError)?;
+    let desc = desc.derive(0);
 
-    let derived_desc = desc.derived_descriptor(&secp, 0).unwrap();
+    let derived_desc = desc.derived_descriptor(&secp).unwrap();
     let desc_address = derived_desc.address(bitcoin::Network::Regtest);
     let desc_address = desc_address.map_err(|_x| DescError::AddressComputationError)?;
 


### PR DESCRIPTION
This PR further develops the idea introduced in #345. It has two commits both with relatively detailed commit messages that can be reviewed separately. In summary:

1. Develop the `DerivedDescriptorKey` (a key that is guaranteed not to have wildcard in it) idea more by adding missing functionality and refining the API. In addition, I removed the error cases from `ConversionError` which seems to have been omitted from #345.
2. Since the introduction of `DerivedDescriptorKey`, the overlapping usage of the term "derive" has become quite confusing. In addition to the usual definition of "derive" we have also used it to mean "replace a wildcard with a particular derivation index". I deprecated and renamed everything that uses the latter definition.