### PR TITLE
Add feature "serde"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,16 @@ no-std = ["hashbrown", "bitcoin/no-std"]
 compiler = []
 trace = []
 unstable = []
-use-serde = ["serde", "bitcoin/use-serde"]
+serde = ["actual-serde", "bitcoin/use-serde"]
 rand = ["bitcoin/rand"]
 
 [dependencies]
 bitcoin = { version = "0.28.1", default-features = false }
-serde = { version = "1.0", optional = true }
 hashbrown = { version = "0.11", optional = true }
+
+# Do NOT use this as a feature! Use the `serde` feature instead.
+actual-serde = { package = "serde", version = "1.0", optional = true }
+
 
 [dev-dependencies]
 bitcoind = {version = "0.26.1", features=["22_0"]}

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-FEATURES="compiler use-serde rand"
+FEATURES="compiler serde rand"
 
 # Use toolchain if explicitly specified
 if [ -n "$TOOLCHAIN" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ extern crate hashbrown;
 extern crate core;
 
 #[cfg(feature = "serde")]
-pub use serde;
+pub use actual_serde as serde;
 #[cfg(all(test, feature = "unstable"))]
 extern crate test;
 


### PR DESCRIPTION
As we did in `rust-bitcoin`; change the "serde" feature to
"actual-serde" and use `package = "serde"`. This allows users of
miniscript to use "serde" as the feature enabling serde instead of our
custom "use-serde".

Fix: #438 