### PR TITLE
Add KeyExpr<Pk> in Taproot descriptor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [features]
 default = ["std"]
-std = ["bitcoin/std", "bitcoin/secp-recovery"]
+std = ["bitcoin/std", "bitcoin/secp-recovery", "secp256k1-zkp"]
 no-std = ["hashbrown", "bitcoin/no-std"]
 compiler = []
 trace = []
@@ -24,6 +24,7 @@ rand = ["bitcoin/rand"]
 bitcoin = { version = "0.28.1", default-features = false }
 serde = { version = "1.0", optional = true }
 hashbrown = { version = "0.11", optional = true }
+secp256k1-zkp = { git = "https://github.com/sanket1729/rust-secp256k1-zkp", branch = "pr29", optional = true}
 
 [dev-dependencies]
 bitcoind = {version = "0.26.1", features=["22_0"]}

--- a/examples/taproot.rs
+++ b/examples/taproot.rs
@@ -75,7 +75,7 @@ fn main() {
     if let Descriptor::Tr(ref p) = desc {
         // Check if internal key is correctly inferred as Ca
         // assert_eq!(p.internal_key(), &pubkeys[2]);
-        assert_eq!(p.internal_key(), "Ca");
+        assert_eq!(p.internal_key().single_key().unwrap(), "Ca");
 
         // Iterate through scripts
         let mut iter = p.iter_scripts();

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -271,7 +271,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
 
     /// Create new tr descriptor
     /// Errors when miniscript exceeds resource limits under Tap context
-    pub fn new_tr(key: Pk, script: Option<tr::TapTree<Pk>>) -> Result<Self, Error> {
+    pub fn new_tr(key: KeyExpr<Pk>, script: Option<tr::TapTree<Pk>>) -> Result<Self, Error> {
         Ok(Descriptor::Tr(Tr::new(key, script)?))
     }
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -34,6 +34,7 @@ use bitcoin::{self, secp256k1, Address, Network, Script, TxIn};
 use sync::Arc;
 
 use self::checksum::verify_checksum;
+use crate::miniscript::musig_key::KeyExpr;
 use crate::miniscript::{Legacy, Miniscript, Segwitv0};
 use crate::prelude::*;
 use crate::{
@@ -180,7 +181,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
         // roundabout way to constuct `c:pk_k(pk)`
         let ms: Miniscript<Pk, BareCtx> =
             Miniscript::from_ast(miniscript::decode::Terminal::Check(Arc::new(
-                Miniscript::from_ast(miniscript::decode::Terminal::PkK(pk))
+                Miniscript::from_ast(miniscript::decode::Terminal::PkK(KeyExpr::SingleKey(pk)))
                     .expect("Type check cannot fail"),
             )))
             .expect("Type check cannot fail");

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -593,6 +593,9 @@ where
                 Terminal::PkK(ref pk) => {
                     debug_assert_eq!(node_state.n_evaluated, 0);
                     debug_assert_eq!(node_state.n_satisfied, 0);
+                    let pk = pk
+                        .single_key()
+                        .expect("Musig keys cannot be parsed from Script");
                     let res = self.stack.evaluate_pk(&mut self.verify_sig, *pk);
                     if res.is_some() {
                         return res;
@@ -868,10 +871,11 @@ where
                         // evaluate each key with as a pk
                         // note that evaluate_pk will error on non-empty incorrect sigs
                         // push 1 on satisfied sigs and push 0 on empty sigs
-                        match self
-                            .stack
-                            .evaluate_pk(&mut self.verify_sig, subs[node_state.n_evaluated])
-                        {
+                        let pkk = subs[node_state.n_evaluated]
+                            .single_key()
+                            .expect("Musig keys cannot be parsed from Script");
+                        let res = self.stack.evaluate_pk(&mut self.verify_sig, *pkk);
+                        match res {
                             Some(Ok(x)) => {
                                 self.push_evaluation_state(
                                     node_state.node,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,9 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 extern crate hashbrown;
 
+#[cfg(feature = "std")]
+extern crate secp256k1_zkp;
+
 #[cfg(any(feature = "std", test))]
 extern crate core;
 
@@ -775,6 +778,8 @@ pub enum Error {
     TrNoScriptCode,
     /// No explicit script for Tr descriptors
     TrNoExplicitScript,
+    /// Parsing error for single key
+    SingleKeyParseError,
 }
 
 // https://github.com/sipa/miniscript/pull/5 for discussion on this number
@@ -848,6 +853,7 @@ impl fmt::Display for Error {
             Error::TaprootSpendInfoUnavialable => write!(f, "Taproot Spend Info not computed."),
             Error::TrNoScriptCode => write!(f, "No script code for Tr descriptors"),
             Error::TrNoExplicitScript => write!(f, "No script code for Tr descriptors"),
+            Error::SingleKeyParseError => f.write_str("not able to parse the single key"),
         }
     }
 }
@@ -888,6 +894,7 @@ impl error::Error for Error {
             | BareDescriptorAddr
             | TaprootSpendInfoUnavialable
             | TrNoScriptCode
+            | SingleKeyParseError
             | TrNoExplicitScript => None,
             Script(e) => Some(e),
             AddrError(e) => Some(e),

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -519,11 +519,10 @@ mod tests {
         let desc = Descriptor::<String>::from_str("tr(X,{pk(musig(X1)),multi_a(1,X2,X3)})");
         assert_eq!(desc.is_ok(), true);
 
-        let desc =
-            Descriptor::<String>::from_str("tr(pk(musig(E)),{pk(A),multi_a(1,B,musig(C,D))})");
+        let desc = Descriptor::<String>::from_str("tr(musig(E),{pk(A),multi_a(1,B,musig(C,D))})");
         assert_eq!(desc.is_ok(), true);
 
-        let desc = Descriptor::<String>::from_str("tr(pk(musig(D)),pk(musig(A,B,musig(C))))");
+        let desc = Descriptor::<String>::from_str("tr(musig(D),pk(musig(A,B,musig(C))))");
         assert_eq!(desc.is_ok(), true);
     }
 

--- a/src/miniscript/musig_key.rs
+++ b/src/miniscript/musig_key.rs
@@ -1,0 +1,269 @@
+//! Support for multi-signature keys
+use core::fmt;
+use core::str::FromStr;
+
+use bitcoin::secp256k1::{Secp256k1, VerifyOnly};
+#[cfg(feature = "std")]
+use secp256k1_zkp::MusigKeyAggCache;
+
+use crate::expression::{FromTree, Tree};
+use crate::prelude::*;
+use crate::{expression, Error, ForEachKey, MiniscriptKey, ToPublicKey, TranslatePk, Translator};
+
+#[derive(Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+/// Enum for representing musig keys in miniscript
+pub enum KeyExpr<Pk: MiniscriptKey> {
+    /// Single-key (e.g pk(a), here 'a' is a single key)
+    SingleKey(Pk),
+
+    /// Collection of keys in used for musig-signature
+    MuSig(Vec<KeyExpr<Pk>>),
+}
+
+impl<Pk: MiniscriptKey + FromStr> FromTree for KeyExpr<Pk>
+where
+    <Pk as FromStr>::Err: ToString,
+{
+    fn from_tree(tree: &Tree) -> Result<KeyExpr<Pk>, Error> {
+        if tree.name == "musig" {
+            let key_expr_vec = tree
+                .args
+                .iter()
+                .map(|subtree| KeyExpr::<Pk>::from_tree(subtree))
+                .collect::<Result<Vec<KeyExpr<Pk>>, Error>>()?;
+            Ok(KeyExpr::MuSig(key_expr_vec))
+        } else {
+            let single_key = expression::terminal(tree, Pk::from_str)?;
+            Ok(KeyExpr::SingleKey(single_key))
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey + FromStr> FromStr for KeyExpr<Pk>
+where
+    <Pk as FromStr>::Err: ToString,
+{
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (key_tree, _) = Tree::from_slice(s)?;
+        FromTree::from_tree(&key_tree)
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Iterator for [`KeyExpr`]
+pub struct KeyExprIter<'a, Pk: MiniscriptKey> {
+    stack: Vec<&'a KeyExpr<Pk>>,
+}
+
+impl<'a, Pk> Iterator for KeyExprIter<'a, Pk>
+where
+    Pk: MiniscriptKey + 'a,
+{
+    type Item = &'a Pk;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while !self.stack.is_empty() {
+            let last = self.stack.pop().expect("Size checked above");
+            match last {
+                KeyExpr::MuSig(key_vec) => {
+                    // push the elements in reverse order
+                    key_vec.iter().rev().for_each(|key| self.stack.push(key));
+                }
+                KeyExpr::SingleKey(ref pk) => return Some(pk),
+            }
+        }
+        None
+    }
+}
+
+impl<Pk: MiniscriptKey> fmt::Debug for KeyExpr<Pk> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            KeyExpr::SingleKey(ref pk) => write!(f, "{:?}", pk),
+            KeyExpr::MuSig(ref my_vec) => {
+                write!(f, "musig(")?;
+                let len = my_vec.len();
+                for (index, k) in my_vec.iter().enumerate() {
+                    if index == len - 1 {
+                        write!(f, "{:?}", k)?;
+                    } else {
+                        write!(f, "{:?}", k)?;
+                    }
+                }
+                f.write_str(")")
+            }
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey> fmt::Display for KeyExpr<Pk> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            KeyExpr::SingleKey(ref pk) => write!(f, "{}", pk),
+            KeyExpr::MuSig(ref my_vec) => {
+                write!(f, "musig(")?;
+                let len = my_vec.len();
+                for (index, k) in my_vec.iter().enumerate() {
+                    if index == len - 1 {
+                        write!(f, "{}", k)?;
+                    } else {
+                        write!(f, "{},", k)?;
+                    }
+                }
+                f.write_str(")")
+            }
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey> KeyExpr<Pk> {
+    /// Iterate over all keys
+    pub fn iter(&self) -> KeyExprIter<Pk> {
+        KeyExprIter { stack: vec![self] }
+    }
+}
+
+impl<Pk: ToPublicKey> KeyExpr<Pk> {
+    /// Returns an XOnlyPublicKey from a KeyExpr
+    pub fn key_agg(&self) -> bitcoin::XOnlyPublicKey {
+        match self {
+            KeyExpr::<Pk>::SingleKey(pk) => pk.to_x_only_pubkey(),
+            KeyExpr::<Pk>::MuSig(_keys) => {
+                let secp = Secp256k1::verification_only();
+                self.key_agg_helper(&secp)
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    fn key_agg_helper(&self, secp: &Secp256k1<VerifyOnly>) -> bitcoin::XOnlyPublicKey {
+        match self {
+            KeyExpr::<Pk>::SingleKey(pk) => pk.to_x_only_pubkey(),
+            KeyExpr::<Pk>::MuSig(keys) => {
+                let xonly = keys
+                    .iter()
+                    .map(|key| key.key_agg_helper(secp))
+                    .collect::<Vec<_>>();
+                let key_agg_cache = MusigKeyAggCache::new(secp, &xonly);
+                key_agg_cache.agg_pk()
+            }
+        }
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn key_agg_helper(&self, _secp: &Secp256k1<VerifyOnly>) -> bitcoin::XOnlyPublicKey {
+        match self {
+            KeyExpr::<Pk>::SingleKey(pk) => pk.to_x_only_pubkey(),
+            KeyExpr::<Pk>::MuSig(_keys) => {
+                unimplemented!("Musig not supported for no-std");
+            }
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey> ForEachKey<Pk> for KeyExpr<Pk> {
+    fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool
+    where
+        Pk: 'a,
+        Pk::RawPkHash: 'a,
+    {
+        let keys_res = self.iter().all(|key| pred(key));
+        keys_res
+    }
+}
+
+impl<P, Q> TranslatePk<P, Q> for KeyExpr<P>
+where
+    P: MiniscriptKey,
+    Q: MiniscriptKey,
+{
+    type Output = KeyExpr<Q>;
+    fn translate_pk<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
+    where
+        T: Translator<P, Q, E>,
+    {
+        match self {
+            KeyExpr::<P>::SingleKey(pk) => Ok(KeyExpr::SingleKey(t.pk(pk)?)),
+            KeyExpr::<P>::MuSig(vec) => {
+                let mut new_vec: Vec<KeyExpr<Q>> = vec![];
+                for x in vec {
+                    new_vec.push(x.translate_pk(t)?)
+                }
+                Ok(KeyExpr::MuSig(new_vec))
+            }
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey> KeyExpr<Pk> {
+    /// Returns the Pk if KeyExpr is SingleKey, otherwise None
+    pub fn single_key(&self) -> Option<&Pk> {
+        match self {
+            KeyExpr::<Pk>::SingleKey(ref pk) => Some(pk),
+            KeyExpr::<Pk>::MuSig(_) => None,
+        }
+    }
+
+    /// Return vector of bytes, in case of musig, it is first aggregated
+    /// and then converted to bytes
+    pub fn to_vec(&self) -> Vec<u8>
+    where
+        Pk: ToPublicKey,
+    {
+        match self {
+            KeyExpr::<Pk>::SingleKey(ref pk) => pk.to_public_key().to_bytes(),
+            KeyExpr::<Pk>::MuSig(_) => {
+                let agg_key = self.key_agg();
+                agg_key.to_public_key().to_bytes()
+            }
+        }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_one(musig_key: &str) {
+        let pk = KeyExpr::<String>::from_str(musig_key).unwrap();
+        println!("{}", pk);
+        assert_eq!(musig_key, format!("{}", pk))
+    }
+
+    #[test]
+    fn test_from_str_and_fmt() {
+        test_one("musig(A,B,musig(C,musig(D,E)))");
+        test_one("musig(A)");
+        test_one("A");
+        test_one("musig(,,)");
+    }
+
+    #[test]
+    fn test_iterator() {
+        let pk = KeyExpr::<String>::from_str("musig(A,B,musig(C,musig(D,E)))").unwrap();
+        let mut my_iter = pk.iter();
+        assert_eq!(my_iter.next(), Some(&String::from("A")));
+        assert_eq!(my_iter.next(), Some(&String::from("B")));
+        assert_eq!(my_iter.next(), Some(&String::from("C")));
+        assert_eq!(my_iter.next(), Some(&String::from("D")));
+        assert_eq!(my_iter.next(), Some(&String::from("E")));
+        assert_eq!(my_iter.next(), None);
+    }
+
+    fn test_helper(musig_key: &str, comma_separated_key: &str) {
+        let pk = KeyExpr::<String>::from_str(musig_key).unwrap();
+        let var: Vec<&str> = comma_separated_key.split(",").collect();
+        let key_names: Vec<&String> = pk.iter().collect();
+        for (key1, key2) in key_names.iter().zip(var.iter()) {
+            assert_eq!(key1, key2);
+        }
+    }
+
+    #[test]
+    fn test_iterator_multi() {
+        test_helper("musig(A)", "A");
+        test_helper("A", "A");
+        test_helper("musig(,,)", "");
+        test_helper("musig(musig(A,B),musig(musig(C)))", "A,B,C");
+    }
+}

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -911,7 +911,7 @@ impl Property for ExtData {
             Terminal::False => Ok(Self::from_false()),
             Terminal::PkK(..) => Ok(Self::from_pk_k::<Ctx>()),
             Terminal::PkH(..) | Terminal::RawPkH(..) => Ok(Self::from_pk_h::<Ctx>()),
-            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
+            Terminal::Multi(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -924,11 +924,22 @@ impl Property for ExtData {
                         error: ErrorKind::OverThreshold(k, pks.len()),
                     });
                 }
-                match *fragment {
-                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
-                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
-                    _ => unreachable!(),
+                Ok(Self::from_multi(k, pks.len()))
+            }
+            Terminal::MultiA(k, ref pks) => {
+                if k == 0 {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::ZeroThreshold,
+                    });
                 }
+                if k > pks.len() {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::OverThreshold(k, pks.len()),
+                    });
+                }
+                Ok(Self::from_multi_a(k, pks.len()))
             }
             Terminal::After(t) => {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -414,7 +414,7 @@ pub trait Property: Sized {
             Terminal::False => Ok(Self::from_false()),
             Terminal::PkK(..) => Ok(Self::from_pk_k::<Ctx>()),
             Terminal::PkH(..) | Terminal::RawPkH(..) => Ok(Self::from_pk_h::<Ctx>()),
-            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
+            Terminal::Multi(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -427,11 +427,22 @@ pub trait Property: Sized {
                         error: ErrorKind::OverThreshold(k, pks.len()),
                     });
                 }
-                match *fragment {
-                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
-                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
-                    _ => unreachable!(),
+                Ok(Self::from_multi(k, pks.len()))
+            }
+            Terminal::MultiA(k, ref pks) => {
+                if k == 0 {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::ZeroThreshold,
+                    });
                 }
+                if k > pks.len() {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::OverThreshold(k, pks.len()),
+                    });
+                }
+                Ok(Self::from_multi_a(k, pks.len()))
             }
             Terminal::After(t) => {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
@@ -797,7 +808,7 @@ impl Property for Type {
             Terminal::False => Ok(Self::from_false()),
             Terminal::PkK(..) => Ok(Self::from_pk_k::<Ctx>()),
             Terminal::PkH(..) | Terminal::RawPkH(..) => Ok(Self::from_pk_h::<Ctx>()),
-            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
+            Terminal::Multi(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
                         fragment: fragment.clone(),
@@ -810,11 +821,22 @@ impl Property for Type {
                         error: ErrorKind::OverThreshold(k, pks.len()),
                     });
                 }
-                match *fragment {
-                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
-                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
-                    _ => unreachable!(),
+                Ok(Self::from_multi(k, pks.len()))
+            }
+            Terminal::MultiA(k, ref pks) => {
+                if k == 0 {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::ZeroThreshold,
+                    });
                 }
+                if k > pks.len() {
+                    return Err(Error {
+                        fragment: fragment.clone(),
+                        error: ErrorKind::OverThreshold(k, pks.len()),
+                    });
+                }
+                Ok(Self::from_multi_a(k, pks.len()))
             }
             Terminal::After(t) => {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -22,6 +22,7 @@ use std::error;
 #[cfg(feature = "compiler")]
 use {
     crate::descriptor::TapTree,
+    crate::miniscript::musig_key::KeyExpr,
     crate::miniscript::ScriptContext,
     crate::policy::compiler::CompilerError,
     crate::policy::compiler::OrdF64,
@@ -277,7 +278,8 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             _ => {
                 let (internal_key, policy) = self.clone().extract_key(unspendable_key)?;
                 let tree = Descriptor::new_tr(
-                    internal_key,
+                    // Temporary solution, need to decide what we should write in place of singlekey
+                    KeyExpr::SingleKey(internal_key),
                     match policy {
                         Policy::Trivial => None,
                         policy => {

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -256,6 +256,8 @@ mod tests {
 
     use super::super::miniscript::context::{Segwitv0, Tap};
     use super::super::miniscript::Miniscript;
+    #[cfg(feature = "compiler")]
+    use super::KeyExpr;
     use super::{Concrete, Liftable, Semantic};
     use crate::prelude::*;
     use crate::DummyKey;
@@ -448,7 +450,8 @@ mod tests {
             let ms_compilation: Miniscript<String, Tap> = ms_str!("multi_a(2,A,B,C,D)");
             let tree: TapTree<String> = TapTree::Leaf(Arc::new(ms_compilation));
             let expected_descriptor =
-                Descriptor::new_tr(unspendable_key.clone(), Some(tree)).unwrap();
+                Descriptor::new_tr(KeyExpr::SingleKey(unspendable_key.clone()), Some(tree))
+                    .unwrap();
             assert_eq!(descriptor, expected_descriptor);
         }
 
@@ -465,7 +468,8 @@ mod tests {
             let right_node: Arc<TapTree<String>> = Arc::from(TapTree::Leaf(right_ms_compilation));
             let tree: TapTree<String> = TapTree::Tree(left_node, right_node);
             let expected_descriptor =
-                Descriptor::new_tr(unspendable_key.clone(), Some(tree)).unwrap();
+                Descriptor::new_tr(KeyExpr::SingleKey(unspendable_key.clone()), Some(tree))
+                    .unwrap();
             assert_eq!(descriptor, expected_descriptor);
         }
 
@@ -548,7 +552,8 @@ mod tests {
                 )),
             );
 
-            let expected_descriptor = Descriptor::new_tr("E".to_string(), Some(tree)).unwrap();
+            let expected_descriptor =
+                Descriptor::new_tr(KeyExpr::SingleKey("E".to_string()), Some(tree)).unwrap();
             assert_eq!(descriptor, expected_descriptor);
         }
     }

--- a/tests/test_desc.rs
+++ b/tests/test_desc.rs
@@ -156,7 +156,7 @@ pub fn test_desc_satisfy(
 
             let internal_key_present = x_only_pks
                 .iter()
-                .position(|&x| x.to_public_key() == *tr.internal_key());
+                .position(|&x| x.to_public_key() == *tr.internal_key().single_key().unwrap());
             let internal_keypair = internal_key_present.map(|idx| xonly_keypairs[idx].clone());
             let prevouts = [witness_utxo];
             let prevouts = sighash::Prevouts::All(&prevouts);


### PR DESCRIPTION
Replace the `internal-key` of taproot to be a `KeyExpr<Pk>` instead of a simple `Pk`.