### PR TITLE
Disable honggfuzz features

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ afl_fuzz = ["afl"]
 honggfuzz_fuzz = ["honggfuzz"]
 
 [dependencies]
-honggfuzz = { version = "0.5", optional = true }
+honggfuzz = { version = "0.5", default-features = false, optional = true }
 afl = { version = "0.8", optional = true }
 regex = { version = "1.4"}
 miniscript = { path = "..", features = ["compiler"] }

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cargo install --force honggfuzz
+cargo install --force honggfuzz --no-default-features
 for TARGET in fuzz_targets/*; do
     FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"


### PR DESCRIPTION
Looks like fuzzing is broken.

Disable `hongfuzz` default features as we did in `rust-bitcoin`.