### PR TITLE
Pin dependencies when using MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ or in [the `examples/` directory](https://github.com/apoelstra/rust-miniscript/t
 This library should always compile with any combination of features (minus
 `no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
 
+Some dependencies do not play nicely with our MSRV, if you are running the tests
+you may need to pin as follows:
+
+```
+cargo update --package url --precise 2.2.2
+cargo update --package form_urlencoded --precise 1.0.1
+```
+
 ## Contributing
 Contributions are generally welcome. If you intend to make larger changes please
 discuss them in an issue before PRing them to avoid duplicate work and

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -10,6 +10,18 @@ cargo update -p serde_derive --precise 1.0.142
 cargo --version
 rustc --version
 
+# Work out if we are using a nightly toolchain.
+MSRV=false
+if cargo --version | grep "1\.41\.0"; then
+    MSRV=true
+fi
+
+# form_urlencoded 1.1.0 breaks MSRV.
+if [ "$MSRV" = true ]; then
+    cargo update -p url --precise 2.2.2
+    cargo update -p form_urlencoded --precise 1.0.1
+fi
+
 # Format if told to
 if [ "$DO_FMT" = true ]
 then

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -4,12 +4,6 @@ set -e
 
 FEATURES="compiler serde rand"
 
-# Use toolchain if explicitly specified
-if [ -n "$TOOLCHAIN" ]
-then
-    alias cargo="cargo +$TOOLCHAIN"
-fi
-
 cargo update -p serde --precise 1.0.142
 cargo update -p serde_derive --precise 1.0.142
 


### PR DESCRIPTION
A recent release of `form_urlencoded` breaks our test run when using 1.41.1 toolchain.
    
Pin the `url` and `form_urlencoded` dependencies when on 1.41.1 toolchain. Add a section to the readme instructing devs how to pin relevant dependencies (only when running tests).
