### PR TITLE
Add `PsbtOutputExt::update_with_descriptor`

### DIFF
--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1304,7 +1304,7 @@ fn script_code_wpkh(script: &Script) -> Script {
 pub enum UtxoUpdateError {
     /// Index out of bounds
     IndexOutOfBounds(usize, usize),
-    /// The PSBT transaction didn't have an input at that index
+    /// The unsigned transaction didn't have an input at that index
     MissingInputUtxo,
     /// Derivation error
     DerivationError(descriptor::ConversionError),
@@ -1321,7 +1321,9 @@ impl fmt::Display for UtxoUpdateError {
             UtxoUpdateError::IndexOutOfBounds(ind, len) => {
                 write!(f, "index {}, psbt input len: {}", ind, len)
             }
-            UtxoUpdateError::MissingInputUtxo => write!(f, "Missing input utxo in pbst"),
+            UtxoUpdateError::MissingInputUtxo => {
+                write!(f, "Missing input in unsigned transaction")
+            }
             UtxoUpdateError::DerivationError(e) => write!(f, "Key derivation error {}", e),
             UtxoUpdateError::UtxoCheck => write!(
                 f,

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1264,7 +1264,7 @@ fn update_item_with_descriptor_helper<F: PsbtFields>(
             }
         }
 
-        *item.bip32_derivation() = bip32_derivation.0;
+        item.bip32_derivation().append(&mut bip32_derivation.0);
 
         match &derived {
             Descriptor::Bare(_) | Descriptor::Pkh(_) | Descriptor::Wpkh(_) => {}

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1234,6 +1234,14 @@ fn update_item_with_descriptor_helper<F: PsbtFields>(
                 }
             }
 
+            // Ensure there are no duplicated leaf hashes. This can happen if some of them were
+            // already present in the map when this function is called, since this only appends new
+            // data to the psbt without checking what's already present.
+            for (tapleaf_hashes, _) in item.tap_key_origins().values_mut() {
+                tapleaf_hashes.sort();
+                tapleaf_hashes.dedup();
+            }
+
             match item.tap_tree() {
                 // Only set the tap_tree if the item supports it (it's an output) and the descriptor actually
                 // contains one, otherwise it'll just be empty


### PR DESCRIPTION
This essentially mirrors `PsbtInputExt::update_with_descriptor` but it works on PSBT outputs.

To avoid code duplication, the current logic that deals with PSBT inputs has been generalized to handle both input and outputs with a new internal `PsbtFields` trait.

-----

I hope it's not too late to get this PR in the new 8.0 release (cc #462)