### PR TITLE
fuzz: fix `compile_descriptor` to sort lifted policies before comparing

### DIFF
--- a/fuzz/fuzz_targets/compile_descriptor.rs
+++ b/fuzz/fuzz_targets/compile_descriptor.rs
@@ -15,7 +15,7 @@ fn do_test(data: &[u8]) {
         // Compile
         if let Ok(desc) = pol.compile::<Segwitv0>() {
             // Lift
-            assert_eq!(desc.clone().lift().unwrap(), pol.clone().lift().unwrap());
+            assert_eq!(desc.clone().lift().unwrap().sorted(), pol.clone().lift().unwrap().sorted());
             // Try to roundtrip the output of the compiler
             let output = desc.to_string();
             if let Ok(desc) = DummyScript::from_str(&output) {


### PR DESCRIPTION
Fixes #466