### PR TITLE
Fix `pk_len()` for `BareCtx`

### DIFF
--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -739,9 +739,9 @@ impl ScriptContext for BareCtx {
 
     fn pk_len<Pk: MiniscriptKey>(pk: &Pk) -> usize {
         if pk.is_uncompressed() {
-            65
+            66
         } else {
-            33
+            34
         }
     }
 


### PR DESCRIPTION
The `pk_len()` returned should account for the extra byte for the OP_PUSH opcode. This is true for all the other contexts, but not for `BareCtx`, so this commit fixes it.

------

This PR is based on the `7.0.0` tag because in my opinion it's worth applying this and releasing as `7.0.1` without waiting for `8.0.0` (BDK would naturally benefit from this because we are about to make one new release still based on `7.0.0` and it's tricky to workaround this issue in our code).

I think the patch is small enough that it can easily be applied on older releases as well, if you want to backport it too.