### PR TITLE
Fix `max_satisfaction_weight` calculations for taproot.

### DIFF
--- a/examples/taproot.rs
+++ b/examples/taproot.rs
@@ -116,11 +116,11 @@ fn main() {
 
     // Max Satisfaction Weight for compilation, corresponding to the script-path spend
     // `multi_a(2,PUBKEY_1,PUBKEY_2) at taptree depth 1, having
-    // Max Witness Size = scriptSig len + control_block size + varint(script_size) + script_size +
-    //                     varint(max satisfaction elements) + max satisfaction size
-    //                  = 4 + 65 + 1 + 70 + 1 + 132
+    // Max Witness Size = scriptSig len + witnessStack len + varint(control_block_size) +
+    //                    control_block size + varint(script_size) + script_size + max_satisfaction_size
+    //                  = 4 + 1 + 1 + 65 + 1 + 70 + 132 = 274
     let max_sat_wt = real_desc.max_satisfaction_weight().unwrap();
-    assert_eq!(max_sat_wt, 273);
+    assert_eq!(max_sat_wt, 274);
 
     // Compute the bitcoin address and check if it matches
     let network = Network::Bitcoin;


### PR DESCRIPTION
* Key spend path should take into consideration the scriptSigLen, stackLen and itemLen (for the one and only stack item).
* Script spend path should consider `control_block` and `script` to be items on the stack.

I also restructured the function to improve readability.