### PR TITLE
Stack len for legacy `max_satisfaction_weight` calculations

### DIFF
--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -77,7 +77,9 @@ impl<Pk: MiniscriptKey> Bare<Pk> {
     /// When the descriptor is impossible to safisfy (ex: sh(OP_FALSE)).
     pub fn max_satisfaction_weight(&self) -> Result<usize, Error> {
         let scriptsig_len = self.ms.max_satisfaction_size()?;
-        Ok(4 * (varint_len(scriptsig_len) + scriptsig_len))
+        Ok(4 * (varint_len(scriptsig_len) + scriptsig_len) +
+            // witness stack size varint (always 1WU for non-segwit)
+            1)
     }
 }
 
@@ -219,7 +221,9 @@ impl<Pk: MiniscriptKey> Pkh<Pk> {
     /// sighash suffix. Includes the weight of the VarInts encoding the
     /// scriptSig and witness stack length.
     pub fn max_satisfaction_weight(&self) -> usize {
-        4 * (1 + 73 + BareCtx::pk_len(&self.pk))
+        4 * (1 + 73 + BareCtx::pk_len(&self.pk)) +
+        // witness stack size varint (always 1 WU for non-segwit)
+        1
     }
 }
 

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -222,7 +222,9 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
                 let ss = smv.script_size();
                 let ps = push_opcode_size(ss);
                 let scriptsig_len = ps + ss + smv.max_satisfaction_size();
-                4 * (varint_len(scriptsig_len) + scriptsig_len)
+                4 * (varint_len(scriptsig_len) + scriptsig_len) +
+                // witnessData stack length 
+                1
             }
             // add weighted script sig, len byte stays the same
             ShInner::Wpkh(ref wpkh) => 4 * 23 + wpkh.max_satisfaction_weight(),
@@ -230,7 +232,9 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
                 let ss = ms.script_size();
                 let ps = push_opcode_size(ss);
                 let scriptsig_len = ps + ss + ms.max_satisfaction_size()?;
-                4 * (varint_len(scriptsig_len) + scriptsig_len)
+                4 * (varint_len(scriptsig_len) + scriptsig_len) +
+                // witnessData stack length 
+                1
             }
         })
     }


### PR DESCRIPTION
As per the definition of `max_satisfaction_weight`, we should take into consideration the varint that records witness stack size. Even legacy spends may require this field if the tx has at least 1 segwit spend, so we should add it.