### PR TITLE
Another attempt at `max_satisfaction_weight` fixes

### DIFF
--- a/embedded/src/main.rs
+++ b/embedded/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> ! {
     assert!(desc.sanity_check().is_ok());
 
     // Estimate the satisfaction cost
-    assert_eq!(desc.max_satisfaction_weight().unwrap(), 293);
+    assert_eq!(desc.max_weight_to_satisfy().unwrap(), 288);
     // end miniscript test
 
     // exit QEMU

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -33,7 +33,7 @@ fn main() {
     );
     println!(
         "Weight for witness satisfaction cost {}",
-        bridge_descriptor.max_satisfaction_weight().unwrap()
+        bridge_descriptor.max_weight_to_satisfy().unwrap()
     );
 
     let master_private_key_str = "cQhdvB3McbBJdx78VSSumqoHQiSXs75qwLptqwxSQBNBMDxafvaw";

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -30,9 +30,9 @@ fn main() {
     let descriptor = miniscript::Descriptor::<bitcoin::PublicKey>::from_str(&s).unwrap();
 
     // Check weight for witness satisfaction cost ahead of time.
-    // 4 (scriptSig length of 0) + 1 (witness stack size) + 106 (serialized witnessScript)
-    // + 73*2 (signature length + signatures + sighash bytes) + 1 (dummy byte) = 258
-    assert_eq!(descriptor.max_satisfaction_weight().unwrap(), 258);
+    // 106 (serialized witnessScript)
+    // + 73*2 (signature length + signatures + sighash bytes) + 1 (dummy byte) = 253
+    assert_eq!(descriptor.max_weight_to_satisfy().unwrap(), 253);
 
     // Sometimes it is necessary to have additional information to get the
     // `bitcoin::PublicKey` from the `MiniscriptKey` which can be supplied by

--- a/examples/taproot.rs
+++ b/examples/taproot.rs
@@ -100,11 +100,11 @@ fn main() {
 
     // Max Satisfaction Weight for compilation, corresponding to the script-path spend
     // `multi_a(2,PUBKEY_1,PUBKEY_2) at taptree depth 1, having
-    // Max Witness Size = scriptSig len + witnessStack len + varint(control_block_size) +
-    //                    control_block size + varint(script_size) + script_size + max_satisfaction_size
-    //                  = 4 + 1 + 1 + 65 + 1 + 70 + 132 = 274
-    let max_sat_wt = real_desc.max_satisfaction_weight().unwrap();
-    assert_eq!(max_sat_wt, 274);
+    // Max Witness Size = varint(control_block_size) + control_block size +
+    //                    varint(script_size) + script_size + max_satisfaction_size
+    //                  = 1 + 65 + 1 + 70 + 132 = 269
+    let max_sat_wt = real_desc.max_weight_to_satisfy().unwrap();
+    assert_eq!(max_sat_wt, 269);
 
     // Compute the bitcoin address and check if it matches
     let network = Network::Bitcoin;

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -56,6 +56,26 @@ impl<Pk: MiniscriptKey> Bare<Pk> {
         Ok(())
     }
 
+    /// Computes an upper bound on the difference between a non-satisfied
+    /// `TxIn`'s `segwit_weight` and a satisfied `TxIn`'s `segwit_weight`
+    ///
+    /// Since this method uses `segwit_weight` instead of `legacy_weight`,
+    /// if you want to include only legacy inputs in your transaction,
+    /// you should remove 1WU from each input's `max_weight_to_satisfy`
+    /// for a more accurate estimate.
+    ///
+    /// Assumes all ECDSA signatures are 73 bytes, including push opcode and
+    /// sighash suffix.
+    ///
+    /// # Errors
+    /// When the descriptor is impossible to safisfy (ex: sh(OP_FALSE)).
+    pub fn max_weight_to_satisfy(&self) -> Result<usize, Error> {
+        let scriptsig_size = self.ms.max_satisfaction_size()?;
+        // scriptSig varint difference between non-satisfied (0) and satisfied
+        let scriptsig_varint_diff = varint_len(scriptsig_size) - varint_len(0);
+        Ok(4 * (scriptsig_varint_diff + scriptsig_size))
+    }
+
     /// Computes an upper bound on the weight of a satisfying witness to the
     /// transaction.
     ///
@@ -65,6 +85,7 @@ impl<Pk: MiniscriptKey> Bare<Pk> {
     ///
     /// # Errors
     /// When the descriptor is impossible to safisfy (ex: sh(OP_FALSE)).
+    #[deprecated(note = "use max_weight_to_satisfy instead")]
     pub fn max_satisfaction_weight(&self) -> Result<usize, Error> {
         let scriptsig_len = self.ms.max_satisfaction_size()?;
         Ok(4 * (varint_len(scriptsig_len) + scriptsig_len))
@@ -200,6 +221,27 @@ impl<Pk: MiniscriptKey> Pkh<Pk> {
     /// Get the inner key
     pub fn into_inner(self) -> Pk {
         self.pk
+    }
+
+    /// Computes an upper bound on the difference between a non-satisfied
+    /// `TxIn`'s `segwit_weight` and a satisfied `TxIn`'s `segwit_weight`
+    ///
+    /// Since this method uses `segwit_weight` instead of `legacy_weight`,
+    /// if you want to include only legacy inputs in your transaction,
+    /// you should remove 1WU from each input's `max_weight_to_satisfy`
+    /// for a more accurate estimate.
+    ///
+    /// Assumes all ECDSA signatures are 73 bytes, including push opcode and
+    /// sighash suffix.
+    ///
+    /// # Errors
+    /// When the descriptor is impossible to safisfy (ex: sh(OP_FALSE)).
+    pub fn max_weight_to_satisfy(&self) -> usize {
+        // OP_72 + <sig(71)+sigHash(1)> + OP_33 + <pubkey>
+        let scriptsig_size = 73 + BareCtx::pk_len(&self.pk);
+        // scriptSig varint different between non-satisfied (0) and satisfied
+        let scriptsig_varint_diff = varint_len(scriptsig_size) - varint_len(0);
+        4 * (scriptsig_varint_diff + scriptsig_size)
     }
 
     /// Computes an upper bound on the weight of a satisfying witness to the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,14 @@
 //! assert!(desc.sanity_check().is_ok());
 //!
 //! // Estimate the satisfaction cost.
-//! assert_eq!(desc.max_satisfaction_weight().unwrap(), 293);
+//! // scriptSig: OP_PUSH34 <OP_0 OP_32 <32-byte-hash>>
+//! // = (1 + 1 + 1 + 32) * 4 = 140 WU
+//! // redeemScript: varint <OP_33 <pk1> OP_CHECKSIG OP_IFDUP OP_NOTIF OP_33 <pk2> OP_CHECKSIG OP_ENDIF>
+//! // = 1 + (1 + 33 + 1 + 1 + 1 + 1 + 33 + 1 + 1) = 74 WU
+//! // stackItem[Sig]: varint <sig+sighash>
+//! // = 1 + 73 = 74 WU
+//! // Expected satisfaction weight: 140 + 74 + 74 = 288
+//! assert_eq!(desc.max_weight_to_satisfy().unwrap(), 288);
 //! ```
 //!
 


### PR DESCRIPTION
Replaces #474, refer to https://github.com/rust-bitcoin/rust-miniscript/pull/474#issuecomment-1272475306

This PR has two intentions:

1. Redefine `max_satisfaction_weight` to be the difference in `TxIn` weight between "satisfied" and "unsatisfied" states. In an "unsatisfied" state, we still need to include the `scriptSigLen` varint, as well as the `witnessStackLen` (for txs with at least one segwit spend).
2. Attempt further fixes to improve accuracy of `max_satisfaction_weight`.

Comments, tests and examples have been updated to reflect the above intentions.

### Notes for reviewers

The new definition of `max_satisfaction_weight` can be seen in this comment:
https://github.com/rust-bitcoin/rust-miniscript/blob/08cff39fa862ff957c7ff96d17a0011dd6446f87/src/descriptor/mod.rs#L320-L339