### PR TITLE
Add the "planning" module

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -22,7 +22,8 @@ use sync::Arc;
 
 use self::checksum::verify_checksum;
 use crate::miniscript::decode::Terminal;
-use crate::miniscript::{Legacy, Miniscript, Segwitv0};
+use crate::miniscript::{satisfy, Legacy, Miniscript, Segwitv0};
+use crate::plan::{AssetProvider, Plan};
 use crate::prelude::*;
 use crate::{
     expression, hash256, BareCtx, Error, ForEachKey, MiniscriptKey, Satisfier, ToPublicKey,
@@ -474,7 +475,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
             Descriptor::Wpkh(ref wpkh) => wpkh.get_satisfaction(satisfier),
             Descriptor::Wsh(ref wsh) => wsh.get_satisfaction(satisfier),
             Descriptor::Sh(ref sh) => sh.get_satisfaction(satisfier),
-            Descriptor::Tr(ref tr) => tr.get_satisfaction(satisfier),
+            Descriptor::Tr(ref tr) => tr.get_satisfaction(&satisfier),
         }
     }
 
@@ -491,7 +492,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
             Descriptor::Wpkh(ref wpkh) => wpkh.get_satisfaction_mall(satisfier),
             Descriptor::Wsh(ref wsh) => wsh.get_satisfaction_mall(satisfier),
             Descriptor::Sh(ref sh) => sh.get_satisfaction_mall(satisfier),
-            Descriptor::Tr(ref tr) => tr.get_satisfaction_mall(satisfier),
+            Descriptor::Tr(ref tr) => tr.get_satisfaction_mall(&satisfier),
         }
     }
 
@@ -506,6 +507,64 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
         txin.witness = Witness::from_slice(&witness);
         txin.script_sig = script_sig;
         Ok(())
+    }
+}
+
+impl Descriptor<DefiniteDescriptorKey> {
+    /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
+    ///
+    /// If the assets aren't sufficient for generating a Plan, the descriptor is returned
+    pub fn plan<P>(self, provider: &P) -> Result<Plan, Self>
+    where
+        P: AssetProvider<DefiniteDescriptorKey>,
+    {
+        let satisfaction = match self {
+            Descriptor::Bare(ref bare) => bare.plan_satisfaction(provider),
+            Descriptor::Pkh(ref pkh) => pkh.plan_satisfaction(provider),
+            Descriptor::Wpkh(ref wpkh) => wpkh.plan_satisfaction(provider),
+            Descriptor::Wsh(ref wsh) => wsh.plan_satisfaction(provider),
+            Descriptor::Sh(ref sh) => sh.plan_satisfaction(provider),
+            Descriptor::Tr(ref tr) => tr.plan_satisfaction(provider),
+        };
+
+        if let satisfy::Witness::Stack(stack) = satisfaction.stack {
+            Ok(Plan {
+                descriptor: self,
+                template: stack,
+                absolute_timelock: satisfaction.absolute_timelock.map(Into::into),
+                relative_timelock: satisfaction.relative_timelock,
+            })
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
+    ///
+    /// If the assets aren't sufficient for generating a Plan, the descriptor is returned
+    pub fn plan_mall<P>(self, provider: &P) -> Result<Plan, Self>
+    where
+        P: AssetProvider<DefiniteDescriptorKey>,
+    {
+        let satisfaction = match self {
+            Descriptor::Bare(ref bare) => bare.plan_satisfaction_mall(provider),
+            Descriptor::Pkh(ref pkh) => pkh.plan_satisfaction_mall(provider),
+            Descriptor::Wpkh(ref wpkh) => wpkh.plan_satisfaction_mall(provider),
+            Descriptor::Wsh(ref wsh) => wsh.plan_satisfaction_mall(provider),
+            Descriptor::Sh(ref sh) => sh.plan_satisfaction_mall(provider),
+            Descriptor::Tr(ref tr) => tr.plan_satisfaction_mall(provider),
+        };
+
+        if let satisfy::Witness::Stack(stack) = satisfaction.stack {
+            Ok(Plan {
+                descriptor: self,
+                template: stack,
+                absolute_timelock: satisfaction.absolute_timelock.map(Into::into),
+                relative_timelock: satisfaction.relative_timelock,
+            })
+        } else {
+            Err(self)
+        }
     }
 }
 

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -15,8 +15,11 @@ use bitcoin::{script, Address, Network, ScriptBuf};
 
 use super::checksum::{self, verify_checksum};
 use super::{SortedMultiVec, Wpkh, Wsh};
+use crate::descriptor::DefiniteDescriptorKey;
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::ScriptContext;
+use crate::miniscript::satisfy::{Placeholder, Satisfaction};
+use crate::plan::AssetProvider;
 use crate::policy::{semantic, Liftable};
 use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
@@ -414,6 +417,39 @@ impl<Pk: MiniscriptKey + ToPublicKey> Sh<Pk> {
                 Ok((witness, script_sig))
             }
             _ => self.get_satisfaction(satisfier),
+        }
+    }
+}
+
+impl Sh<DefiniteDescriptorKey> {
+    /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
+    pub fn plan_satisfaction<P>(
+        &self,
+        provider: &P,
+    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    where
+        P: AssetProvider<DefiniteDescriptorKey>,
+    {
+        match &self.inner {
+            ShInner::Wsh(ref wsh) => wsh.plan_satisfaction(provider),
+            ShInner::Wpkh(ref wpkh) => wpkh.plan_satisfaction(provider),
+            ShInner::SortedMulti(ref smv) => smv.build_template(provider),
+            ShInner::Ms(ref ms) => ms.build_template(provider),
+        }
+    }
+
+    /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
+    pub fn plan_satisfaction_mall<P>(
+        &self,
+        provider: &P,
+    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    where
+        P: AssetProvider<DefiniteDescriptorKey>,
+    {
+        match &self.inner {
+            ShInner::Wsh(ref wsh) => wsh.plan_satisfaction_mall(provider),
+            ShInner::Ms(ref ms) => ms.build_template_mall(provider),
+            _ => self.plan_satisfaction(provider),
         }
     }
 }

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -14,6 +14,8 @@ use bitcoin::script;
 use crate::miniscript::context::ScriptContext;
 use crate::miniscript::decode::Terminal;
 use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
+use crate::miniscript::satisfy::{Placeholder, Satisfaction};
+use crate::plan::AssetProvider;
 use crate::prelude::*;
 use crate::{
     errstr, expression, policy, script_num_size, Error, ForEachKey, Miniscript, MiniscriptKey,
@@ -152,6 +154,16 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     {
         let ms = Miniscript::from_ast(self.sorted_node()).expect("Multi node typecheck");
         ms.satisfy(satisfier)
+    }
+
+    /// Attempt to produce a witness template given the assets available
+    pub fn build_template<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
+    where
+        Pk: ToPublicKey,
+        P: AssetProvider<Pk>,
+    {
+        let ms = Miniscript::from_ast(self.sorted_node()).expect("Multi node typecheck");
+        ms.build_template(provider)
     }
 
     /// Size, in bytes of the script-pubkey. If this Miniscript is used outside

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub mod expression;
 pub mod interpreter;
 pub mod iter;
 pub mod miniscript;
+pub mod plan;
 pub mod policy;
 pub mod psbt;
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1230,8 +1230,11 @@ mod tests {
 
         let schnorr_sig = secp256k1::schnorr::Signature::from_str("84526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f0784526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f07").unwrap();
         let s = SimpleSatisfier(schnorr_sig);
+        let template = tap_ms.build_template(&s);
+        assert_eq!(template.absolute_timelock, None);
+        assert_eq!(template.relative_timelock, None);
 
-        let wit = tap_ms.satisfy(s).unwrap();
+        let wit = tap_ms.satisfy(&s).unwrap();
         assert_eq!(wit, vec![schnorr_sig.as_ref().to_vec(), vec![], vec![]]);
     }
 
@@ -1283,5 +1286,115 @@ mod tests {
         let uncompressed = bitcoin::PublicKey::from_str("0400232a2acfc9b43fa89f1b4f608fde335d330d7114f70ea42bfb4a41db368a3e3be6934a4097dd25728438ef73debb1f2ffdb07fec0f18049df13bdc5285dc5b").unwrap();
         t.pk_map.insert(String::from("A"), uncompressed);
         ms.translate_pk(&mut t).unwrap_err();
+    }
+
+    #[test]
+    fn template_timelocks() {
+        use crate::AbsLockTime;
+        let key_present = bitcoin::PublicKey::from_str(
+            "0327a6ed0e71b451c79327aa9e4a6bb26ffb1c0056abc02c25e783f6096b79bb4f",
+        )
+        .unwrap();
+        let key_missing = bitcoin::PublicKey::from_str(
+            "03e4d788718644a59030b1d234d8bb8fff28314720b9a1a237874b74b089c638da",
+        )
+        .unwrap();
+
+        // ms, absolute_timelock, relative_timelock
+        let test_cases = vec![
+            (
+                format!("t:or_c(pk({}),v:pkh({}))", key_present, key_missing),
+                None,
+                None,
+            ),
+            (
+                format!(
+                    "thresh(2,pk({}),s:pk({}),snl:after(1))",
+                    key_present, key_missing
+                ),
+                Some(AbsLockTime::from_consensus(1)),
+                None,
+            ),
+            (
+                format!(
+                    "or_d(pk({}),and_v(v:pk({}),older(12960)))",
+                    key_present, key_missing
+                ),
+                None,
+                None,
+            ),
+            (
+                format!(
+                    "or_d(pk({}),and_v(v:pk({}),older(12960)))",
+                    key_missing, key_present
+                ),
+                None,
+                Some(bitcoin::Sequence(12960)),
+            ),
+            (
+                format!(
+                    "thresh(3,pk({}),s:pk({}),snl:older(10),snl:after(11))",
+                    key_present, key_missing
+                ),
+                Some(AbsLockTime::from_consensus(11)),
+                Some(bitcoin::Sequence(10)),
+            ),
+            (
+                format!("and_v(v:and_v(v:pk({}),older(10)),older(20))", key_present),
+                None,
+                Some(bitcoin::Sequence(20)),
+            ),
+            (
+                format!(
+                    "andor(pk({}),older(10),and_v(v:pk({}),older(20)))",
+                    key_present, key_missing
+                ),
+                None,
+                Some(bitcoin::Sequence(10)),
+            ),
+        ];
+
+        // Test satisfaction code
+        struct SimpleSatisfier(secp256k1::schnorr::Signature, bitcoin::PublicKey);
+
+        // a simple satisfier that always outputs the same signature
+        impl Satisfier<bitcoin::PublicKey> for SimpleSatisfier {
+            fn lookup_tap_leaf_script_sig(
+                &self,
+                pk: &bitcoin::PublicKey,
+                _h: &TapLeafHash,
+            ) -> Option<bitcoin::taproot::Signature> {
+                if pk == &self.1 {
+                    Some(bitcoin::taproot::Signature {
+                        sig: self.0,
+                        hash_ty: bitcoin::sighash::TapSighashType::Default,
+                    })
+                } else {
+                    None
+                }
+            }
+
+            fn check_older(&self, _: bitcoin::Sequence) -> bool {
+                true
+            }
+
+            fn check_after(&self, _: bitcoin::absolute::LockTime) -> bool {
+                true
+            }
+        }
+
+        let schnorr_sig = secp256k1::schnorr::Signature::from_str("84526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f0784526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f07").unwrap();
+        let s = SimpleSatisfier(schnorr_sig, key_present);
+
+        for (ms_str, absolute_timelock, relative_timelock) in test_cases {
+            let ms = Miniscript::<bitcoin::PublicKey, Tap>::from_str(&ms_str).unwrap();
+            let template = ms.build_template(&s);
+            match template.stack {
+                crate::miniscript::satisfy::Witness::Stack(_) => {}
+                _ => panic!("All testcases should be possible"),
+            }
+            assert_eq!(template.absolute_timelock, absolute_timelock, "{}", ms_str);
+            assert_eq!(template.relative_timelock, relative_timelock, "{}", ms_str);
+        }
     }
 }

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -6,15 +6,16 @@
 //! scriptpubkeys.
 //!
 
-use core::{cmp, i64, mem};
+use core::{cmp, fmt, i64, mem};
 
 use bitcoin::hashes::hash160;
 use bitcoin::key::XOnlyPublicKey;
-use bitcoin::taproot::{ControlBlock, LeafVersion, TapLeafHash};
-use bitcoin::{absolute, Sequence};
+use bitcoin::taproot::{ControlBlock, LeafVersion, TapLeafHash, TapNodeHash};
+use bitcoin::{absolute, ScriptBuf, Sequence};
 use sync::Arc;
 
 use super::context::SigType;
+use crate::plan::AssetProvider;
 use crate::prelude::*;
 use crate::util::witness_size;
 use crate::{AbsLockTime, Miniscript, MiniscriptKey, ScriptContext, Terminal, ToPublicKey};
@@ -105,11 +106,19 @@ pub trait Satisfier<Pk: MiniscriptKey + ToPublicKey> {
     }
 
     /// Assert whether an relative locktime is satisfied
+    ///
+    /// NOTE: If a descriptor mixes time-based and height-based timelocks, the implementation of
+    /// this method MUST only allow timelocks of either unit, but not both. Allowing both could cause
+    /// miniscript to construct an invalid witness.
     fn check_older(&self, _: Sequence) -> bool {
         false
     }
 
     /// Assert whether a absolute locktime is satisfied
+    ///
+    /// NOTE: If a descriptor mixes time-based and height-based timelocks, the implementation of
+    /// this method MUST only allow timelocks of either unit, but not both. Allowing both could cause
+    /// miniscript to construct an invalid witness.
     fn check_after(&self, _: absolute::LockTime) -> bool {
         false
     }
@@ -436,7 +445,6 @@ macro_rules! impl_tuple_satisfier {
                 )*
                 None
             }
-
             fn lookup_raw_pkh_x_only_pk(
                 &self,
                 key_hash: &hash160::Hash,
@@ -534,11 +542,156 @@ impl_tuple_satisfier!(A, B, C, D, E, F);
 impl_tuple_satisfier!(A, B, C, D, E, F, G);
 impl_tuple_satisfier!(A, B, C, D, E, F, G, H);
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Type of schnorr signature to produce
+pub enum SchnorrSigType {
+    /// Key spend signature
+    KeySpend {
+        /// Merkle root to tweak the key, if present
+        merkle_root: Option<TapNodeHash>,
+    },
+    /// Script spend signature
+    ScriptSpend {
+        /// Leaf hash of the script
+        leaf_hash: TapLeafHash,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Placeholder for some data in a [`Plan`]
+///
+/// [`Plan`]: crate::plan::Plan
+pub enum Placeholder<Pk: MiniscriptKey> {
+    /// Public key and its size
+    Pubkey(Pk, usize),
+    /// Public key hash and public key size
+    PubkeyHash(hash160::Hash, usize),
+    /// ECDSA signature given the raw pubkey
+    EcdsaSigPk(Pk),
+    /// ECDSA signature given the pubkey hash
+    EcdsaSigPkHash(hash160::Hash),
+    /// Schnorr signature and its size
+    SchnorrSigPk(Pk, SchnorrSigType, usize),
+    /// Schnorr signature given the pubkey hash, the tapleafhash, and the sig size
+    SchnorrSigPkHash(hash160::Hash, TapLeafHash, usize),
+    /// SHA-256 preimage
+    Sha256Preimage(Pk::Sha256),
+    /// HASH256 preimage
+    Hash256Preimage(Pk::Hash256),
+    /// RIPEMD160 preimage
+    Ripemd160Preimage(Pk::Ripemd160),
+    /// HASH160 preimage
+    Hash160Preimage(Pk::Hash160),
+    /// Hash dissatisfaction (32 bytes of 0x00)
+    HashDissatisfaction,
+    /// OP_1
+    PushOne,
+    /// \<empty item\>
+    PushZero,
+    /// Taproot leaf script
+    TapScript(ScriptBuf),
+    /// Taproot control block
+    TapControlBlock(ControlBlock),
+}
+
+impl<Pk: MiniscriptKey> fmt::Display for Placeholder<Pk> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Placeholder::*;
+        match self {
+            Pubkey(pk, size) => write!(f, "Pubkey(pk: {}, size: {})", pk, size),
+            PubkeyHash(hash, size) => write!(f, "PubkeyHash(hash: {}, size: {})", hash, size),
+            EcdsaSigPk(pk) => write!(f, "EcdsaSigPk(pk: {})", pk),
+            EcdsaSigPkHash(hash) => write!(f, "EcdsaSigPkHash(pkh: {})", hash),
+            SchnorrSigPk(pk, tap_leaf_hash, size) => write!(
+                f,
+                "SchnorrSig(pk: {}, tap_leaf_hash: {:?}, size: {})",
+                pk, tap_leaf_hash, size
+            ),
+            SchnorrSigPkHash(pkh, tap_leaf_hash, size) => write!(
+                f,
+                "SchnorrSigPkHash(pkh: {}, tap_leaf_hash: {:?}, size: {})",
+                pkh, tap_leaf_hash, size
+            ),
+            Sha256Preimage(hash) => write!(f, "Sha256Preimage(hash: {})", hash),
+            Hash256Preimage(hash) => write!(f, "Hash256Preimage(hash: {})", hash),
+            Ripemd160Preimage(hash) => write!(f, "Ripemd160Preimage(hash: {})", hash),
+            Hash160Preimage(hash) => write!(f, "Hash160Preimage(hash: {})", hash),
+            HashDissatisfaction => write!(f, "HashDissatisfaction"),
+            PushOne => write!(f, "PushOne"),
+            PushZero => write!(f, "PushZero"),
+            TapScript(script) => write!(f, "TapScript(script: {})", script),
+            TapControlBlock(control_block) => write!(
+                f,
+                "TapControlBlock(control_block: {})",
+                bitcoin::consensus::encode::serialize_hex(&control_block.serialize())
+            ),
+        }
+    }
+}
+
+impl<Pk: MiniscriptKey + ToPublicKey> Placeholder<Pk> {
+    /// Replaces the placeholders with the information given by the satisfier
+    pub fn satisfy_self<Sat: Satisfier<Pk>>(&self, sat: &Sat) -> Option<Vec<u8>> {
+        match self {
+            Placeholder::Pubkey(pk, size) => {
+                if *size == 33 {
+                    Some(pk.to_x_only_pubkey().serialize().to_vec())
+                } else {
+                    Some(pk.to_public_key().to_bytes())
+                }
+            }
+            Placeholder::PubkeyHash(pkh, size) => sat
+                .lookup_raw_pkh_pk(pkh)
+                .map(|p| p.to_public_key())
+                .or(sat.lookup_raw_pkh_ecdsa_sig(pkh).map(|(p, _)| p))
+                .map(|pk| {
+                    let pk = pk.to_bytes();
+                    // We have to add a 1-byte OP_PUSH
+                    debug_assert!(1 + pk.len() == *size);
+                    pk
+                }),
+            Placeholder::Hash256Preimage(h) => sat.lookup_hash256(h).map(|p| p.to_vec()),
+            Placeholder::Sha256Preimage(h) => sat.lookup_sha256(h).map(|p| p.to_vec()),
+            Placeholder::Hash160Preimage(h) => sat.lookup_hash160(h).map(|p| p.to_vec()),
+            Placeholder::Ripemd160Preimage(h) => sat.lookup_ripemd160(h).map(|p| p.to_vec()),
+            Placeholder::EcdsaSigPk(pk) => sat.lookup_ecdsa_sig(pk).map(|s| s.to_vec()),
+            Placeholder::EcdsaSigPkHash(pkh) => {
+                sat.lookup_raw_pkh_ecdsa_sig(pkh).map(|(_, s)| s.to_vec())
+            }
+            Placeholder::SchnorrSigPk(pk, SchnorrSigType::ScriptSpend { leaf_hash }, size) => sat
+                .lookup_tap_leaf_script_sig(pk, leaf_hash)
+                .map(|s| s.to_vec())
+                .map(|s| {
+                    debug_assert!(s.len() == *size);
+                    s
+                }),
+            Placeholder::SchnorrSigPk(_, _, size) => {
+                sat.lookup_tap_key_spend_sig().map(|s| s.to_vec()).map(|s| {
+                    debug_assert!(s.len() == *size);
+                    s
+                })
+            }
+            Placeholder::SchnorrSigPkHash(pkh, tap_leaf_hash, size) => sat
+                .lookup_raw_pkh_tap_leaf_script_sig(&(*pkh, *tap_leaf_hash))
+                .map(|(_, s)| {
+                    let sig = s.to_vec();
+                    debug_assert!(sig.len() == *size);
+                    sig
+                }),
+            Placeholder::HashDissatisfaction => Some(vec![0; 32]),
+            Placeholder::PushZero => Some(vec![]),
+            Placeholder::PushOne => Some(vec![1]),
+            Placeholder::TapScript(s) => Some(s.to_bytes()),
+            Placeholder::TapControlBlock(cb) => Some(cb.serialize()),
+        }
+    }
+}
+
 /// A witness, if available, for a Miniscript fragment
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub enum Witness {
+pub enum Witness<T> {
     /// Witness Available and the value of the witness
-    Stack(Vec<Vec<u8>>),
+    Stack(Vec<T>),
     /// Third party can possibly satisfy the fragment but we cannot
     /// Witness Unavailable
     Unavailable,
@@ -547,13 +700,13 @@ pub enum Witness {
     Impossible,
 }
 
-impl PartialOrd for Witness {
+impl<Pk: MiniscriptKey> PartialOrd for Witness<Placeholder<Pk>> {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for Witness {
+impl<Pk: MiniscriptKey> Ord for Witness<Placeholder<Pk>> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         match (self, other) {
             (Witness::Stack(v1), Witness::Stack(v2)) => {
@@ -571,111 +724,128 @@ impl Ord for Witness {
     }
 }
 
-impl Witness {
+impl<Pk: MiniscriptKey + ToPublicKey> Witness<Placeholder<Pk>> {
     /// Turn a signature into (part of) a satisfaction
-    fn signature<Pk: ToPublicKey, S: Satisfier<Pk>, Ctx: ScriptContext>(
-        sat: S,
+    fn signature<S: AssetProvider<Pk>, Ctx: ScriptContext>(
+        sat: &S,
         pk: &Pk,
         leaf_hash: &TapLeafHash,
     ) -> Self {
         match Ctx::sig_type() {
-            super::context::SigType::Ecdsa => match sat.lookup_ecdsa_sig(pk) {
-                Some(sig) => Witness::Stack(vec![sig.to_vec()]),
-                // Signatures cannot be forged
-                None => Witness::Impossible,
-            },
-            super::context::SigType::Schnorr => match sat.lookup_tap_leaf_script_sig(pk, leaf_hash)
-            {
-                Some(sig) => Witness::Stack(vec![sig.to_vec()]),
-                // Signatures cannot be forged
-                None => Witness::Impossible,
-            },
+            super::context::SigType::Ecdsa => {
+                if sat.provider_lookup_ecdsa_sig(pk) {
+                    Witness::Stack(vec![Placeholder::EcdsaSigPk(pk.clone())])
+                } else {
+                    // Signatures cannot be forged
+                    Witness::Impossible
+                }
+            }
+            super::context::SigType::Schnorr => {
+                match sat.provider_lookup_tap_leaf_script_sig(pk, leaf_hash) {
+                    Some(size) => Witness::Stack(vec![Placeholder::SchnorrSigPk(
+                        pk.clone(),
+                        SchnorrSigType::ScriptSpend {
+                            leaf_hash: *leaf_hash,
+                        },
+                        size,
+                    )]),
+                    // Signatures cannot be forged
+                    None => Witness::Impossible,
+                }
+            }
         }
     }
 
     /// Turn a public key related to a pkh into (part of) a satisfaction
-    fn pkh_public_key<Pk: ToPublicKey, S: Satisfier<Pk>, Ctx: ScriptContext>(
-        sat: S,
+    fn pkh_public_key<S: AssetProvider<Pk>, Ctx: ScriptContext>(
+        sat: &S,
         pkh: &hash160::Hash,
     ) -> Self {
         // public key hashes are assumed to be unavailable
         // instead of impossible since it is the same as pub-key hashes
         match Ctx::sig_type() {
-            SigType::Ecdsa => match sat.lookup_raw_pkh_pk(pkh) {
-                Some(pk) => Witness::Stack(vec![pk.to_bytes()]),
+            SigType::Ecdsa => match sat.provider_lookup_raw_pkh_pk(pkh) {
+                Some(pk) => Witness::Stack(vec![Placeholder::PubkeyHash(*pkh, Ctx::pk_len(&pk))]),
                 None => Witness::Unavailable,
             },
-            SigType::Schnorr => match sat.lookup_raw_pkh_x_only_pk(pkh) {
-                Some(pk) => Witness::Stack(vec![pk.serialize().to_vec()]),
+            SigType::Schnorr => match sat.provider_lookup_raw_pkh_x_only_pk(pkh) {
+                Some(pk) => Witness::Stack(vec![Placeholder::PubkeyHash(*pkh, Ctx::pk_len(&pk))]),
                 None => Witness::Unavailable,
             },
         }
     }
 
     /// Turn a key/signature pair related to a pkh into (part of) a satisfaction
-    fn pkh_signature<Pk: ToPublicKey, S: Satisfier<Pk>, Ctx: ScriptContext>(
-        sat: S,
+    fn pkh_signature<S: AssetProvider<Pk>, Ctx: ScriptContext>(
+        sat: &S,
         pkh: &hash160::Hash,
         leaf_hash: &TapLeafHash,
     ) -> Self {
         match Ctx::sig_type() {
-            SigType::Ecdsa => match sat.lookup_raw_pkh_ecdsa_sig(pkh) {
-                Some((pk, sig)) => {
-                    Witness::Stack(vec![sig.to_vec(), pk.to_public_key().to_bytes()])
-                }
-                None => Witness::Impossible,
-            },
-            SigType::Schnorr => match sat.lookup_raw_pkh_tap_leaf_script_sig(&(*pkh, *leaf_hash)) {
-                Some((pk, sig)) => Witness::Stack(vec![
-                    sig.to_vec(),
-                    pk.to_x_only_pubkey().serialize().to_vec(),
+            SigType::Ecdsa => match sat.provider_lookup_raw_pkh_ecdsa_sig(pkh) {
+                Some(pk) => Witness::Stack(vec![
+                    Placeholder::EcdsaSigPkHash(*pkh),
+                    Placeholder::PubkeyHash(*pkh, Ctx::pk_len(&pk)),
                 ]),
                 None => Witness::Impossible,
             },
+            SigType::Schnorr => {
+                match sat.provider_lookup_raw_pkh_tap_leaf_script_sig(&(*pkh, *leaf_hash)) {
+                    Some((pk, size)) => Witness::Stack(vec![
+                        Placeholder::SchnorrSigPkHash(*pkh, *leaf_hash, size),
+                        Placeholder::PubkeyHash(*pkh, Ctx::pk_len(&pk)),
+                    ]),
+                    None => Witness::Impossible,
+                }
+            }
         }
     }
 
     /// Turn a hash preimage into (part of) a satisfaction
-    fn ripemd160_preimage<Pk: ToPublicKey, S: Satisfier<Pk>>(sat: S, h: &Pk::Ripemd160) -> Self {
-        match sat.lookup_ripemd160(h) {
-            Some(pre) => Witness::Stack(vec![pre.to_vec()]),
-            // Note hash preimages are unavailable instead of impossible
-            None => Witness::Unavailable,
+    fn ripemd160_preimage<S: AssetProvider<Pk>>(sat: &S, h: &Pk::Ripemd160) -> Self {
+        if sat.provider_lookup_ripemd160(h) {
+            Witness::Stack(vec![Placeholder::Ripemd160Preimage(h.clone())])
+        // Note hash preimages are unavailable instead of impossible
+        } else {
+            Witness::Unavailable
         }
     }
 
     /// Turn a hash preimage into (part of) a satisfaction
-    fn hash160_preimage<Pk: ToPublicKey, S: Satisfier<Pk>>(sat: S, h: &Pk::Hash160) -> Self {
-        match sat.lookup_hash160(h) {
-            Some(pre) => Witness::Stack(vec![pre.to_vec()]),
-            // Note hash preimages are unavailable instead of impossible
-            None => Witness::Unavailable,
+    fn hash160_preimage<S: AssetProvider<Pk>>(sat: &S, h: &Pk::Hash160) -> Self {
+        if sat.provider_lookup_hash160(h) {
+            Witness::Stack(vec![Placeholder::Hash160Preimage(h.clone())])
+        // Note hash preimages are unavailable instead of impossible
+        } else {
+            Witness::Unavailable
         }
     }
 
     /// Turn a hash preimage into (part of) a satisfaction
-    fn sha256_preimage<Pk: ToPublicKey, S: Satisfier<Pk>>(sat: S, h: &Pk::Sha256) -> Self {
-        match sat.lookup_sha256(h) {
-            Some(pre) => Witness::Stack(vec![pre.to_vec()]),
-            // Note hash preimages are unavailable instead of impossible
-            None => Witness::Unavailable,
+    fn sha256_preimage<S: AssetProvider<Pk>>(sat: &S, h: &Pk::Sha256) -> Self {
+        if sat.provider_lookup_sha256(h) {
+            Witness::Stack(vec![Placeholder::Sha256Preimage(h.clone())])
+        // Note hash preimages are unavailable instead of impossible
+        } else {
+            Witness::Unavailable
         }
     }
 
     /// Turn a hash preimage into (part of) a satisfaction
-    fn hash256_preimage<Pk: ToPublicKey, S: Satisfier<Pk>>(sat: S, h: &Pk::Hash256) -> Self {
-        match sat.lookup_hash256(h) {
-            Some(pre) => Witness::Stack(vec![pre.to_vec()]),
-            // Note hash preimages are unavailable instead of impossible
-            None => Witness::Unavailable,
+    fn hash256_preimage<S: AssetProvider<Pk>>(sat: &S, h: &Pk::Hash256) -> Self {
+        if sat.provider_lookup_hash256(h) {
+            Witness::Stack(vec![Placeholder::Hash256Preimage(h.clone())])
+        // Note hash preimages are unavailable instead of impossible
+        } else {
+            Witness::Unavailable
         }
     }
 }
 
-impl Witness {
+impl<Pk: MiniscriptKey> Witness<Placeholder<Pk>> {
     /// Produce something like a 32-byte 0 push
     fn hash_dissatisfaction() -> Self {
-        Witness::Stack(vec![vec![0; 32]])
+        Witness::Stack(vec![Placeholder::HashDissatisfaction])
     }
 
     /// Construct a satisfaction equivalent to an empty stack
@@ -685,12 +855,12 @@ impl Witness {
 
     /// Construct a satisfaction equivalent to `OP_1`
     fn push_1() -> Self {
-        Witness::Stack(vec![vec![1]])
+        Witness::Stack(vec![Placeholder::PushOne])
     }
 
     /// Construct a satisfaction equivalent to a single empty push
     fn push_0() -> Self {
-        Witness::Stack(vec![vec![]])
+        Witness::Stack(vec![Placeholder::PushZero])
     }
 
     /// Concatenate, or otherwise combine, two satisfactions
@@ -708,9 +878,9 @@ impl Witness {
 
 /// A (dis)satisfaction of a Miniscript fragment
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Satisfaction {
+pub struct Satisfaction<T> {
     /// The actual witness stack
-    pub stack: Witness,
+    pub stack: Witness<T>,
     /// Whether or not this (dis)satisfaction has a signature somewhere
     /// in it
     pub has_sig: bool,
@@ -722,9 +892,49 @@ pub struct Satisfaction {
     pub relative_timelock: Option<Sequence>,
 }
 
-impl Satisfaction {
+impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
+    pub(crate) fn build_template<P, Ctx>(
+        term: &Terminal<Pk, Ctx>,
+        provider: &P,
+        root_has_sig: bool,
+        leaf_hash: &TapLeafHash,
+    ) -> Self
+    where
+        Ctx: ScriptContext,
+        P: AssetProvider<Pk>,
+    {
+        Self::satisfy_helper(
+            term,
+            provider,
+            root_has_sig,
+            leaf_hash,
+            &mut Satisfaction::minimum,
+            &mut Satisfaction::thresh,
+        )
+    }
+
+    pub(crate) fn build_template_mall<P, Ctx>(
+        term: &Terminal<Pk, Ctx>,
+        provider: &P,
+        root_has_sig: bool,
+        leaf_hash: &TapLeafHash,
+    ) -> Self
+    where
+        Ctx: ScriptContext,
+        P: AssetProvider<Pk>,
+    {
+        Self::satisfy_helper(
+            term,
+            provider,
+            root_has_sig,
+            leaf_hash,
+            &mut Satisfaction::minimum_mall,
+            &mut Satisfaction::thresh_mall,
+        )
+    }
+
     // produce a non-malleable satisafaction for thesh frag
-    fn thresh<Pk, Ctx, Sat, F>(
+    fn thresh<Ctx, Sat, F>(
         k: usize,
         subs: &[Arc<Miniscript<Pk, Ctx>>],
         stfr: &Sat,
@@ -733,10 +943,12 @@ impl Satisfaction {
         min_fn: &mut F,
     ) -> Self
     where
-        Pk: MiniscriptKey + ToPublicKey,
         Ctx: ScriptContext,
-        Sat: Satisfier<Pk>,
-        F: FnMut(Satisfaction, Satisfaction) -> Satisfaction,
+        Sat: AssetProvider<Pk>,
+        F: FnMut(
+            Satisfaction<Placeholder<Pk>>,
+            Satisfaction<Placeholder<Pk>>,
+        ) -> Satisfaction<Placeholder<Pk>>,
     {
         let mut sats = subs
             .iter()
@@ -854,7 +1066,7 @@ impl Satisfaction {
     }
 
     // produce a possily malleable satisafaction for thesh frag
-    fn thresh_mall<Pk, Ctx, Sat, F>(
+    fn thresh_mall<Ctx, Sat, F>(
         k: usize,
         subs: &[Arc<Miniscript<Pk, Ctx>>],
         stfr: &Sat,
@@ -863,10 +1075,12 @@ impl Satisfaction {
         min_fn: &mut F,
     ) -> Self
     where
-        Pk: MiniscriptKey + ToPublicKey,
         Ctx: ScriptContext,
-        Sat: Satisfier<Pk>,
-        F: FnMut(Satisfaction, Satisfaction) -> Satisfaction,
+        Sat: AssetProvider<Pk>,
+        F: FnMut(
+            Satisfaction<Placeholder<Pk>>,
+            Satisfaction<Placeholder<Pk>>,
+        ) -> Satisfaction<Placeholder<Pk>>,
     {
         let mut sats = subs
             .iter()
@@ -1011,7 +1225,7 @@ impl Satisfaction {
     }
 
     // produce a non-malleable satisfaction
-    fn satisfy_helper<Pk, Ctx, Sat, F, G>(
+    fn satisfy_helper<Ctx, Sat, F, G>(
         term: &Terminal<Pk, Ctx>,
         stfr: &Sat,
         root_has_sig: bool,
@@ -1020,10 +1234,12 @@ impl Satisfaction {
         thresh_fn: &mut G,
     ) -> Self
     where
-        Pk: MiniscriptKey + ToPublicKey,
         Ctx: ScriptContext,
-        Sat: Satisfier<Pk>,
-        F: FnMut(Satisfaction, Satisfaction) -> Satisfaction,
+        Sat: AssetProvider<Pk>,
+        F: FnMut(
+            Satisfaction<Placeholder<Pk>>,
+            Satisfaction<Placeholder<Pk>>,
+        ) -> Satisfaction<Placeholder<Pk>>,
         G: FnMut(
             usize,
             &[Arc<Miniscript<Pk, Ctx>>],
@@ -1031,30 +1247,29 @@ impl Satisfaction {
             bool,
             &TapLeafHash,
             &mut F,
-        ) -> Satisfaction,
+        ) -> Satisfaction<Placeholder<Pk>>,
     {
         match *term {
             Terminal::PkK(ref pk) => Satisfaction {
-                stack: Witness::signature::<_, _, Ctx>(stfr, pk, leaf_hash),
+                stack: Witness::signature::<_, Ctx>(stfr, pk, leaf_hash),
                 has_sig: true,
                 relative_timelock: None,
                 absolute_timelock: None,
             },
             Terminal::PkH(ref pk) => {
-                let wit = Witness::signature::<_, _, Ctx>(stfr, pk, leaf_hash);
-                let pk_bytes = match Ctx::sig_type() {
-                    SigType::Ecdsa => pk.to_public_key().to_bytes(),
-                    SigType::Schnorr => pk.to_x_only_pubkey().serialize().to_vec(),
-                };
+                let wit = Witness::signature::<_, Ctx>(stfr, pk, leaf_hash);
                 Satisfaction {
-                    stack: Witness::combine(wit, Witness::Stack(vec![pk_bytes])),
+                    stack: Witness::combine(
+                        wit,
+                        Witness::Stack(vec![Placeholder::Pubkey(pk.clone(), Ctx::pk_len(pk))]),
+                    ),
                     has_sig: true,
                     relative_timelock: None,
                     absolute_timelock: None,
                 }
             }
             Terminal::RawPkH(ref pkh) => Satisfaction {
-                stack: Witness::pkh_signature::<_, _, Ctx>(stfr, pkh, leaf_hash),
+                stack: Witness::pkh_signature::<_, Ctx>(stfr, pkh, leaf_hash),
                 has_sig: true,
                 relative_timelock: None,
                 absolute_timelock: None,
@@ -1303,7 +1518,7 @@ impl Satisfaction {
                 let mut sig_count = 0;
                 let mut sigs = Vec::with_capacity(k);
                 for pk in keys {
-                    match Witness::signature::<_, _, Ctx>(stfr, pk, leaf_hash) {
+                    match Witness::signature::<_, Ctx>(stfr, pk, leaf_hash) {
                         Witness::Stack(sig) => {
                             sigs.push(sig);
                             sig_count += 1;
@@ -1347,9 +1562,9 @@ impl Satisfaction {
             Terminal::MultiA(k, ref keys) => {
                 // Collect all available signatures
                 let mut sig_count = 0;
-                let mut sigs = vec![vec![vec![]]; keys.len()];
+                let mut sigs = vec![vec![Placeholder::PushZero]; keys.len()];
                 for (i, pk) in keys.iter().rev().enumerate() {
-                    match Witness::signature::<_, _, Ctx>(stfr, pk, leaf_hash) {
+                    match Witness::signature::<_, Ctx>(stfr, pk, leaf_hash) {
                         Witness::Stack(sig) => {
                             sigs[i] = sig;
                             sig_count += 1;
@@ -1390,7 +1605,7 @@ impl Satisfaction {
     }
 
     // Helper function to produce a dissatisfaction
-    fn dissatisfy_helper<Pk, Ctx, Sat, F, G>(
+    fn dissatisfy_helper<Ctx, Sat, F, G>(
         term: &Terminal<Pk, Ctx>,
         stfr: &Sat,
         root_has_sig: bool,
@@ -1399,10 +1614,12 @@ impl Satisfaction {
         thresh_fn: &mut G,
     ) -> Self
     where
-        Pk: MiniscriptKey + ToPublicKey,
         Ctx: ScriptContext,
-        Sat: Satisfier<Pk>,
-        F: FnMut(Satisfaction, Satisfaction) -> Satisfaction,
+        Sat: AssetProvider<Pk>,
+        F: FnMut(
+            Satisfaction<Placeholder<Pk>>,
+            Satisfaction<Placeholder<Pk>>,
+        ) -> Satisfaction<Placeholder<Pk>>,
         G: FnMut(
             usize,
             &[Arc<Miniscript<Pk, Ctx>>],
@@ -1410,7 +1627,7 @@ impl Satisfaction {
             bool,
             &TapLeafHash,
             &mut F,
-        ) -> Satisfaction,
+        ) -> Satisfaction<Placeholder<Pk>>,
     {
         match *term {
             Terminal::PkK(..) => Satisfaction {
@@ -1419,22 +1636,19 @@ impl Satisfaction {
                 relative_timelock: None,
                 absolute_timelock: None,
             },
-            Terminal::PkH(ref pk) => {
-                let pk_bytes = match Ctx::sig_type() {
-                    SigType::Ecdsa => pk.to_public_key().to_bytes(),
-                    SigType::Schnorr => pk.to_x_only_pubkey().serialize().to_vec(),
-                };
-                Satisfaction {
-                    stack: Witness::combine(Witness::push_0(), Witness::Stack(vec![pk_bytes])),
-                    has_sig: false,
-                    relative_timelock: None,
-                    absolute_timelock: None,
-                }
-            }
+            Terminal::PkH(ref pk) => Satisfaction {
+                stack: Witness::combine(
+                    Witness::push_0(),
+                    Witness::Stack(vec![Placeholder::Pubkey(pk.clone(), Ctx::pk_len(pk))]),
+                ),
+                has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
+            },
             Terminal::RawPkH(ref pkh) => Satisfaction {
                 stack: Witness::combine(
                     Witness::push_0(),
-                    Witness::pkh_public_key::<_, _, Ctx>(stfr, pkh),
+                    Witness::pkh_public_key::<_, Ctx>(stfr, pkh),
                 ),
                 has_sig: false,
                 relative_timelock: None,
@@ -1574,13 +1788,13 @@ impl Satisfaction {
                 absolute_timelock: None,
             },
             Terminal::Multi(k, _) => Satisfaction {
-                stack: Witness::Stack(vec![vec![]; k + 1]),
+                stack: Witness::Stack(vec![Placeholder::PushZero; k + 1]),
                 has_sig: false,
                 relative_timelock: None,
                 absolute_timelock: None,
             },
             Terminal::MultiA(_, ref pks) => Satisfaction {
-                stack: Witness::Stack(vec![vec![]; pks.len()]),
+                stack: Witness::Stack(vec![Placeholder::PushZero; pks.len()]),
                 has_sig: false,
                 relative_timelock: None,
                 absolute_timelock: None,
@@ -1588,45 +1802,65 @@ impl Satisfaction {
         }
     }
 
+    /// Try creating the final witness using a [`Satisfier`]
+    pub fn try_completing<Sat: Satisfier<Pk>>(&self, stfr: &Sat) -> Option<Satisfaction<Vec<u8>>> {
+        let Satisfaction {
+            stack,
+            has_sig,
+            relative_timelock,
+            absolute_timelock,
+        } = self;
+        let stack = match stack {
+            Witness::Stack(stack) => Witness::Stack(
+                stack
+                    .iter()
+                    .map(|placeholder| placeholder.satisfy_self(stfr))
+                    .collect::<Option<_>>()?,
+            ),
+            Witness::Unavailable => Witness::Unavailable,
+            Witness::Impossible => Witness::Impossible,
+        };
+        Some(Satisfaction {
+            stack,
+            has_sig: *has_sig,
+            relative_timelock: *relative_timelock,
+            absolute_timelock: *absolute_timelock,
+        })
+    }
+}
+
+impl Satisfaction<Vec<u8>> {
     /// Produce a satisfaction non-malleable satisfaction
-    pub(super) fn satisfy<
-        Pk: MiniscriptKey + ToPublicKey,
-        Ctx: ScriptContext,
-        Sat: Satisfier<Pk>,
-    >(
+    pub(super) fn satisfy<Ctx, Pk, Sat>(
         term: &Terminal<Pk, Ctx>,
         stfr: &Sat,
         root_has_sig: bool,
         leaf_hash: &TapLeafHash,
-    ) -> Self {
-        Self::satisfy_helper(
-            term,
-            stfr,
-            root_has_sig,
-            leaf_hash,
-            &mut Satisfaction::minimum,
-            &mut Satisfaction::thresh,
-        )
+    ) -> Self
+    where
+        Ctx: ScriptContext,
+        Pk: MiniscriptKey + ToPublicKey,
+        Sat: Satisfier<Pk>,
+    {
+        Satisfaction::<Placeholder<Pk>>::build_template(term, &stfr, root_has_sig, leaf_hash)
+            .try_completing(stfr)
+            .expect("the same satisfier should manage to complete the template")
     }
 
     /// Produce a satisfaction(possibly malleable)
-    pub(super) fn satisfy_mall<
-        Pk: MiniscriptKey + ToPublicKey,
-        Ctx: ScriptContext,
-        Sat: Satisfier<Pk>,
-    >(
+    pub(super) fn satisfy_mall<Ctx, Pk, Sat>(
         term: &Terminal<Pk, Ctx>,
         stfr: &Sat,
         root_has_sig: bool,
         leaf_hash: &TapLeafHash,
-    ) -> Self {
-        Self::satisfy_helper(
-            term,
-            stfr,
-            root_has_sig,
-            leaf_hash,
-            &mut Satisfaction::minimum_mall,
-            &mut Satisfaction::thresh_mall,
-        )
+    ) -> Self
+    where
+        Ctx: ScriptContext,
+        Pk: MiniscriptKey + ToPublicKey,
+        Sat: Satisfier<Pk>,
+    {
+        Satisfaction::<Placeholder<Pk>>::build_template_mall(term, &stfr, root_has_sig, leaf_hash)
+            .try_completing(stfr)
+            .expect("the same satisfier should manage to complete the template")
     }
 }

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -17,7 +17,7 @@ use sync::Arc;
 use super::context::SigType;
 use crate::prelude::*;
 use crate::util::witness_size;
-use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal, ToPublicKey};
+use crate::{AbsLockTime, Miniscript, MiniscriptKey, ScriptContext, Terminal, ToPublicKey};
 
 /// Type alias for 32 byte Preimage.
 pub type Preimage32 = [u8; 32];
@@ -714,6 +714,12 @@ pub struct Satisfaction {
     /// Whether or not this (dis)satisfaction has a signature somewhere
     /// in it
     pub has_sig: bool,
+    // We use AbsLockTime here as we need to compare timelocks using Ord. This is safe,
+    // as miniscript checks for us beforehand that the timelocks are of the same type.
+    /// The absolute timelock used by this satisfaction
+    pub absolute_timelock: Option<AbsLockTime>,
+    /// The relative timelock used by this satisfaction
+    pub relative_timelock: Option<Sequence>,
 }
 
 impl Satisfaction {
@@ -796,8 +802,10 @@ impl Satisfaction {
             Satisfaction {
                 stack: Witness::Impossible,
                 // If the witness is impossible, we don't care about the
-                // has_sig flag
+                // has_sig flag, nor about the timelocks
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             }
         }
         // We are now guaranteed that all elements in `k` satisfactions
@@ -823,11 +831,21 @@ impl Satisfaction {
             Satisfaction {
                 stack: Witness::Unavailable,
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             }
         } else {
             // Otherwise flatten everything out
             Satisfaction {
                 has_sig: ret_stack.iter().any(|sat| sat.has_sig),
+                relative_timelock: ret_stack
+                    .iter()
+                    .filter_map(|sat| sat.relative_timelock)
+                    .max(),
+                absolute_timelock: ret_stack
+                    .iter()
+                    .filter_map(|sat| sat.absolute_timelock)
+                    .max(),
                 stack: ret_stack.into_iter().fold(Witness::empty(), |acc, next| {
                     Witness::combine(next.stack, acc)
                 }),
@@ -903,6 +921,14 @@ impl Satisfaction {
         // no non-malleability checks needed
         Satisfaction {
             has_sig: ret_stack.iter().any(|sat| sat.has_sig),
+            relative_timelock: ret_stack
+                .iter()
+                .filter_map(|sat| sat.relative_timelock)
+                .max(),
+            absolute_timelock: ret_stack
+                .iter()
+                .filter_map(|sat| sat.absolute_timelock)
+                .max(),
             stack: ret_stack.into_iter().fold(Witness::empty(), |acc, next| {
                 Witness::combine(next.stack, acc)
             }),
@@ -924,6 +950,8 @@ impl Satisfaction {
             (false, false) => Satisfaction {
                 stack: Witness::Unavailable,
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             // If only one has a signature, take the one that doesn't; a
             // third party could malleate by removing the signature, but
@@ -931,17 +959,29 @@ impl Satisfaction {
             (false, true) => Satisfaction {
                 stack: sat1.stack,
                 has_sig: false,
+                relative_timelock: sat1.relative_timelock,
+                absolute_timelock: sat1.absolute_timelock,
             },
             (true, false) => Satisfaction {
                 stack: sat2.stack,
                 has_sig: false,
+                relative_timelock: sat2.relative_timelock,
+                absolute_timelock: sat2.absolute_timelock,
             },
             // If both have a signature associated with them, choose the
             // cheaper one (where "cheaper" is defined such that available
             // things are cheaper than unavailable ones)
-            (true, true) => Satisfaction {
-                stack: cmp::min(sat1.stack, sat2.stack),
+            (true, true) if sat1.stack < sat2.stack => Satisfaction {
+                stack: sat1.stack,
                 has_sig: true,
+                relative_timelock: sat1.relative_timelock,
+                absolute_timelock: sat1.absolute_timelock,
+            },
+            (true, true) => Satisfaction {
+                stack: sat2.stack,
+                has_sig: true,
+                relative_timelock: sat2.relative_timelock,
+                absolute_timelock: sat2.absolute_timelock,
             },
         }
     }
@@ -955,11 +995,18 @@ impl Satisfaction {
             (_, &Witness::Impossible) | (_, &Witness::Unavailable) => return sat1,
             _ => {}
         }
+        let (stack, absolute_timelock, relative_timelock) = if sat1.stack < sat2.stack {
+            (sat1.stack, sat1.absolute_timelock, sat1.relative_timelock)
+        } else {
+            (sat2.stack, sat2.absolute_timelock, sat2.relative_timelock)
+        };
         Satisfaction {
-            stack: cmp::min(sat1.stack, sat2.stack),
+            stack,
             // The fragment is has_sig only if both of the
             // fragments are has_sig
             has_sig: sat1.has_sig && sat2.has_sig,
+            relative_timelock,
+            absolute_timelock,
         }
     }
 
@@ -990,6 +1037,8 @@ impl Satisfaction {
             Terminal::PkK(ref pk) => Satisfaction {
                 stack: Witness::signature::<_, _, Ctx>(stfr, pk, leaf_hash),
                 has_sig: true,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::PkH(ref pk) => {
                 let wit = Witness::signature::<_, _, Ctx>(stfr, pk, leaf_hash);
@@ -1000,66 +1049,91 @@ impl Satisfaction {
                 Satisfaction {
                     stack: Witness::combine(wit, Witness::Stack(vec![pk_bytes])),
                     has_sig: true,
+                    relative_timelock: None,
+                    absolute_timelock: None,
                 }
             }
             Terminal::RawPkH(ref pkh) => Satisfaction {
                 stack: Witness::pkh_signature::<_, _, Ctx>(stfr, pkh, leaf_hash),
                 has_sig: true,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
-            Terminal::After(t) => Satisfaction {
-                stack: if stfr.check_after(t.into()) {
-                    Witness::empty()
+            Terminal::After(t) => {
+                let (stack, absolute_timelock) = if stfr.check_after(t.into()) {
+                    (Witness::empty(), Some(t))
                 } else if root_has_sig {
                     // If the root terminal has signature, the
                     // signature covers the nLockTime and nSequence
                     // values. The sender of the transaction should
                     // take care that it signs the value such that the
                     // timelock is not met
-                    Witness::Impossible
+                    (Witness::Impossible, None)
                 } else {
-                    Witness::Unavailable
-                },
-                has_sig: false,
-            },
-            Terminal::Older(t) => Satisfaction {
-                stack: if stfr.check_older(t) {
-                    Witness::empty()
+                    (Witness::Unavailable, None)
+                };
+                Satisfaction {
+                    stack,
+                    has_sig: false,
+                    relative_timelock: None,
+                    absolute_timelock,
+                }
+            }
+            Terminal::Older(t) => {
+                let (stack, relative_timelock) = if stfr.check_older(t) {
+                    (Witness::empty(), Some(t))
                 } else if root_has_sig {
                     // If the root terminal has signature, the
                     // signature covers the nLockTime and nSequence
                     // values. The sender of the transaction should
                     // take care that it signs the value such that the
                     // timelock is not met
-                    Witness::Impossible
+                    (Witness::Impossible, None)
                 } else {
-                    Witness::Unavailable
-                },
-
-                has_sig: false,
-            },
+                    (Witness::Unavailable, None)
+                };
+                Satisfaction {
+                    stack,
+                    has_sig: false,
+                    relative_timelock,
+                    absolute_timelock: None,
+                }
+            }
             Terminal::Ripemd160(ref h) => Satisfaction {
                 stack: Witness::ripemd160_preimage(stfr, h),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::Hash160(ref h) => Satisfaction {
                 stack: Witness::hash160_preimage(stfr, h),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::Sha256(ref h) => Satisfaction {
                 stack: Witness::sha256_preimage(stfr, h),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::Hash256(ref h) => Satisfaction {
                 stack: Witness::hash256_preimage(stfr, h),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::True => Satisfaction {
                 stack: Witness::empty(),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::False => Satisfaction {
                 stack: Witness::Impossible,
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::Alt(ref sub)
             | Terminal::Swap(ref sub)
@@ -1081,6 +1155,8 @@ impl Satisfaction {
                 Satisfaction {
                     stack: Witness::combine(sat.stack, Witness::push_1()),
                     has_sig: sat.has_sig,
+                    relative_timelock: sat.relative_timelock,
+                    absolute_timelock: sat.absolute_timelock,
                 }
             }
             Terminal::AndV(ref l, ref r) | Terminal::AndB(ref l, ref r) => {
@@ -1091,6 +1167,8 @@ impl Satisfaction {
                 Satisfaction {
                     stack: Witness::combine(r_sat.stack, l_sat.stack),
                     has_sig: l_sat.has_sig || r_sat.has_sig,
+                    relative_timelock: cmp::max(l_sat.relative_timelock, r_sat.relative_timelock),
+                    absolute_timelock: cmp::max(l_sat.absolute_timelock, r_sat.absolute_timelock),
                 }
             }
             Terminal::AndOr(ref a, ref b, ref c) => {
@@ -1113,10 +1191,21 @@ impl Satisfaction {
                     Satisfaction {
                         stack: Witness::combine(b_sat.stack, a_sat.stack),
                         has_sig: a_sat.has_sig || b_sat.has_sig,
+                        relative_timelock: cmp::max(
+                            a_sat.relative_timelock,
+                            b_sat.relative_timelock,
+                        ),
+                        absolute_timelock: cmp::max(
+                            a_sat.absolute_timelock,
+                            b_sat.absolute_timelock,
+                        ),
                     },
                     Satisfaction {
                         stack: Witness::combine(c_sat.stack, a_nsat.stack),
                         has_sig: a_nsat.has_sig || c_sat.has_sig,
+                        // timelocks can't be dissatisfied, so here we ignore a_nsat and only consider c_sat
+                        relative_timelock: c_sat.relative_timelock,
+                        absolute_timelock: c_sat.absolute_timelock,
                     },
                 )
             }
@@ -1149,10 +1238,14 @@ impl Satisfaction {
                     Satisfaction {
                         stack: Witness::combine(r_sat.stack, l_nsat.stack),
                         has_sig: r_sat.has_sig,
+                        relative_timelock: r_sat.relative_timelock,
+                        absolute_timelock: r_sat.absolute_timelock,
                     },
                     Satisfaction {
                         stack: Witness::combine(r_nsat.stack, l_sat.stack),
                         has_sig: l_sat.has_sig,
+                        relative_timelock: l_sat.relative_timelock,
+                        absolute_timelock: l_sat.absolute_timelock,
                     },
                 )
             }
@@ -1177,6 +1270,8 @@ impl Satisfaction {
                     Satisfaction {
                         stack: Witness::combine(r_sat.stack, l_nsat.stack),
                         has_sig: r_sat.has_sig,
+                        relative_timelock: r_sat.relative_timelock,
+                        absolute_timelock: r_sat.absolute_timelock,
                     },
                 )
             }
@@ -1189,10 +1284,14 @@ impl Satisfaction {
                     Satisfaction {
                         stack: Witness::combine(l_sat.stack, Witness::push_1()),
                         has_sig: l_sat.has_sig,
+                        relative_timelock: l_sat.relative_timelock,
+                        absolute_timelock: l_sat.absolute_timelock,
                     },
                     Satisfaction {
                         stack: Witness::combine(r_sat.stack, Witness::push_0()),
                         has_sig: r_sat.has_sig,
+                        relative_timelock: r_sat.relative_timelock,
+                        absolute_timelock: r_sat.absolute_timelock,
                     },
                 )
             }
@@ -1220,6 +1319,8 @@ impl Satisfaction {
                     Satisfaction {
                         stack: Witness::Impossible,
                         has_sig: false,
+                        relative_timelock: None,
+                        absolute_timelock: None,
                     }
                 } else {
                     // Throw away the most expensive ones
@@ -1238,6 +1339,8 @@ impl Satisfaction {
                             Witness::combine(acc, Witness::Stack(sig))
                         }),
                         has_sig: true,
+                        relative_timelock: None,
+                        absolute_timelock: None,
                     }
                 }
             }
@@ -1269,6 +1372,8 @@ impl Satisfaction {
                     Satisfaction {
                         stack: Witness::Impossible,
                         has_sig: false,
+                        relative_timelock: None,
+                        absolute_timelock: None,
                     }
                 } else {
                     Satisfaction {
@@ -1276,6 +1381,8 @@ impl Satisfaction {
                             Witness::combine(acc, Witness::Stack(sig))
                         }),
                         has_sig: true,
+                        relative_timelock: None,
+                        absolute_timelock: None,
                     }
                 }
             }
@@ -1309,6 +1416,8 @@ impl Satisfaction {
             Terminal::PkK(..) => Satisfaction {
                 stack: Witness::push_0(),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::PkH(ref pk) => {
                 let pk_bytes = match Ctx::sig_type() {
@@ -1318,6 +1427,8 @@ impl Satisfaction {
                 Satisfaction {
                     stack: Witness::combine(Witness::push_0(), Witness::Stack(vec![pk_bytes])),
                     has_sig: false,
+                    relative_timelock: None,
+                    absolute_timelock: None,
                 }
             }
             Terminal::RawPkH(ref pkh) => Satisfaction {
@@ -1326,10 +1437,14 @@ impl Satisfaction {
                     Witness::pkh_public_key::<_, _, Ctx>(stfr, pkh),
                 ),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::False => Satisfaction {
                 stack: Witness::empty(),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::True
             | Terminal::Older(_)
@@ -1338,6 +1453,8 @@ impl Satisfaction {
             | Terminal::OrC(..) => Satisfaction {
                 stack: Witness::Impossible,
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::Sha256(_)
             | Terminal::Hash256(_)
@@ -1345,6 +1462,8 @@ impl Satisfaction {
             | Terminal::Hash160(_) => Satisfaction {
                 stack: Witness::hash_dissatisfaction(),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::Alt(ref sub)
             | Terminal::Swap(ref sub)
@@ -1355,6 +1474,8 @@ impl Satisfaction {
             Terminal::DupIf(_) | Terminal::NonZero(_) => Satisfaction {
                 stack: Witness::push_0(),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::AndV(ref v, ref other) => {
                 let vsat =
@@ -1370,6 +1491,8 @@ impl Satisfaction {
                 Satisfaction {
                     stack: Witness::combine(odissat.stack, vsat.stack),
                     has_sig: vsat.has_sig || odissat.has_sig,
+                    relative_timelock: None,
+                    absolute_timelock: None,
                 }
             }
             Terminal::AndB(ref l, ref r)
@@ -1395,6 +1518,8 @@ impl Satisfaction {
                 Satisfaction {
                     stack: Witness::combine(rnsat.stack, lnsat.stack),
                     has_sig: rnsat.has_sig || lnsat.has_sig,
+                    relative_timelock: None,
+                    absolute_timelock: None,
                 }
             }
             Terminal::OrI(ref l, ref r) => {
@@ -1409,6 +1534,8 @@ impl Satisfaction {
                 let dissat_1 = Satisfaction {
                     stack: Witness::combine(lnsat.stack, Witness::push_1()),
                     has_sig: lnsat.has_sig,
+                    relative_timelock: None,
+                    absolute_timelock: None,
                 };
 
                 let rnsat = Self::dissatisfy_helper(
@@ -1422,6 +1549,8 @@ impl Satisfaction {
                 let dissat_2 = Satisfaction {
                     stack: Witness::combine(rnsat.stack, Witness::push_0()),
                     has_sig: rnsat.has_sig,
+                    relative_timelock: None,
+                    absolute_timelock: None,
                 };
 
                 // Dissatisfactions don't need to non-malleable. Use minimum_mall always
@@ -1441,14 +1570,20 @@ impl Satisfaction {
                     Witness::combine(nsat.stack, acc)
                 }),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::Multi(k, _) => Satisfaction {
                 stack: Witness::Stack(vec![vec![]; k + 1]),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
             Terminal::MultiA(_, ref pks) => Satisfaction {
                 stack: Witness::Stack(vec![vec![]; pks.len()]),
                 has_sig: false,
+                relative_timelock: None,
+                absolute_timelock: None,
             },
         }
     }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,0 +1,760 @@
+// Miniscript
+// Written in 2022 by rust-miniscript developers
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//! A spending plan or *plan* for short is a representation of a particular spending path on a
+//! descriptor. This allows us to analayze a choice of spending path without producing any
+//! signatures or other witness data for it.
+//!
+//! To make a plan you provide the descriptor with "assets" like which keys you are able to use, hash
+//! pre-images you have access to, absolute/relative timelock constraints etc.
+//!
+//! Once you've got a plan it can tell you its expected satisfaction weight which can be useful for
+//! doing coin selection. Furthermore it provides which subset of those keys and hash pre-images you
+//! will actually need as well as what locktime or sequence number you need to set.
+//!
+//! Once you've obstained signatures, hash pre-images etc required by the plan, it can create a
+//! witness/script_sig for the input.
+
+use core::cmp::Ordering;
+use core::iter::FromIterator;
+
+use bitcoin::absolute::LockTime;
+use bitcoin::address::WitnessVersion;
+use bitcoin::hashes::{hash160, ripemd160, sha256};
+use bitcoin::key::XOnlyPublicKey;
+use bitcoin::script::PushBytesBuf;
+use bitcoin::taproot::{ControlBlock, LeafVersion, TapLeafHash};
+use bitcoin::{bip32, psbt, ScriptBuf, Sequence};
+
+use crate::descriptor::{self, Descriptor, DescriptorType, KeyMap};
+use crate::miniscript::hash256;
+use crate::miniscript::satisfy::{Placeholder, Satisfier, SchnorrSigType};
+use crate::prelude::*;
+use crate::util::witness_size;
+use crate::{DefiniteDescriptorKey, DescriptorPublicKey, Error, MiniscriptKey, ToPublicKey};
+
+/// Trait describing a present/missing lookup table for constructing witness templates
+///
+/// This trait mirrors the [`Satisfier`] trait with the difference that instead of returning the
+/// item if it's present, it only returns a boolean to indicate its presence.
+///
+/// This trait is automatically implemented for every type that is also a satisfier, and simply
+/// proxies the queries to the satisfier and returns whether an item is available or not.
+///
+/// All the methods have a default implementation that returns `false`.
+pub trait AssetProvider<Pk: MiniscriptKey> {
+    /// Given a public key, look up an ECDSA signature with that key
+    fn provider_lookup_ecdsa_sig(&self, _: &Pk) -> bool {
+        false
+    }
+
+    /// Lookup the tap key spend sig and return its size
+    fn provider_lookup_tap_key_spend_sig(&self, _: &Pk) -> Option<usize> {
+        None
+    }
+
+    /// Given a public key and a associated leaf hash, look up an schnorr signature with that key
+    /// and return its size
+    fn provider_lookup_tap_leaf_script_sig(&self, _: &Pk, _: &TapLeafHash) -> Option<usize> {
+        None
+    }
+
+    /// Obtain a reference to the control block for a ver and script
+    fn provider_lookup_tap_control_block_map(
+        &self,
+    ) -> Option<&BTreeMap<ControlBlock, (bitcoin::ScriptBuf, LeafVersion)>> {
+        None
+    }
+
+    /// Given a raw `Pkh`, lookup corresponding [`bitcoin::PublicKey`]
+    fn provider_lookup_raw_pkh_pk(&self, _: &hash160::Hash) -> Option<bitcoin::PublicKey> {
+        None
+    }
+
+    /// Given a raw `Pkh`, lookup corresponding [`bitcoin::secp256k1::XOnlyPublicKey`]
+    fn provider_lookup_raw_pkh_x_only_pk(&self, _: &hash160::Hash) -> Option<XOnlyPublicKey> {
+        None
+    }
+
+    /// Given a keyhash, look up the EC signature and the associated key.
+    /// Returns the key if a signature is found.
+    /// Even if signatures for public key Hashes are not available, the users
+    /// can use this map to provide pkh -> pk mapping which can be useful
+    /// for dissatisfying pkh.
+    fn provider_lookup_raw_pkh_ecdsa_sig(&self, _: &hash160::Hash) -> Option<bitcoin::PublicKey> {
+        None
+    }
+
+    /// Given a keyhash, look up the schnorr signature and the associated key.
+    /// Returns the key and sig len if a signature is found.
+    /// Even if signatures for public key Hashes are not available, the users
+    /// can use this map to provide pkh -> pk mapping which can be useful
+    /// for dissatisfying pkh.
+    fn provider_lookup_raw_pkh_tap_leaf_script_sig(
+        &self,
+        _: &(hash160::Hash, TapLeafHash),
+    ) -> Option<(XOnlyPublicKey, usize)> {
+        None
+    }
+
+    /// Given a SHA256 hash, look up its preimage
+    fn provider_lookup_sha256(&self, _: &Pk::Sha256) -> bool {
+        false
+    }
+
+    /// Given a HASH256 hash, look up its preimage
+    fn provider_lookup_hash256(&self, _: &Pk::Hash256) -> bool {
+        false
+    }
+
+    /// Given a RIPEMD160 hash, look up its preimage
+    fn provider_lookup_ripemd160(&self, _: &Pk::Ripemd160) -> bool {
+        false
+    }
+
+    /// Given a HASH160 hash, look up its preimage
+    fn provider_lookup_hash160(&self, _: &Pk::Hash160) -> bool {
+        false
+    }
+
+    /// Assert whether a relative locktime is satisfied
+    fn check_older(&self, _: Sequence) -> bool {
+        false
+    }
+
+    /// Assert whether an absolute locktime is satisfied
+    fn check_after(&self, _: LockTime) -> bool {
+        false
+    }
+}
+
+/// Wrapper around [`Assets`] that logs every query and value returned
+#[cfg(feature = "std")]
+pub struct LoggerAssetProvider(Assets);
+
+#[cfg(feature = "std")]
+macro_rules! impl_log_method {
+    ( $name:ident, $( <$ctx:ident: ScriptContext > )? $( $arg:ident : $ty:ty, )* -> $ret_ty:ty ) => {
+        fn $name $( <$ctx: ScriptContext> )? ( &self, $( $arg:$ty ),* ) -> $ret_ty {
+            let ret = (self.0).$name $( ::<$ctx> )*( $( $arg ),* );
+            dbg!(stringify!( $name ), ( $( $arg ),* ), &ret);
+
+            ret
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl AssetProvider<DefiniteDescriptorKey> for LoggerAssetProvider {
+    impl_log_method!(provider_lookup_ecdsa_sig, pk: &DefiniteDescriptorKey, -> bool);
+    impl_log_method!(provider_lookup_tap_key_spend_sig, pk: &DefiniteDescriptorKey, -> Option<usize>);
+    impl_log_method!(provider_lookup_tap_leaf_script_sig, pk: &DefiniteDescriptorKey, leaf_hash: &TapLeafHash, -> Option<usize>);
+    impl_log_method!(provider_lookup_sha256, hash: &sha256::Hash, -> bool);
+    impl_log_method!(provider_lookup_hash256, hash: &hash256::Hash, -> bool);
+    impl_log_method!(provider_lookup_ripemd160, hash: &ripemd160::Hash, -> bool);
+    impl_log_method!(provider_lookup_hash160, hash: &hash160::Hash, -> bool);
+    impl_log_method!(check_older, s: Sequence, -> bool);
+    impl_log_method!(check_after, t: LockTime, -> bool);
+}
+
+impl<T, Pk> AssetProvider<Pk> for T
+where
+    T: Satisfier<Pk>,
+    Pk: MiniscriptKey + ToPublicKey,
+{
+    fn provider_lookup_ecdsa_sig(&self, pk: &Pk) -> bool {
+        Satisfier::lookup_ecdsa_sig(self, pk).is_some()
+    }
+
+    fn provider_lookup_tap_key_spend_sig(&self, _: &Pk) -> Option<usize> {
+        Satisfier::lookup_tap_key_spend_sig(self).map(|s| s.to_vec().len())
+    }
+
+    fn provider_lookup_tap_leaf_script_sig(
+        &self,
+        pk: &Pk,
+        leaf_hash: &TapLeafHash,
+    ) -> Option<usize> {
+        Satisfier::lookup_tap_leaf_script_sig(self, pk, leaf_hash).map(|s| s.to_vec().len())
+    }
+
+    fn provider_lookup_tap_control_block_map(
+        &self,
+    ) -> Option<&BTreeMap<ControlBlock, (bitcoin::ScriptBuf, LeafVersion)>> {
+        Satisfier::lookup_tap_control_block_map(self)
+    }
+
+    fn provider_lookup_raw_pkh_pk(&self, hash: &hash160::Hash) -> Option<bitcoin::PublicKey> {
+        Satisfier::lookup_raw_pkh_pk(self, hash)
+    }
+
+    fn provider_lookup_raw_pkh_x_only_pk(&self, hash: &hash160::Hash) -> Option<XOnlyPublicKey> {
+        Satisfier::lookup_raw_pkh_x_only_pk(self, hash)
+    }
+
+    fn provider_lookup_raw_pkh_ecdsa_sig(
+        &self,
+        hash: &hash160::Hash,
+    ) -> Option<bitcoin::PublicKey> {
+        Satisfier::lookup_raw_pkh_ecdsa_sig(self, hash).map(|(pk, _)| pk)
+    }
+
+    fn provider_lookup_raw_pkh_tap_leaf_script_sig(
+        &self,
+        hash: &(hash160::Hash, TapLeafHash),
+    ) -> Option<(XOnlyPublicKey, usize)> {
+        Satisfier::lookup_raw_pkh_tap_leaf_script_sig(self, hash)
+            .map(|(pk, sig)| (pk, sig.to_vec().len()))
+    }
+
+    fn provider_lookup_sha256(&self, hash: &Pk::Sha256) -> bool {
+        Satisfier::lookup_sha256(self, hash).is_some()
+    }
+
+    fn provider_lookup_hash256(&self, hash: &Pk::Hash256) -> bool {
+        Satisfier::lookup_hash256(self, hash).is_some()
+    }
+
+    fn provider_lookup_ripemd160(&self, hash: &Pk::Ripemd160) -> bool {
+        Satisfier::lookup_ripemd160(self, hash).is_some()
+    }
+
+    fn provider_lookup_hash160(&self, hash: &Pk::Hash160) -> bool {
+        Satisfier::lookup_hash160(self, hash).is_some()
+    }
+
+    fn check_older(&self, s: Sequence) -> bool {
+        Satisfier::check_older(self, s)
+    }
+
+    fn check_after(&self, l: LockTime) -> bool {
+        Satisfier::check_after(self, l)
+    }
+}
+
+/// Representation of a particular spending path on a descriptor. Contains the witness template
+/// and the timelocks needed for satisfying the plan.
+/// Calling `plan` on a Descriptor will return this structure,
+/// containing the cheapest spending path possible (considering the `Assets` given)
+#[derive(Debug, Clone)]
+pub struct Plan {
+    /// This plan's witness template
+    pub template: Vec<Placeholder<DefiniteDescriptorKey>>,
+    /// The absolute timelock this plan uses
+    pub absolute_timelock: Option<LockTime>,
+    /// The relative timelock this plan uses
+    pub relative_timelock: Option<Sequence>,
+
+    pub(crate) descriptor: Descriptor<DefiniteDescriptorKey>,
+}
+
+impl Plan {
+    /// Returns the witness version
+    pub fn witness_version(&self) -> Option<WitnessVersion> {
+        self.descriptor.desc_type().segwit_version()
+    }
+
+    /// The weight, in witness units, needed for satisfying this plan (includes both
+    /// the script sig weight and the witness weight)
+    pub fn satisfaction_weight(&self) -> usize {
+        self.witness_size() + self.scriptsig_size() * 4
+    }
+
+    /// The size in bytes of the script sig that satisfies this plan
+    pub fn scriptsig_size(&self) -> usize {
+        match (
+            self.descriptor.desc_type().segwit_version(),
+            self.descriptor.desc_type(),
+        ) {
+            // Entire witness goes in the script_sig
+            (None, _) => witness_size(self.template.as_ref()),
+            // Taproot doesn't have a "wrapped" version (scriptSig len (1))
+            (Some(WitnessVersion::V1), _) => 1,
+            // scriptSig len (1) + OP_0 (1) + OP_PUSHBYTES_20 (1) + <pk hash> (20)
+            (_, DescriptorType::ShWpkh) => 1 + 1 + 1 + 20,
+            // scriptSig len (1) + OP_0 (1) + OP_PUSHBYTES_32 (1) + <script hash> (32)
+            (_, DescriptorType::ShWsh) | (_, DescriptorType::ShWshSortedMulti) => 1 + 1 + 1 + 32,
+            // Native Segwit v0 (scriptSig len (1))
+            __ => 1,
+        }
+    }
+
+    /// The size in bytes of the witness that satisfies this plan
+    pub fn witness_size(&self) -> usize {
+        if let Some(_) = self.descriptor.desc_type().segwit_version() {
+            witness_size(self.template.as_ref())
+        } else {
+            0 // should be 1 if there's at least one segwit input in the tx, but that's out of
+              // scope as we can't possibly know that just by looking at the descriptor
+        }
+    }
+
+    /// Try creating the final script_sig and witness using a [`Satisfier`]
+    pub fn satisfy<Sat: Satisfier<DefiniteDescriptorKey>>(
+        &self,
+        stfr: &Sat,
+    ) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error> {
+        use bitcoin::blockdata::script::Builder;
+
+        let stack = self
+            .template
+            .iter()
+            .map(|placeholder| placeholder.satisfy_self(stfr))
+            .collect::<Option<Vec<Vec<u8>>>>()
+            .ok_or(Error::CouldNotSatisfy)?;
+
+        Ok(match self.descriptor.desc_type() {
+            DescriptorType::Bare
+            | DescriptorType::Sh
+            | DescriptorType::Pkh
+            | DescriptorType::ShSortedMulti => (
+                vec![],
+                stack
+                    .into_iter()
+                    .fold(Builder::new(), |builder, item| {
+                        use core::convert::TryFrom;
+                        let bytes = PushBytesBuf::try_from(item)
+                            .expect("All the possible placeholders can be made into PushBytesBuf");
+                        builder.push_slice(bytes)
+                    })
+                    .into_script(),
+            ),
+            DescriptorType::Wpkh
+            | DescriptorType::Wsh
+            | DescriptorType::WshSortedMulti
+            | DescriptorType::Tr => (stack, ScriptBuf::new()),
+            DescriptorType::ShWsh | DescriptorType::ShWshSortedMulti | DescriptorType::ShWpkh => {
+                (stack, self.descriptor.unsigned_script_sig())
+            }
+        })
+    }
+
+    /// Update a PSBT input with the metadata required to complete this plan
+    ///
+    /// This will only add the metadata for items required to complete this plan. For example, if
+    /// there are multiple keys present in the descriptor, only the few used by this plan will be
+    /// added to the PSBT.
+    pub fn update_psbt_input(&self, input: &mut psbt::Input) {
+        if let Descriptor::Tr(tr) = &self.descriptor {
+            enum SpendType {
+                KeySpend { internal_key: XOnlyPublicKey },
+                ScriptSpend { leaf_hash: TapLeafHash },
+            }
+
+            #[derive(Default)]
+            struct TrDescriptorData {
+                tap_script: Option<ScriptBuf>,
+                control_block: Option<ControlBlock>,
+                spend_type: Option<SpendType>,
+                key_origins: BTreeMap<XOnlyPublicKey, bip32::KeySource>,
+            }
+
+            let spend_info = tr.spend_info();
+            input.tap_merkle_root = spend_info.merkle_root();
+
+            let data = self
+                .template
+                .iter()
+                .fold(TrDescriptorData::default(), |mut data, item| {
+                    match item {
+                        Placeholder::TapScript(script) => data.tap_script = Some(script.clone()),
+                        Placeholder::TapControlBlock(cb) => data.control_block = Some(cb.clone()),
+                        Placeholder::SchnorrSigPk(pk, sig_type, _) => {
+                            let raw_pk = pk.to_x_only_pubkey();
+
+                            match (&data.spend_type, sig_type) {
+                                // First encountered schnorr sig, update the `TrDescriptorData` accordingly
+                                (None, SchnorrSigType::KeySpend { .. }) => data.spend_type = Some(SpendType::KeySpend { internal_key: raw_pk }),
+                                (None, SchnorrSigType::ScriptSpend { leaf_hash }) => data.spend_type = Some(SpendType::ScriptSpend { leaf_hash: *leaf_hash }),
+
+                                // Inconsistent placeholders (should be unreachable with the
+                                // current implementation)
+                                (Some(SpendType::KeySpend {..}), SchnorrSigType::ScriptSpend { .. }) | (Some(SpendType::ScriptSpend {..}), SchnorrSigType::KeySpend{..}) => unreachable!("Mixed taproot key-spend and script-spend placeholders in the same plan"),
+
+                                _ => {},
+                            }
+
+                            for path in pk.full_derivation_paths() {
+                                data.key_origins.insert(raw_pk, (pk.master_fingerprint(), path));
+                            }
+                        }
+                        Placeholder::SchnorrSigPkHash(_, tap_leaf_hash, _) => {
+                            data.spend_type = Some(SpendType::ScriptSpend { leaf_hash: *tap_leaf_hash });
+                        }
+                        _ => {}
+                    }
+
+                    data
+                });
+
+            // TODO: TapTree. we need to re-traverse the tree to build it, sigh
+
+            let leaf_hash = match data.spend_type {
+                Some(SpendType::KeySpend { internal_key }) => {
+                    input.tap_internal_key = Some(internal_key);
+                    None
+                }
+                Some(SpendType::ScriptSpend { leaf_hash }) => Some(leaf_hash),
+                _ => None,
+            };
+            for (pk, key_source) in data.key_origins {
+                input
+                    .tap_key_origins
+                    .entry(pk)
+                    .and_modify(|(leaf_hashes, _)| {
+                        if let Some(lh) = leaf_hash {
+                            if leaf_hashes.iter().find(|&&i| i == lh).is_none() {
+                                leaf_hashes.push(lh);
+                            }
+                        }
+                    })
+                    .or_insert_with(|| (vec![], key_source));
+            }
+            if let (Some(tap_script), Some(control_block)) = (data.tap_script, data.control_block) {
+                input
+                    .tap_scripts
+                    .insert(control_block, (tap_script, LeafVersion::TapScript));
+            }
+        } else {
+            for item in &self.template {
+                match item {
+                    Placeholder::EcdsaSigPk(pk) => {
+                        let public_key = pk.to_public_key().inner;
+                        let master_fingerprint = pk.master_fingerprint();
+                        for derivation_path in pk.full_derivation_paths() {
+                            input
+                                .bip32_derivation
+                                .insert(public_key, (master_fingerprint, derivation_path));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            match &self.descriptor {
+                Descriptor::Bare(_) | Descriptor::Pkh(_) | Descriptor::Wpkh(_) => {}
+                Descriptor::Sh(sh) => match sh.as_inner() {
+                    descriptor::ShInner::Wsh(wsh) => {
+                        input.witness_script = Some(wsh.inner_script());
+                        input.redeem_script = Some(wsh.inner_script().to_v0_p2wsh());
+                    }
+                    descriptor::ShInner::Wpkh(..) => input.redeem_script = Some(sh.inner_script()),
+                    descriptor::ShInner::SortedMulti(_) | descriptor::ShInner::Ms(_) => {
+                        input.redeem_script = Some(sh.inner_script())
+                    }
+                },
+                Descriptor::Wsh(wsh) => input.witness_script = Some(wsh.inner_script()),
+                Descriptor::Tr(_) => unreachable!("Tr is dealt with separately"),
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// Signatures which a key can produce
+///
+/// Defaults to `ecdsa=true` and `taproot=TaprootCanSign::default()`
+pub struct CanSign {
+    /// Whether the key can produce ECDSA signatures
+    pub ecdsa: bool,
+    /// Whether the key can produce taproot (Schnorr) signatures
+    pub taproot: TaprootCanSign,
+}
+
+impl Default for CanSign {
+    fn default() -> Self {
+        CanSign {
+            ecdsa: true,
+            taproot: TaprootCanSign::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// Signatures which a taproot key can produce
+///
+/// Defaults to `key_spend=true`, `script_spend=Any` and `sighash_default=true`
+pub struct TaprootCanSign {
+    /// Can produce key spend signatures
+    pub key_spend: bool,
+    /// Can produce script spend signatures
+    pub script_spend: TaprootAvailableLeaves,
+    /// Whether `SIGHASH_DEFAULT` will be used to sign
+    pub sighash_default: bool,
+}
+
+impl TaprootCanSign {
+    fn sig_len(&self) -> usize {
+        match self.sighash_default {
+            true => 64,
+            false => 65,
+        }
+    }
+}
+
+impl Default for TaprootCanSign {
+    fn default() -> Self {
+        TaprootCanSign {
+            key_spend: true,
+            script_spend: TaprootAvailableLeaves::Any,
+            sighash_default: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// Which taproot leaves the key can sign for
+pub enum TaprootAvailableLeaves {
+    /// Cannot sign for any leaf
+    None,
+    /// Can sign for any leaf
+    Any,
+    /// Can sign only for a specific leaf
+    Single(TapLeafHash),
+    /// Can sign for multiple leaves
+    Many(Vec<TapLeafHash>),
+}
+
+impl TaprootAvailableLeaves {
+    fn is_available(&self, lh: &TapLeafHash) -> bool {
+        use TaprootAvailableLeaves::*;
+
+        match self {
+            None => false,
+            Any => true,
+            Single(v) => v == lh,
+            Many(list) => list.contains(lh),
+        }
+    }
+}
+
+/// The Assets we can use to satisfy a particular spending path
+#[derive(Debug, Default)]
+pub struct Assets {
+    /// Keys the user can sign for, and how
+    pub keys: HashSet<(DescriptorPublicKey, CanSign)>,
+    /// Set of available sha256 preimages
+    pub sha256_preimages: HashSet<sha256::Hash>,
+    /// Set of available hash256 preimages
+    pub hash256_preimages: HashSet<hash256::Hash>,
+    /// Set of available ripemd160 preimages
+    pub ripemd160_preimages: HashSet<ripemd160::Hash>,
+    /// Set of available hash160 preimages
+    pub hash160_preimages: HashSet<hash160::Hash>,
+    /// Maximum absolute timelock allowed
+    pub absolute_timelock: Option<LockTime>,
+    /// Maximum relative timelock allowed
+    pub relative_timelock: Option<Sequence>,
+}
+
+impl Assets {
+    pub(crate) fn has_ecdsa_key(&self, pk: &DefiniteDescriptorKey) -> bool {
+        self.keys
+            .iter()
+            .any(|(key, can_sign)| can_sign.ecdsa && key.is_parent(pk).is_some())
+    }
+
+    pub(crate) fn has_taproot_internal_key(&self, pk: &DefiniteDescriptorKey) -> Option<usize> {
+        self.keys.iter().find_map(|(key, can_sign)| {
+            if !can_sign.taproot.key_spend || !key.is_parent(pk).is_some() {
+                None
+            } else {
+                Some(can_sign.taproot.sig_len())
+            }
+        })
+    }
+
+    pub(crate) fn has_taproot_script_key(
+        &self,
+        pk: &DefiniteDescriptorKey,
+        tap_leaf_hash: &TapLeafHash,
+    ) -> Option<usize> {
+        self.keys.iter().find_map(|(key, can_sign)| {
+            if !can_sign.taproot.script_spend.is_available(tap_leaf_hash)
+                || !key.is_parent(pk).is_some()
+            {
+                None
+            } else {
+                Some(can_sign.taproot.sig_len())
+            }
+        })
+    }
+}
+
+impl AssetProvider<DefiniteDescriptorKey> for Assets {
+    fn provider_lookup_ecdsa_sig(&self, pk: &DefiniteDescriptorKey) -> bool {
+        self.has_ecdsa_key(pk)
+    }
+
+    fn provider_lookup_tap_key_spend_sig(&self, pk: &DefiniteDescriptorKey) -> Option<usize> {
+        self.has_taproot_internal_key(pk)
+    }
+
+    fn provider_lookup_tap_leaf_script_sig(
+        &self,
+        pk: &DefiniteDescriptorKey,
+        tap_leaf_hash: &TapLeafHash,
+    ) -> Option<usize> {
+        self.has_taproot_script_key(pk, tap_leaf_hash)
+    }
+
+    fn provider_lookup_sha256(&self, hash: &sha256::Hash) -> bool {
+        self.sha256_preimages.contains(hash)
+    }
+
+    fn provider_lookup_hash256(&self, hash: &hash256::Hash) -> bool {
+        self.hash256_preimages.contains(hash)
+    }
+
+    fn provider_lookup_ripemd160(&self, hash: &ripemd160::Hash) -> bool {
+        self.ripemd160_preimages.contains(hash)
+    }
+
+    fn provider_lookup_hash160(&self, hash: &hash160::Hash) -> bool {
+        self.hash160_preimages.contains(hash)
+    }
+
+    fn check_older(&self, s: Sequence) -> bool {
+        if let Some(rt) = &self.relative_timelock {
+            return rt.is_relative_lock_time()
+                && rt.is_height_locked() == s.is_height_locked()
+                && s <= *rt;
+        }
+
+        false
+    }
+
+    fn check_after(&self, l: LockTime) -> bool {
+        if let Some(at) = &self.absolute_timelock {
+            let cmp = l.partial_cmp(at);
+            return cmp == Some(Ordering::Less) || cmp == Some(Ordering::Equal);
+        }
+
+        false
+    }
+}
+
+impl FromIterator<DescriptorPublicKey> for Assets {
+    fn from_iter<I: IntoIterator<Item = DescriptorPublicKey>>(iter: I) -> Self {
+        Assets {
+            keys: iter
+                .into_iter()
+                .map(|pk| (pk, CanSign::default()))
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Conversion into a `Assets`
+pub trait IntoAssets {
+    /// Convert `self` into a `Assets` struct
+    fn into_assets(self) -> Assets;
+}
+
+impl IntoAssets for KeyMap {
+    fn into_assets(mut self) -> Assets {
+        Assets::from_iter(self.drain().map(|(k, _)| k))
+    }
+}
+
+impl IntoAssets for DescriptorPublicKey {
+    fn into_assets(self) -> Assets {
+        vec![self].into_assets()
+    }
+}
+
+impl IntoAssets for Vec<DescriptorPublicKey> {
+    fn into_assets(self) -> Assets {
+        Assets::from_iter(self.into_iter())
+    }
+}
+
+impl IntoAssets for sha256::Hash {
+    fn into_assets(self) -> Assets {
+        Assets {
+            sha256_preimages: vec![self].into_iter().collect(),
+            ..Default::default()
+        }
+    }
+}
+
+impl IntoAssets for hash256::Hash {
+    fn into_assets(self) -> Assets {
+        Assets {
+            hash256_preimages: vec![self].into_iter().collect(),
+            ..Default::default()
+        }
+    }
+}
+
+impl IntoAssets for ripemd160::Hash {
+    fn into_assets(self) -> Assets {
+        Assets {
+            ripemd160_preimages: vec![self].into_iter().collect(),
+            ..Default::default()
+        }
+    }
+}
+
+impl IntoAssets for hash160::Hash {
+    fn into_assets(self) -> Assets {
+        Assets {
+            hash160_preimages: vec![self].into_iter().collect(),
+            ..Default::default()
+        }
+    }
+}
+
+impl IntoAssets for Assets {
+    fn into_assets(self) -> Assets {
+        self
+    }
+}
+
+impl Assets {
+    /// Contruct an empty instance
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add some assets
+    pub fn add<A: IntoAssets>(mut self, asset: A) -> Self {
+        self.append(asset.into_assets());
+        self
+    }
+
+    /// Set the maximum relative timelock allowed
+    pub fn older(mut self, seq: Sequence) -> Self {
+        self.relative_timelock = Some(seq);
+        self
+    }
+
+    /// Set the maximum absolute timelock allowed
+    pub fn after(mut self, lt: LockTime) -> Self {
+        self.absolute_timelock = Some(lt);
+        self
+    }
+
+    fn append(&mut self, b: Self) {
+        self.keys.extend(b.keys.into_iter());
+        self.sha256_preimages.extend(b.sha256_preimages.into_iter());
+        self.hash256_preimages
+            .extend(b.hash256_preimages.into_iter());
+        self.ripemd160_preimages
+            .extend(b.ripemd160_preimages.into_iter());
+        self.hash160_preimages
+            .extend(b.hash160_preimages.into_iter());
+
+        self.relative_timelock = b.relative_timelock.or(self.relative_timelock);
+        self.absolute_timelock = b.absolute_timelock.or(self.absolute_timelock);
+    }
+}

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -758,3 +758,478 @@ impl Assets {
         self.absolute_timelock = b.absolute_timelock.or(self.absolute_timelock);
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use bitcoin::absolute::LockTime;
+    use bitcoin::bip32::ExtendedPubKey;
+    use bitcoin::Sequence;
+
+    use super::*;
+    use crate::*;
+
+    fn test_inner(
+        desc: &str,
+        keys: Vec<DescriptorPublicKey>,
+        hashes: Vec<hash160::Hash>,
+        // [ (key_indexes, hash_indexes, older, after, expected) ]
+        tests: Vec<(
+            Vec<usize>,
+            Vec<usize>,
+            Option<Sequence>,
+            Option<LockTime>,
+            Option<usize>,
+        )>,
+    ) {
+        let desc = Descriptor::<DefiniteDescriptorKey>::from_str(&desc).unwrap();
+
+        for (key_indexes, hash_indexes, older, after, expected) in tests {
+            let mut assets = Assets::new();
+            if let Some(seq) = older {
+                assets = assets.older(seq);
+            }
+            if let Some(locktime) = after {
+                assets = assets.after(locktime);
+            }
+            for ki in key_indexes {
+                assets = assets.add(keys[ki].clone());
+            }
+            for hi in hash_indexes {
+                assets = assets.add(hashes[hi].clone());
+            }
+
+            let result = desc.clone().plan(&assets);
+            assert_eq!(
+                result.as_ref().ok().map(|plan| plan.satisfaction_weight()),
+                expected,
+                "{:#?}",
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn test_or() {
+        let keys = vec![
+            DescriptorPublicKey::from_str(
+                "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "0257f4a2816338436cccabc43aa724cf6e69e43e84c3c8a305212761389dd73a8a",
+            )
+            .unwrap(),
+        ];
+        let hashes = vec![];
+        let desc = format!("wsh(t:or_c(pk({}),v:pkh({})))", keys[0], keys[1]);
+
+        // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig)
+        let tests = vec![
+            (vec![], vec![], None, None, None),
+            (vec![0], vec![], None, None, Some(4 + 1 + 73)),
+            (vec![0, 1], vec![], None, None, Some(4 + 1 + 73)),
+        ];
+
+        test_inner(&desc, keys, hashes, tests);
+    }
+
+    #[test]
+    fn test_and() {
+        let keys = vec![
+            DescriptorPublicKey::from_str(
+                "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "0257f4a2816338436cccabc43aa724cf6e69e43e84c3c8a305212761389dd73a8a",
+            )
+            .unwrap(),
+        ];
+        let hashes = vec![];
+        let desc = format!("wsh(and_v(v:pk({}),pk({})))", keys[0], keys[1]);
+
+        // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 2
+        let tests = vec![
+            (vec![], vec![], None, None, None),
+            (vec![0], vec![], None, None, None),
+            (vec![0, 1], vec![], None, None, Some(4 + 1 + 73 * 2)),
+        ];
+
+        test_inner(&desc, keys, hashes, tests);
+    }
+
+    #[test]
+    fn test_multi() {
+        let keys = vec![
+            DescriptorPublicKey::from_str(
+                "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "0257f4a2816338436cccabc43aa724cf6e69e43e84c3c8a305212761389dd73a8a",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "03500a2b48b0f66c8183cc0d6645ab21cc19c7fad8a33ff04d41c3ece54b0bc1c5",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "033ad2d191da4f39512adbaac320cae1f12f298386a4e9d43fd98dec7cf5db2ac9",
+            )
+            .unwrap(),
+        ];
+        let hashes = vec![];
+        let desc = format!(
+            "wsh(multi(3,{},{},{},{}))",
+            keys[0], keys[1], keys[2], keys[3]
+        );
+
+        let tests = vec![
+            (vec![], vec![], None, None, None),
+            (vec![0, 1], vec![], None, None, None),
+            // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 3 + 1 (dummy push)
+            (vec![0, 1, 3], vec![], None, None, Some(4 + 1 + 73 * 3 + 1)),
+        ];
+
+        test_inner(&desc, keys, hashes, tests);
+    }
+
+    #[test]
+    fn test_thresh() {
+        let keys = vec![
+            DescriptorPublicKey::from_str(
+                "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "0257f4a2816338436cccabc43aa724cf6e69e43e84c3c8a305212761389dd73a8a",
+            )
+            .unwrap(),
+        ];
+        let hashes = vec![];
+        let desc = format!(
+            "wsh(thresh(2,pk({}),s:pk({}),snl:older(144)))",
+            keys[0], keys[1]
+        );
+
+        let tests = vec![
+            (vec![], vec![], None, None, None),
+            (vec![], vec![], Some(Sequence(1000)), None, None),
+            (vec![0], vec![], None, None, None),
+            // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) + 1 (OP_0) + 1 (OP_ZERO)
+            (vec![0], vec![], Some(Sequence(1000)), None, Some(80)),
+            // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 2 + 2 (OP_PUSHBYTE_1 0x01)
+            (vec![0, 1], vec![], None, None, Some(153)),
+            // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) + 1 (OP_0) + 1 (OP_ZERO)
+            (vec![0, 1], vec![], Some(Sequence(1000)), None, Some(80)),
+            // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 2 + 2 (OP_PUSHBYTE_1 0x01)
+            (
+                vec![0, 1],
+                vec![],
+                Some(Sequence::from_512_second_intervals(10)),
+                None,
+                Some(153),
+            ), // incompatible timelock
+        ];
+
+        test_inner(&desc, keys.clone(), hashes.clone(), tests);
+
+        let desc = format!(
+            "wsh(thresh(2,pk({}),s:pk({}),snl:after(144)))",
+            keys[0], keys[1]
+        );
+
+        let tests = vec![
+            // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) + 1 (OP_0) + 1 (OP_ZERO)
+            (
+                vec![0],
+                vec![],
+                None,
+                Some(LockTime::from_height(1000).unwrap()),
+                Some(80),
+            ),
+            // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 2 + 2 (OP_PUSHBYTE_1 0x01)
+            (
+                vec![0, 1],
+                vec![],
+                None,
+                Some(LockTime::from_time(500_001_000).unwrap()),
+                Some(153),
+            ), // incompatible timelock
+        ];
+
+        test_inner(&desc, keys, hashes, tests);
+    }
+
+    #[test]
+    fn test_taproot() {
+        let keys = vec![
+            DescriptorPublicKey::from_str(
+                "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "0257f4a2816338436cccabc43aa724cf6e69e43e84c3c8a305212761389dd73a8a",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "03500a2b48b0f66c8183cc0d6645ab21cc19c7fad8a33ff04d41c3ece54b0bc1c5",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "033ad2d191da4f39512adbaac320cae1f12f298386a4e9d43fd98dec7cf5db2ac9",
+            )
+            .unwrap(),
+            DescriptorPublicKey::from_str(
+                "023fc33527afab09fa97135f2180bcd22ce637b1d2fbcb2db748b1f2c33f45b2b4",
+            )
+            .unwrap(),
+        ];
+        let hashes = vec![];
+        //    .
+        //   / \
+        //  .   .
+        //  A  / \
+        //    .   .
+        //    B   C
+        //  where A = pk(key1)
+        //        B = multi(1, key2, key3)
+        //        C = and(key4, after(10))
+        let desc = format!(
+            "tr({},{{pk({}),{{multi_a(1,{},{}),and_v(v:pk({}),after(10))}}}})",
+            keys[0], keys[1], keys[2], keys[3], keys[4]
+        );
+
+        // expected weight: 4 (scriptSig len) + 1 (witness len) + 1 (OP_PUSH) + 64 (sig)
+        let internal_key_sat_weight = Some(70);
+        // expected weight: 4 (scriptSig len) + 1 (witness len) + 1 (OP_PUSH) + 64 (sig)
+        // + 34 [script: 1 (OP_PUSHBYTES_32) + 32 (key) + 1 (OP_CHECKSIG)]
+        // + 65 [control block: 1 (control byte) + 32 (internal key) + 32 (hash BC)]
+        let first_leaf_sat_weight = Some(169);
+        // expected weight: 4 (scriptSig len) + 1 (witness len) + 1 (OP_PUSH) + 64 (sig)
+        // + 1 (OP_ZERO)
+        // + 70 [script: 1 (OP_PUSHBYTES_32) + 32 (key) + 1 (OP_CHECKSIG)
+        //       + 1 (OP_PUSHBYTES_32) + 32 (key) + 1 (OP_CHECKSIGADD)
+        //       + 1 (OP_PUSHNUM1) + 1 (OP_NUMEQUAL)]
+        // + 97 [control block: 1 (control byte) + 32 (internal key) + 32 (hash C) + 32 (hash
+        //       A)]
+        let second_leaf_sat_weight = Some(238);
+        // expected weight: 4 (scriptSig len) + 1 (witness len) + 1 (OP_PUSH) + 64 (sig)
+        // + 36 [script: 1 (OP_PUSHBYTES_32) + 32 (key) + 1 (OP_CHECKSIGVERIFY)
+        //       + 1 (OP_PUSHNUM_10) + 1 (OP_CLTV)]
+        // + 97 [control block: 1 (control byte) + 32 (internal key) + 32 (hash B) + 32 (hash
+        //       A)]
+        let third_leaf_sat_weight = Some(203);
+
+        let tests = vec![
+            // Don't give assets
+            (vec![], vec![], None, None, None),
+            // Spend with internal key
+            (vec![0], vec![], None, None, internal_key_sat_weight),
+            // Spend with first leaf (single pk)
+            (vec![1], vec![], None, None, first_leaf_sat_weight),
+            // Spend with second leaf (1of2)
+            (vec![2], vec![], None, None, second_leaf_sat_weight),
+            // Spend with second leaf (1of2)
+            (vec![2, 3], vec![], None, None, second_leaf_sat_weight),
+            // Spend with third leaf (key + timelock)
+            (
+                vec![4],
+                vec![],
+                None,
+                Some(LockTime::from_height(10).unwrap()),
+                third_leaf_sat_weight,
+            ),
+            // Spend with third leaf (key + timelock),
+            // but timelock is too low (=impossible)
+            (
+                vec![4],
+                vec![],
+                None,
+                Some(LockTime::from_height(9).unwrap()),
+                None,
+            ),
+            // Spend with third leaf (key + timelock),
+            // but timelock is in the wrong unit (=impossible)
+            (
+                vec![4],
+                vec![],
+                None,
+                Some(LockTime::from_time(1296000000).unwrap()),
+                None,
+            ),
+            // Spend with third leaf (key + timelock),
+            // but don't give the timelock (=impossible)
+            (vec![4], vec![], None, None, None),
+            // Give all the keys (internal key will be used, as it's cheaper)
+            (
+                vec![0, 1, 2, 3, 4],
+                vec![],
+                None,
+                None,
+                internal_key_sat_weight,
+            ),
+            // Give all the leaf keys (uses 1st leaf)
+            (vec![1, 2, 3, 4], vec![], None, None, first_leaf_sat_weight),
+            // Give 2nd+3rd leaf without timelock (uses 2nd leaf)
+            (vec![2, 3, 4], vec![], None, None, second_leaf_sat_weight),
+            // Give 2nd+3rd leaf with timelock (uses 3rd leaf)
+            (
+                vec![2, 3, 4],
+                vec![],
+                None,
+                Some(LockTime::from_consensus(11)),
+                third_leaf_sat_weight,
+            ),
+        ];
+
+        test_inner(&desc, keys, hashes, tests);
+    }
+
+    #[test]
+    fn test_hash() {
+        let keys = vec![DescriptorPublicKey::from_str(
+            "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
+        )
+        .unwrap()];
+        let hashes = vec![hash160::Hash::from_slice(&vec![0; 20]).unwrap()];
+        let desc = format!("wsh(and_v(v:pk({}),hash160({})))", keys[0], hashes[0]);
+
+        let tests = vec![
+            // No assets, impossible
+            (vec![], vec![], None, None, None),
+            // Only key, impossible
+            (vec![0], vec![], None, None, None),
+            // Only hash, impossible
+            (vec![], vec![0], None, None, None),
+            // Key + hash
+            // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) + 1 (OP_PUSH) + 32 (preimage)
+            (vec![0], vec![0], None, None, Some(111)),
+        ];
+
+        test_inner(&desc, keys, hashes, tests);
+    }
+
+    #[test]
+    fn test_plan_update_psbt_tr() {
+        // keys taken from: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#Specifications
+        let root_xpub = ExtendedPubKey::from_str("xpub661MyMwAqRbcFkPHucMnrGNzDwb6teAX1RbKQmqtEF8kK3Z7LZ59qafCjB9eCRLiTVG3uxBxgKvRgbubRhqSKXnGGb1aoaqLrpMBDrVxga8").unwrap();
+        let fingerprint = root_xpub.fingerprint();
+        let xpub = format!("[{}/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ", fingerprint);
+        let desc = format!(
+            "tr({}/0/0,{{pkh({}/0/1),multi_a(2,{}/1/0,{}/1/1)}})",
+            xpub, xpub, xpub, xpub
+        );
+
+        let desc = Descriptor::from_str(&desc).unwrap();
+
+        let internal_key = DescriptorPublicKey::from_str(&format!("{}/0/0", xpub)).unwrap();
+        let first_branch = DescriptorPublicKey::from_str(&format!("{}/0/1", xpub)).unwrap();
+        let second_branch = DescriptorPublicKey::from_str(&format!("{}/1/*", xpub)).unwrap(); // Note this is a wildcard key, so it can sign for the whole multi_a
+
+        let mut psbt_input = bitcoin::psbt::Input::default();
+        let assets = Assets::new().add(internal_key);
+        desc.clone()
+            .plan(&assets)
+            .unwrap()
+            .update_psbt_input(&mut psbt_input);
+        assert!(
+            psbt_input.tap_internal_key.is_some(),
+            "Internal key is missing"
+        );
+        assert!(
+            psbt_input.tap_merkle_root.is_some(),
+            "Merkle root is missing"
+        );
+        assert_eq!(
+            psbt_input.tap_key_origins.len(),
+            1,
+            "Unexpected number of tap_key_origins"
+        );
+        assert_eq!(
+            psbt_input.tap_scripts.len(),
+            0,
+            "Unexpected number of tap_scripts"
+        );
+
+        let mut psbt_input = bitcoin::psbt::Input::default();
+        let assets = Assets::new().add(first_branch);
+        desc.clone()
+            .plan(&assets)
+            .unwrap()
+            .update_psbt_input(&mut psbt_input);
+        assert!(
+            psbt_input.tap_internal_key.is_none(),
+            "Internal key is present"
+        );
+        assert!(
+            psbt_input.tap_merkle_root.is_some(),
+            "Merkle root is missing"
+        );
+        assert_eq!(
+            psbt_input.tap_key_origins.len(),
+            1,
+            "Unexpected number of tap_key_origins"
+        );
+        assert_eq!(
+            psbt_input.tap_scripts.len(),
+            1,
+            "Unexpected number of tap_scripts"
+        );
+
+        let mut psbt_input = bitcoin::psbt::Input::default();
+        let assets = Assets::new().add(second_branch);
+        desc.plan(&assets)
+            .unwrap()
+            .update_psbt_input(&mut psbt_input);
+        assert!(
+            psbt_input.tap_internal_key.is_none(),
+            "Internal key is present"
+        );
+        assert!(
+            psbt_input.tap_merkle_root.is_some(),
+            "Merkle root is missing"
+        );
+        assert_eq!(
+            psbt_input.tap_key_origins.len(),
+            2,
+            "Unexpected number of tap_key_origins"
+        );
+        assert_eq!(
+            psbt_input.tap_scripts.len(),
+            1,
+            "Unexpected number of tap_scripts"
+        );
+    }
+
+    #[test]
+    fn test_plan_update_psbt_segwit() {
+        // keys taken from: https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki#Specifications
+        let root_xpub = ExtendedPubKey::from_str("xpub661MyMwAqRbcFkPHucMnrGNzDwb6teAX1RbKQmqtEF8kK3Z7LZ59qafCjB9eCRLiTVG3uxBxgKvRgbubRhqSKXnGGb1aoaqLrpMBDrVxga8").unwrap();
+        let fingerprint = root_xpub.fingerprint();
+        let xpub = format!("[{}/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ", fingerprint);
+        let desc = format!("wsh(multi(2,{}/1/0,{}/1/1))", xpub, xpub);
+
+        let desc = Descriptor::from_str(&desc).unwrap();
+
+        let asset_key = DescriptorPublicKey::from_str(&format!("{}/1/*", xpub)).unwrap(); // Note this is a wildcard key, so it can sign for the whole multi
+
+        let mut psbt_input = bitcoin::psbt::Input::default();
+        let assets = Assets::new().add(asset_key);
+        desc.plan(&assets)
+            .unwrap()
+            .update_psbt_input(&mut psbt_input);
+        assert!(
+            psbt_input.witness_script.is_some(),
+            "Witness script missing"
+        );
+        assert!(psbt_input.redeem_script.is_none(), "Redeem script present");
+        assert_eq!(
+            psbt_input.bip32_derivation.len(),
+            2,
+            "Unexpected number of bip32_derivation"
+        );
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,15 +7,48 @@ use bitcoin::script::{self, PushBytes, ScriptBuf};
 use bitcoin::PubkeyHash;
 
 use crate::miniscript::context;
+use crate::miniscript::satisfy::Placeholder;
 use crate::prelude::*;
-use crate::{ScriptContext, ToPublicKey};
+use crate::{MiniscriptKey, ScriptContext, ToPublicKey};
 pub(crate) fn varint_len(n: usize) -> usize {
     bitcoin::VarInt(n as u64).len()
 }
 
+pub(crate) trait ItemSize {
+    fn size(&self) -> usize;
+}
+
+impl<Pk: MiniscriptKey> ItemSize for Placeholder<Pk> {
+    fn size(&self) -> usize {
+        match self {
+            Placeholder::Pubkey(_, size) => *size,
+            Placeholder::PubkeyHash(_, size) => *size,
+            Placeholder::EcdsaSigPk(_) | Placeholder::EcdsaSigPkHash(_) => 73,
+            Placeholder::SchnorrSigPk(_, _, size) | Placeholder::SchnorrSigPkHash(_, _, size) => {
+                size + 1
+            } // +1 for the OP_PUSH
+            Placeholder::HashDissatisfaction
+            | Placeholder::Sha256Preimage(_)
+            | Placeholder::Hash256Preimage(_)
+            | Placeholder::Ripemd160Preimage(_)
+            | Placeholder::Hash160Preimage(_) => 33,
+            Placeholder::PushOne => 2, // On legacy this should be 1 ?
+            Placeholder::PushZero => 1,
+            Placeholder::TapScript(s) => s.len(),
+            Placeholder::TapControlBlock(cb) => cb.serialize().len(),
+        }
+    }
+}
+
+impl ItemSize for Vec<u8> {
+    fn size(&self) -> usize {
+        self.len()
+    }
+}
+
 // Helper function to calculate witness size
-pub(crate) fn witness_size(wit: &[Vec<u8>]) -> usize {
-    wit.iter().map(Vec::len).sum::<usize>() + varint_len(wit.len())
+pub(crate) fn witness_size<T: ItemSize>(wit: &[T]) -> usize {
+    wit.iter().map(T::size).sum::<usize>() + varint_len(wit.len())
 }
 
 pub(crate) fn witness_to_scriptsig(witness: &[Vec<u8>]) -> ScriptBuf {


### PR DESCRIPTION
This PR modifies the satisfaction logic so that instead of building a full witness it builds "witness templates", essentially containing placeholders instead of the actual signatures/preimages.

Once you have a "witness template" you can then analyze it (figure out the precise weight) and interactively (or in single shot) try to construct an actual witness by replacing the placeholders with actual values.

We introduce the `AssetProvider` trait which somewhat mirrors the `Satisfier` trait, but only returns whether something is available or not. For convenience the `AssetProvider` trait is automatically implemented for every `Satisfier` through a wrapping structure.

Finally, we also introduce the `Assets` structure which is a builder-like struct that implements the `AssetProvider` trait and can be used to easily tell miniscript which keys and preimages are available, or how long one is willing to wait for timelocks to expire. Using this, one can easily figure out, before creating a transaction, how much the witness is going to weight and what nLockTime/nSequence should be set in the transaction assuming those *assets* will be available later for signing.

The commits are co-authored by @danielabrozzoni since we've both worked together on this on and off for the past couple of weeks.