### PR TITLE
Remove `unstable` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ no-std = ["hashbrown", "bitcoin/no-std"]
 compiler = []
 trace = []
 
-unstable = []
 serde = ["actual-serde", "bitcoin/serde"]
 rand = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ architectural mismatches. If you have any questions or ideas you want to discuss
 please join us in
 [##miniscript](https://web.libera.chat/?channels=##miniscript) on Libera.
 
+## Benchmarks
+
+We use a custom Rust compiler configuration conditional to guard the bench mark code. To run the
+bench marks use: `RUSTFLAGS='--cfg=bench' cargo +nightly bench`.
+
 
 ## Release Notes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,8 @@
 //!
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(all(test, feature = "unstable"), feature(test))]
+// Experimental features we need.
+#![cfg_attr(bench, feature(test))]
 // Coding conventions
 #![deny(unsafe_code)]
 #![deny(non_upper_case_globals)]
@@ -107,7 +108,8 @@ extern crate core;
 
 #[cfg(feature = "serde")]
 pub use actual_serde as serde;
-#[cfg(all(test, feature = "unstable"))]
+
+#[cfg(bench)]
 extern crate test;
 
 #[macro_use]

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1598,7 +1598,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "unstable"))]
+#[cfg(bench)]
 mod benches {
     use std::str::FromStr;
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -541,7 +541,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "compiler", feature = "unstable"))]
+#[cfg(all(bench, feature = "compiler"))]
 mod benches {
     use core::str::FromStr;
 


### PR DESCRIPTION
Currently it is not possible to run the test suite with `cargo test --all-features`, this is because we use a feature called `unstable` to enable the unstable `test` crate that is used for benchmarking.

There is another way to conditionally enable the test crate and guard the benchmark code. We can use a custom configuration option `bench` and then set it using `RUSTFLAGS='--cfg=bench`.