### PR TITLE
DefiniteDescriptorKey: provide additional methods for converting to a DescriptorPublicKey

### DIFF
--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -777,6 +777,16 @@ impl DefiniteDescriptorKey {
     pub fn full_derivation_path(&self) -> bip32::DerivationPath {
         self.0.full_derivation_path()
     }
+
+    /// Reference to the underlying `DescriptorPublicKey`
+    pub fn as_descriptor_public_key(&self) -> &DescriptorPublicKey {
+        &self.0
+    }
+
+    /// Converts the definite key into a generic one
+    pub fn into_descriptor_public_key(self) -> DescriptorPublicKey {
+        self.0
+    }
 }
 
 impl FromStr for DefiniteDescriptorKey {
@@ -839,6 +849,12 @@ impl ToPublicKey for DefiniteDescriptorKey {
 impl From<DefiniteDescriptorKey> for DescriptorPublicKey {
     fn from(d: DefiniteDescriptorKey) -> Self {
         d.0
+    }
+}
+
+impl Borrow<DescriptorPublicKey> for DefiniteDescriptorKey {
+    fn borrow(&self) -> &DescriptorPublicKey {
+        &self.0
     }
 }
 


### PR DESCRIPTION
Fixes #491 

I didn't provide a mutable version of this. I'm not sure if we want to support this or not; generally public keys should be immutable after creation.