### PR TITLE
update TranslatePk again

### DIFF
--- a/bitcoind-tests/tests/setup/test_util.rs
+++ b/bitcoind-tests/tests/setup/test_util.rs
@@ -279,8 +279,10 @@ pub fn parse_test_desc(
     let desc = subs_hash_frag(desc, pubdata);
     let desc = Descriptor::<String>::from_str(&desc)?;
     let mut translator = StrDescPubKeyTranslator(0, pubdata);
-    let desc: Result<_, ()> = desc.translate_pk(&mut translator);
-    Ok(desc.expect("Translate must succeed"))
+    let desc = desc
+        .translate_pk(&mut translator)
+        .expect("Translation failed");
+    Ok(desc)
 }
 
 // substitute hash fragments in the string as the per rules

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -15,7 +15,7 @@ use bitcoin::{Address, Network, ScriptBuf};
 
 use super::checksum::{self, verify_checksum};
 use crate::expression::{self, FromTree};
-use crate::miniscript::context::ScriptContext;
+use crate::miniscript::context::{ScriptContext, ScriptContextError};
 use crate::policy::{semantic, Liftable};
 use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
@@ -205,9 +205,12 @@ pub struct Pkh<Pk: MiniscriptKey> {
 
 impl<Pk: MiniscriptKey> Pkh<Pk> {
     /// Create a new Pkh descriptor
-    pub fn new(pk: Pk) -> Self {
+    pub fn new(pk: Pk) -> Result<Self, ScriptContextError> {
         // do the top-level checks
-        Self { pk }
+        match BareCtx::check_pk(&pk) {
+            Ok(()) => Ok(Pkh { pk }),
+            Err(e) => Err(e),
+        }
     }
 
     /// Get a reference to the inner key
@@ -336,7 +339,7 @@ impl_from_tree!(
         if top.name == "pkh" && top.args.len() == 1 {
             Ok(Pkh::new(expression::terminal(&top.args[0], |pk| {
                 Pk::from_str(pk)
-            })?))
+            })?)?)
         } else {
             Err(Error::Unexpected(format!(
                 "{}({} args) while parsing pkh descriptor",
@@ -374,6 +377,7 @@ where
     where
         T: Translator<P, Q, E>,
     {
-        Ok(Pkh::new(t.pk(&self.pk)?))
+        let res = Pkh::new(t.pk(&self.pk)?);
+        Ok(res.expect("Expect will be fixed in next commit"))
     }
 }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -581,10 +581,8 @@ impl Descriptor<DescriptorPublicKey> {
 
             translate_hash_clone!(DescriptorPublicKey, DescriptorPublicKey, ConversionError);
         }
-        self.translate_pk(&mut Derivator(index)).map_err(|e| {
-            e.try_into_translator_err()
-                .expect("No Context errors while translating")
-        })
+        self.translate_pk(&mut Derivator(index))
+            .map_err(|e| e.expect_translator_err("No Context errors while translating"))
     }
 
     #[deprecated(note = "use at_derivation_index instead")]
@@ -699,8 +697,7 @@ impl Descriptor<DescriptorPublicKey> {
         let descriptor = Descriptor::<String>::from_str(s)?;
         let descriptor = descriptor.translate_pk(&mut keymap_pk).map_err(|e| {
             Error::Unexpected(
-                e.try_into_translator_err()
-                    .expect("No Outer context errors")
+                e.expect_translator_err("No Outer context errors")
                     .to_string(),
             )
         })?;
@@ -830,10 +827,9 @@ impl Descriptor<DescriptorPublicKey> {
 
         for (i, desc) in descriptors.iter_mut().enumerate() {
             let mut index_choser = IndexChoser(i);
-            *desc = desc.translate_pk(&mut index_choser).map_err(|e| {
-                e.try_into_translator_err()
-                    .expect("No Context errors possible")
-            })?;
+            *desc = desc
+                .translate_pk(&mut index_choser)
+                .map_err(|e| e.expect_translator_err("No Context errors possible"))?;
         }
 
         Ok(descriptors)
@@ -886,10 +882,7 @@ impl Descriptor<DefiniteDescriptorKey> {
         let derived = self.translate_pk(&mut Derivator(secp));
         match derived {
             Ok(derived) => Ok(derived),
-            Err(e) => match e.try_into_translator_err() {
-                Ok(e) => Err(e),
-                Err(_) => unreachable!("No Context errors when deriving keys"),
-            },
+            Err(e) => Err(e.expect_translator_err("No Context errors when deriving keys")),
         }
     }
 }

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -18,8 +18,8 @@ use crate::policy::{semantic, Liftable};
 use crate::prelude::*;
 use crate::util::varint_len;
 use crate::{
-    Error, ForEachKey, Miniscript, MiniscriptKey, Satisfier, Segwitv0, ToPublicKey, TranslatePk,
-    Translator,
+    Error, ForEachKey, Miniscript, MiniscriptKey, Satisfier, Segwitv0, ToPublicKey, TranslateErr,
+    TranslatePk, Translator,
 };
 /// A Segwitv0 wsh descriptor
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -282,7 +282,7 @@ where
 {
     type Output = Wsh<Q>;
 
-    fn translate_pk<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
+    fn translate_pk<T, E>(&self, t: &mut T) -> Result<Self::Output, TranslateErr<E>>
     where
         T: Translator<P, Q, E>,
     {
@@ -480,10 +480,14 @@ where
 {
     type Output = Wpkh<Q>;
 
-    fn translate_pk<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
+    fn translate_pk<T, E>(&self, t: &mut T) -> Result<Self::Output, TranslateErr<E>>
     where
         T: Translator<P, Q, E>,
     {
-        Ok(Wpkh::new(t.pk(&self.pk)?).expect("Uncompressed keys in Wpkh"))
+        let res = Wpkh::new(t.pk(&self.pk)?);
+        match res {
+            Ok(pk) => Ok(pk),
+            Err(e) => Err(TranslateErr::OuterError(Error::from(e))),
+        }
     }
 }

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -303,14 +303,11 @@ pub struct Wpkh<Pk: MiniscriptKey> {
 
 impl<Pk: MiniscriptKey> Wpkh<Pk> {
     /// Create a new Wpkh descriptor
-    pub fn new(pk: Pk) -> Result<Self, Error> {
+    pub fn new(pk: Pk) -> Result<Self, ScriptContextError> {
         // do the top-level checks
-        if pk.is_uncompressed() {
-            Err(Error::ContextError(ScriptContextError::CompressedOnly(
-                pk.to_string(),
-            )))
-        } else {
-            Ok(Self { pk })
+        match Segwitv0::check_pk(&pk) {
+            Ok(_) => Ok(Wpkh { pk }),
+            Err(e) => Err(e),
         }
     }
 

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -23,7 +23,7 @@ use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
     push_opcode_size, Error, ForEachKey, Legacy, Miniscript, MiniscriptKey, Satisfier, Segwitv0,
-    ToPublicKey, TranslatePk, Translator,
+    ToPublicKey, TranslateErr, TranslatePk, Translator,
 };
 
 /// A Legacy p2sh Descriptor
@@ -437,7 +437,7 @@ where
 {
     type Output = Sh<Q>;
 
-    fn translate_pk<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
+    fn translate_pk<T, E>(&self, t: &mut T) -> Result<Self::Output, TranslateErr<E>>
     where
         T: Translator<P, Q, E>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,14 +391,14 @@ impl<E> TranslateErr<E> {
     /// - Translating into multi-path descriptors should have same number of path
     /// for all the keys in the descriptor
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// This function will return an error if the Error is OutError.
-    pub fn try_into_translator_err(self) -> Result<E, Self> {
+    /// This function will panic if the Error is OutError.
+    pub fn expect_translator_err(self, msg: &str) -> E {
         if let Self::TranslatorErr(v) = self {
-            Ok(v)
+            v
         } else {
-            Err(self)
+            panic!("{}", msg)
         }
     }
 }

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -22,7 +22,7 @@ use crate::prelude::*;
 use crate::util::MsKeyBuilder;
 use crate::{
     errstr, expression, script_num_size, AbsLockTime, Error, ForEachKey, Miniscript, MiniscriptKey,
-    Terminal, ToPublicKey, TranslatePk, Translator,
+    Terminal, ToPublicKey, TranslateErr, TranslatePk, Translator,
 };
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
@@ -55,7 +55,7 @@ where
     type Output = Terminal<Q, Ctx>;
 
     /// Converts an AST element with one public key type to one of another public key type.
-    fn translate_pk<T, E>(&self, translate: &mut T) -> Result<Self::Output, E>
+    fn translate_pk<T, E>(&self, translate: &mut T) -> Result<Self::Output, TranslateErr<E>>
     where
         T: Translator<Pk, Q, E>,
     {
@@ -102,7 +102,10 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
         }
     }
 
-    pub(super) fn real_translate_pk<Q, CtxQ, T, E>(&self, t: &mut T) -> Result<Terminal<Q, CtxQ>, E>
+    pub(super) fn real_translate_pk<Q, CtxQ, T, E>(
+        &self,
+        t: &mut T,
+    ) -> Result<Terminal<Q, CtxQ>, TranslateErr<E>>
     where
         Q: MiniscriptKey,
         CtxQ: ScriptContext,

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -208,6 +208,12 @@ where
         Ok(())
     }
 
+    /// Each context has slightly different rules on what Pks are allowed in descriptors
+    /// Legacy/Bare does not allow x_only keys
+    /// Segwit does not allow uncompressed keys and x_only keys
+    /// Tapscript does not allow uncompressed keys
+    fn check_pk<Pk: MiniscriptKey>(pk: &Pk) -> Result<(), ScriptContextError>;
+
     /// Depending on script context, the size of a satifaction witness may slightly differ.
     fn max_satisfaction_size<Pk: MiniscriptKey>(ms: &Miniscript<Pk, Self>) -> Option<usize>;
     /// Depending on script Context, some of the Terminals might not
@@ -355,6 +361,18 @@ impl ScriptContext for Legacy {
         }
     }
 
+    // Only compressed and uncompressed public keys are allowed in Legacy context
+    fn check_pk<Pk: MiniscriptKey>(pk: &Pk) -> Result<(), ScriptContextError> {
+        if pk.is_x_only_key() {
+            Err(ScriptContextError::XOnlyKeysNotAllowed(
+                pk.to_string(),
+                Self::name_str(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     fn check_witness<Pk: MiniscriptKey>(witness: &[Vec<u8>]) -> Result<(), ScriptContextError> {
         // In future, we could avoid by having a function to count only
         // len of script instead of converting it.
@@ -372,31 +390,21 @@ impl ScriptContext for Legacy {
         }
 
         match ms.node {
-            Terminal::PkK(ref key) if key.is_x_only_key() => {
-                return Err(ScriptContextError::XOnlyKeysNotAllowed(
-                    key.to_string(),
-                    Self::name_str(),
-                ))
-            }
+            Terminal::PkK(ref pk) => Self::check_pk(pk),
             Terminal::Multi(_k, ref pks) => {
                 if pks.len() > MAX_PUBKEYS_PER_MULTISIG {
                     return Err(ScriptContextError::CheckMultiSigLimitExceeded);
                 }
                 for pk in pks.iter() {
-                    if pk.is_x_only_key() {
-                        return Err(ScriptContextError::XOnlyKeysNotAllowed(
-                            pk.to_string(),
-                            Self::name_str(),
-                        ));
-                    }
+                    Self::check_pk(pk)?;
                 }
+                Ok(())
             }
             Terminal::MultiA(..) => {
                 return Err(ScriptContextError::MultiANotAllowed);
             }
-            _ => {}
+            _ => Ok(()),
         }
-        Ok(())
     }
 
     fn check_local_consensus_validity<Pk: MiniscriptKey>(
@@ -460,6 +468,20 @@ impl ScriptContext for Segwitv0 {
         Ok(())
     }
 
+    // No x-only keys or uncompressed keys in Segwitv0 context
+    fn check_pk<Pk: MiniscriptKey>(pk: &Pk) -> Result<(), ScriptContextError> {
+        if pk.is_uncompressed() {
+            Err(ScriptContextError::UncompressedKeysNotAllowed)
+        } else if pk.is_x_only_key() {
+            Err(ScriptContextError::XOnlyKeysNotAllowed(
+                pk.to_string(),
+                Self::name_str(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     fn check_witness<Pk: MiniscriptKey>(witness: &[Vec<u8>]) -> Result<(), ScriptContextError> {
         if witness.len() > MAX_STANDARD_P2WSH_STACK_ITEMS {
             return Err(ScriptContextError::MaxWitnessItemssExceeded {
@@ -478,30 +500,13 @@ impl ScriptContext for Segwitv0 {
         }
 
         match ms.node {
-            Terminal::PkK(ref pk) => {
-                if pk.is_uncompressed() {
-                    return Err(ScriptContextError::CompressedOnly(pk.to_string()));
-                } else if pk.is_x_only_key() {
-                    return Err(ScriptContextError::XOnlyKeysNotAllowed(
-                        pk.to_string(),
-                        Self::name_str(),
-                    ));
-                }
-                Ok(())
-            }
+            Terminal::PkK(ref pk) => Self::check_pk(pk),
             Terminal::Multi(_k, ref pks) => {
                 if pks.len() > MAX_PUBKEYS_PER_MULTISIG {
                     return Err(ScriptContextError::CheckMultiSigLimitExceeded);
                 }
                 for pk in pks.iter() {
-                    if pk.is_uncompressed() {
-                        return Err(ScriptContextError::CompressedOnly(pk.to_string()));
-                    } else if pk.is_x_only_key() {
-                        return Err(ScriptContextError::XOnlyKeysNotAllowed(
-                            pk.to_string(),
-                            Self::name_str(),
-                        ));
-                    }
+                    Self::check_pk(pk)?;
                 }
                 Ok(())
             }
@@ -582,6 +587,15 @@ impl ScriptContext for Tap {
         Ok(())
     }
 
+    // No uncompressed keys in Tap context
+    fn check_pk<Pk: MiniscriptKey>(pk: &Pk) -> Result<(), ScriptContextError> {
+        if pk.is_uncompressed() {
+            Err(ScriptContextError::UncompressedKeysNotAllowed)
+        } else {
+            Ok(())
+        }
+    }
+
     fn check_witness<Pk: MiniscriptKey>(witness: &[Vec<u8>]) -> Result<(), ScriptContextError> {
         // Note that tapscript has a 1000 limit compared to 100 of segwitv0
         if witness.len() > MAX_STACK_SIZE {
@@ -606,9 +620,10 @@ impl ScriptContext for Tap {
         }
 
         match ms.node {
-            Terminal::PkK(ref pk) => {
-                if pk.is_uncompressed() {
-                    return Err(ScriptContextError::UncompressedKeysNotAllowed);
+            Terminal::PkK(ref pk) => Self::check_pk(pk),
+            Terminal::MultiA(_, ref keys) => {
+                for pk in keys.iter() {
+                    Self::check_pk(pk)?;
                 }
                 Ok(())
             }
@@ -693,6 +708,18 @@ impl ScriptContext for BareCtx {
         Ok(())
     }
 
+    // No x-only keys in Bare context
+    fn check_pk<Pk: MiniscriptKey>(pk: &Pk) -> Result<(), ScriptContextError> {
+        if pk.is_x_only_key() {
+            Err(ScriptContextError::XOnlyKeysNotAllowed(
+                pk.to_string(),
+                Self::name_str(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     fn check_global_consensus_validity<Pk: MiniscriptKey>(
         ms: &Miniscript<Pk, Self>,
     ) -> Result<(), ScriptContextError> {
@@ -700,23 +727,13 @@ impl ScriptContext for BareCtx {
             return Err(ScriptContextError::MaxWitnessScriptSizeExceeded);
         }
         match ms.node {
-            Terminal::PkK(ref key) if key.is_x_only_key() => {
-                return Err(ScriptContextError::XOnlyKeysNotAllowed(
-                    key.to_string(),
-                    Self::name_str(),
-                ))
-            }
+            Terminal::PkK(ref key) => Self::check_pk(key),
             Terminal::Multi(_k, ref pks) => {
                 if pks.len() > MAX_PUBKEYS_PER_MULTISIG {
                     return Err(ScriptContextError::CheckMultiSigLimitExceeded);
                 }
                 for pk in pks.iter() {
-                    if pk.is_x_only_key() {
-                        return Err(ScriptContextError::XOnlyKeysNotAllowed(
-                            pk.to_string(),
-                            Self::name_str(),
-                        ));
-                    }
+                    Self::check_pk(pk)?;
                 }
                 Ok(())
             }
@@ -784,6 +801,11 @@ impl ScriptContext for NoChecks {
     fn check_terminal_non_malleable<Pk: MiniscriptKey>(
         _frag: &Terminal<Pk, Self>,
     ) -> Result<(), ScriptContextError> {
+        Ok(())
+    }
+
+    // No checks in NoChecks
+    fn check_pk<Pk: MiniscriptKey>(_pk: &Pk) -> Result<(), ScriptContextError> {
         Ok(())
     }
 

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -986,15 +986,14 @@ where
             }
 
             let ast = Terminal::Thresh(k, sub_ast);
-            let ast_ext = AstElemExt {
-                ms: Arc::new(
-                    Miniscript::from_ast(ast)
+            if let Ok(ms) = Miniscript::from_ast(ast) {
+                let ast_ext = AstElemExt {
+                    ms: Arc::new(ms),
+                    comp_ext_data: CompilerExtData::threshold(k, n, |i| Ok(sub_ext_data[i]))
                         .expect("threshold subs, which we just compiled, typeck"),
-                ),
-                comp_ext_data: CompilerExtData::threshold(k, n, |i| Ok(sub_ext_data[i]))
-                    .expect("threshold subs, which we just compiled, typeck"),
-            };
-            insert_wrap!(ast_ext);
+                };
+                insert_wrap!(ast_ext);
+            }
 
             let key_vec: Vec<Pk> = subs
                 .iter()

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -7,7 +7,6 @@
 //!
 
 use core::convert::From;
-use core::marker::PhantomData;
 use core::{cmp, f64, fmt, hash, mem};
 #[cfg(feature = "std")]
 use std::error;
@@ -496,12 +495,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> AstElemExt<Pk, Ctx> {
         let ext = types::ExtData::type_check(&ast, |_| None)?;
         let comp_ext_data = CompilerExtData::type_check(&ast, lookup_ext)?;
         Ok(AstElemExt {
-            ms: Arc::new(Miniscript {
-                ty,
-                ext,
-                node: ast,
-                phantom: PhantomData,
-            }),
+            ms: Arc::new(Miniscript::from_components_unchecked(ast, ty, ext)),
             comp_ext_data,
         })
     }
@@ -524,12 +518,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> AstElemExt<Pk, Ctx> {
         let ext = types::ExtData::type_check(&ast, |_| None)?;
         let comp_ext_data = CompilerExtData::type_check(&ast, lookup_ext)?;
         Ok(AstElemExt {
-            ms: Arc::new(Miniscript {
-                ty,
-                ext,
-                node: ast,
-                phantom: PhantomData,
-            }),
+            ms: Arc::new(Miniscript::from_components_unchecked(ast, ty, ext)),
             comp_ext_data,
         })
     }
@@ -547,12 +536,11 @@ struct Cast<Pk: MiniscriptKey, Ctx: ScriptContext> {
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Cast<Pk, Ctx> {
     fn cast(&self, ast: &AstElemExt<Pk, Ctx>) -> Result<AstElemExt<Pk, Ctx>, ErrorKind> {
         Ok(AstElemExt {
-            ms: Arc::new(Miniscript {
-                ty: (self.ast_type)(ast.ms.ty)?,
-                ext: (self.ext_data)(ast.ms.ext)?,
-                node: (self.node)(Arc::clone(&ast.ms)),
-                phantom: PhantomData,
-            }),
+            ms: Arc::new(Miniscript::from_components_unchecked(
+                (self.node)(Arc::clone(&ast.ms)),
+                (self.ast_type)(ast.ms.ty)?,
+                (self.ext_data)(ast.ms.ext)?,
+            )),
             comp_ext_data: (self.comp_ext_data)(ast.comp_ext_data)?,
         })
     }

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -146,7 +146,7 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
             *script_pubkey == addr.script_pubkey()
         });
         match partial_sig_contains_pk {
-            Some((pk, _sig)) => Ok(Descriptor::new_pkh(*pk)),
+            Some((pk, _sig)) => Descriptor::new_pkh(*pk).map_err(|e| InputError::from(e)),
             None => Err(InputError::MissingPubkey),
         }
     } else if script_pubkey.is_v0_p2wpkh() {

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1236,7 +1236,12 @@ fn update_item_with_descriptor_helper<F: PsbtFields>(
         derived
     } else {
         let mut bip32_derivation = KeySourceLookUp(BTreeMap::new(), Secp256k1::verification_only());
-        let derived = descriptor.translate_pk(&mut bip32_derivation)?;
+        let derived = descriptor
+            .translate_pk(&mut bip32_derivation)
+            .map_err(|e| {
+                e.try_into_translator_err()
+                    .expect("No Outer Context errors in translations")
+            })?;
 
         if let Some(check_script) = check_script {
             if check_script != &derived.script_pubkey() {

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1238,10 +1238,7 @@ fn update_item_with_descriptor_helper<F: PsbtFields>(
         let mut bip32_derivation = KeySourceLookUp(BTreeMap::new(), Secp256k1::verification_only());
         let derived = descriptor
             .translate_pk(&mut bip32_derivation)
-            .map_err(|e| {
-                e.try_into_translator_err()
-                    .expect("No Outer Context errors in translations")
-            })?;
+            .map_err(|e| e.expect_translator_err("No Outer Context errors in translations"))?;
 
         if let Some(check_script) = check_script {
             if check_script != &derived.script_pubkey() {


### PR DESCRIPTION
This PR has lot of cleanups that I had planned but did not have time for a long time. 

- All places now use constructors that do invariant checking on the struct being created. 
- Translate* APIs had a soundness bug you could create uncompressed keys in segwit descriptors etc.