### PR TITLE
Remove support for 1.29

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1127,7 +1127,7 @@ mod tests {
         let (pks, der_sigs, ecdsa_sigs, sighash, secp, xpks, schnorr_sigs, ser_schnorr_sigs) =
             setup_keys_sigs(10);
         let secp_ref = &secp;
-        let vfyfn_ = |pksig: &KeySigPair| match pksig {
+        let vfyfn = |pksig: &KeySigPair| match pksig {
             KeySigPair::Ecdsa(pk, ecdsa_sig) => secp_ref
                 .verify_ecdsa(&sighash, &ecdsa_sig.sig, &pk.inner)
                 .is_ok(),
@@ -1174,7 +1174,6 @@ mod tests {
         let ripemd160 = no_checks_ms(&format!("ripemd160({})", ripemd160_hash));
 
         let stack = Stack::from(vec![stack::Element::Push(&der_sigs[0])]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &pk);
         let pk_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert_eq!(
@@ -1186,7 +1185,6 @@ mod tests {
 
         //Check Pk failure with wrong signature
         let stack = Stack::from(vec![stack::Element::Dissatisfied]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &pk);
         let pk_err: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert!(pk_err.is_err());
@@ -1197,7 +1195,6 @@ mod tests {
             stack::Element::Push(&der_sigs[1]),
             stack::Element::Push(&pk_bytes),
         ]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &pkh);
         let pkh_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert_eq!(
@@ -1210,7 +1207,6 @@ mod tests {
 
         //Check After
         let stack = Stack::from(vec![]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &after);
         let after_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert_eq!(
@@ -1222,7 +1218,6 @@ mod tests {
 
         //Check Older
         let stack = Stack::from(vec![]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &older);
         let older_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert_eq!(
@@ -1234,7 +1229,6 @@ mod tests {
 
         //Check Sha256
         let stack = Stack::from(vec![stack::Element::Push(&preimage)]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &sha256);
         let sah256_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert_eq!(
@@ -1247,7 +1241,6 @@ mod tests {
 
         //Check Shad256
         let stack = Stack::from(vec![stack::Element::Push(&preimage)]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &hash256);
         let sha256d_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert_eq!(
@@ -1260,7 +1253,6 @@ mod tests {
 
         //Check hash160
         let stack = Stack::from(vec![stack::Element::Push(&preimage)]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &hash160);
         let hash160_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert_eq!(
@@ -1273,7 +1265,6 @@ mod tests {
 
         //Check ripemd160
         let stack = Stack::from(vec![stack::Element::Push(&preimage)]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &ripemd160);
         let ripemd160_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
         assert_eq!(
@@ -1292,7 +1283,6 @@ mod tests {
             stack::Element::Push(&der_sigs[0]),
         ]);
         let elem = no_checks_ms(&format!("and_v(vc:pk_k({}),c:pk_h({}))", pks[0], pks[1]));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let and_v_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1318,7 +1308,6 @@ mod tests {
             "and_b(c:pk_k({}),sjtv:sha256({}))",
             pks[0], sha256_hash
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let and_b_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1344,7 +1333,6 @@ mod tests {
             "andor(c:pk_k({}),jtv:sha256({}),c:pk_h({}))",
             pks[0], sha256_hash, pks[1],
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let and_or_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1368,7 +1356,6 @@ mod tests {
             stack::Element::Push(&pk_bytes),
             stack::Element::Dissatisfied,
         ]);
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let and_or_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1389,7 +1376,6 @@ mod tests {
             "or_b(c:pk_k({}),sjtv:sha256({}))",
             pks[0], sha256_hash
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let or_b_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1407,7 +1393,6 @@ mod tests {
             "or_d(c:pk_k({}),jtv:sha256({}))",
             pks[0], sha256_hash
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let or_d_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1427,7 +1412,6 @@ mod tests {
             "t:or_c(jtv:sha256({}),vc:pk_k({}))",
             sha256_hash, pks[0]
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let or_c_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1447,7 +1431,6 @@ mod tests {
             "or_i(jtv:sha256({}),c:pk_k({}))",
             sha256_hash, pks[0]
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let or_i_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1470,7 +1453,6 @@ mod tests {
             "thresh(3,c:pk_k({}),sc:pk_k({}),sc:pk_k({}),sc:pk_k({}),sc:pk_k({}))",
             pks[4], pks[3], pks[2], pks[1], pks[0],
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let thresh_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1500,7 +1482,6 @@ mod tests {
             "multi(3,{},{},{},{},{})",
             pks[4], pks[3], pks[2], pks[1], pks[0],
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let multi_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1530,7 +1511,6 @@ mod tests {
             "multi(3,{},{},{},{},{})",
             pks[4], pks[3], pks[2], pks[1], pks[0],
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let multi_error: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1549,7 +1529,6 @@ mod tests {
             "multi_a(3,{},{},{},{},{})",
             xpks[0], xpks[1], xpks[2], xpks[3], xpks[4],
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let multi_a_satisfied: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1581,7 +1560,6 @@ mod tests {
             "multi_a(3,{},{},{},{},{})",
             xpks[0], xpks[1], xpks[2], xpks[3], xpks[4],
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack.clone(), &elem);
 
         let multi_a_error: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1592,7 +1570,6 @@ mod tests {
             "multi_a(2,{},{},{},{},{})",
             xpks[0], xpks[1], xpks[2], xpks[3], xpks[4],
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack.clone(), &elem);
 
         let multi_a_error: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();
@@ -1603,7 +1580,6 @@ mod tests {
             "multi_a(3,{},{},{},{},{},{})",
             xpks[0], xpks[1], xpks[2], xpks[3], xpks[4], xpks[5]
         ));
-        let vfyfn = vfyfn_.clone(); // sigh rust 1.29...
         let constraints = from_stack(Box::new(vfyfn), stack, &elem);
 
         let multi_a_error: Result<Vec<SatisfiedConstraint>, Error> = constraints.collect();


### PR DESCRIPTION
We no longer have the MSRV 1.29 - no need to support it.