### PR TITLE
Take self by value

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -103,7 +103,7 @@ enum BitcoinKey {
 }
 
 impl BitcoinKey {
-    fn to_pubkeyhash(&self, sig_type: SigType) -> hash160::Hash {
+    fn to_pubkeyhash(self, sig_type: SigType) -> hash160::Hash {
         match self {
             BitcoinKey::Fullkey(pk) => pk.to_pubkeyhash(sig_type),
             BitcoinKey::XOnlyPublicKey(pk) => pk.to_pubkeyhash(sig_type),


### PR DESCRIPTION
Clippy emits:

 warning: methods with the following characteristics: (`to_*` and `self`
 type is `Copy`) usually take `self` by value

The method in question is private, change to take `self` by value. Requires no other changes.

(Should have been part of the trivial clippy fixes :)