### PR TITLE
Use allow attribute

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -738,6 +738,7 @@ impl Descriptor<DescriptorPublicKey> {
     ///
     /// For multipath descriptors it will return as many descriptors as there is
     /// "parallel" paths. For regular descriptors it will just return itself.
+    #[allow(clippy::blocks_in_if_conditions)]
     pub fn into_single_descriptors(self) -> Result<Vec<Descriptor<DescriptorPublicKey>>, Error> {
         // All single-path descriptors contained in this descriptor.
         let mut descriptors = Vec::new();

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -1055,6 +1055,7 @@ fn sat_minus_option_dissat(
 //
 // Args are of form: (<max_sat_size>, <count_dissat_size>)
 // max_[dis]sat_size of form: (<cost_of_witness>, <cost_of_sciptsig>)
+#[allow(clippy::type_complexity)]
 fn sat_minus_dissat_witness(
     a: &(Option<(usize, usize)>, Option<(usize, usize)>),
     b: &(Option<(usize, usize)>, Option<(usize, usize)>),


### PR DESCRIPTION
Done in an effort to clear all clippy warnings.

Add two allow attributes to quieten clippy. This may not be the best solution but it at least flags the code for future improvement and allows us to enable clippy in CI (along with other clippy work).