### PR TITLE
Introduce SPDX identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ architectural mismatches. If you have any questions or ideas you want to discuss
 please join us in
 [##miniscript](https://web.libera.chat/?channels=##miniscript) on Libera.
 
-# Release Notes
+
+## Release Notes
 
 See [CHANGELOG.md](CHANGELOG.md).
+
+
+## Licensing
+
+The code in this project is licensed under the [Creative Commons CC0 1.0
+Universal license](LICENSE). We use the [SPDX license list](https://spdx.org/licenses/) and [SPDX
+IDs](https://spdx.dev/ids/).

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -1,15 +1,5 @@
-// Miniscript
-// Written in 2020 by rust-miniscript developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2020 by the rust-miniscript developers
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Bare Output Descriptors
 //!

--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Descriptor checksum
 //!
 //! This module contains a re-implementation of the function used by Bitcoin Core to calculate the

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 use core::fmt;
 use core::str::FromStr;
 #[cfg(feature = "std")]

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2018 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Output Descriptors
 //!

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -1,15 +1,5 @@
-// Miniscript
-// Written in 2020 by rust-miniscript developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2020 by the rust-miniscript developers
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Segwit Output Descriptors
 //!

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -1,15 +1,5 @@
-// Miniscript
-// Written in 2020 by rust-miniscript developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2020 by the rust-miniscript developers
+// SPDX-License-Identifier: CC0-1.0
 
 //! # P2SH Descriptors
 //!

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -1,15 +1,5 @@
-// Miniscript
-// Written in 2020 by rust-miniscript developers
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2020 by the rust-miniscript developers
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Sorted Multi
 //!

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -1,4 +1,5 @@
-// Tapscript
+// SPDX-License-Identifier: CC0-1.0
+
 use core::cmp::{self, max};
 use core::str::FromStr;
 use core::{fmt, hash};

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Function-like Expression Language
 //!

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Sanket Kanjular and Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Sanket Kanjular and Andrew Poelstra
+// SPDX-License-Identifier: CC0-1.0
 
 use core::fmt;
 #[cfg(feature = "std")]

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Sanket Kanjular and Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Sanket Kanjular and Andrew Poelstra
+// SPDX-License-Identifier: CC0-1.0
 
 use bitcoin;
 use bitcoin::blockdata::witness::Witness;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Sanket Kanjular and Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Sanket Kanjular and Andrew Poelstra
+// SPDX-License-Identifier: CC0-1.0
 
 //! Interpreter
 //!

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2020 by
-//     Sanket Kanjular and Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2020 by Sanket Kanjular and Andrew Poelstra
+// SPDX-License-Identifier: CC0-1.0
 
 //! Interpreter stack
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Miniscript and Output Descriptors
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Macros
 //!
 //! Macros meant to be used inside the Rust Miniscript library

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -1,16 +1,5 @@
-// Miniscript Analysis
-// Written in 2018 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //!  Miniscript Analysis
 //!

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! AST Elements
 //!

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Sanket Kanjalkar and Andrew Poelstra
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Sanket Kanjalkar and Andrew Poelstra
+// SPDX-License-Identifier: CC0-1.0
 
 use core::{fmt, hash};
 #[cfg(feature = "std")]

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Script Decoder
 //!

--- a/src/miniscript/hash256.rs
+++ b/src/miniscript/hash256.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2022 by
-//     Sanket Kanjalkar <sanket1729@gmail.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2022 by Sanket Kanjalkar <sanket1729@gmail.com>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Hash256 type
 //!

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2020 by
-//     Dr Maxim Orlovsky <orlovsky@pandoracore.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2022 by Dr Maxim Orlovsky <orlovsky@pandoracore.com>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Miniscript Iterators
 //!

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2018 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Lexer
 //!

--- a/src/miniscript/limits.rs
+++ b/src/miniscript/limits.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Miscellaneous constraints imposed by Bitcoin.
 //! These constraints can be either Consensus or Policy (standardness) rules, for either Segwitv0
 //! or Legacy scripts.

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Abstract Syntax Tree
 //!

--- a/src/miniscript/ms_tests.rs
+++ b/src/miniscript/ms_tests.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Sanket K <sanket1729>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Sanket Kanjalkar <sanket1729@gmail.com>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Miniscript Tests generated from dgpv's dot files
 //!

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2018 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Satisfaction and Dissatisfaction
 //!

--- a/src/miniscript/types/correctness.rs
+++ b/src/miniscript/types/correctness.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Correctness/Soundness type properties
 

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Other miscellaneous type properties which are not related to
 //! correctness or malleability.
 

--- a/src/miniscript/types/malleability.rs
+++ b/src/miniscript/types/malleability.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Malleability-related Type properties
 

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Miniscript Types
 //! Contains structures representing Miniscript types and utility functions

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Policy Compiler
 //!

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Concrete Policies
 //!

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2018 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //!  Script Policies
 //!

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! Abstract Policies
 

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2020 by
-//     Sanket Kanjalkar <sanket1729@gmail.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2020 by Sanket Kanjalkar <sanket1729@gmail.com>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Partially-Signed Bitcoin Transactions
 //!

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1,16 +1,5 @@
-// Miniscript
-// Written in 2019 by
-//     Andrew Poelstra <apoelstra@wpsoftware.net>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Partially-Signed Bitcoin Transactions
 //!

--- a/src/pub_macros.rs
+++ b/src/pub_macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Macros exported by the miniscript crate
 //!
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 //! Generally useful utilities for test scripts
 
 use std::collections::HashMap;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+
 use bitcoin::blockdata::script;
 use bitcoin::hashes::Hash;
 use bitcoin::{PubkeyHash, Script};


### PR DESCRIPTION
Recently we introduced SPDX identifiers into `rust-bitcoin`. In brief, SPDX identifiers are a way to fully describe the license of a source file in a single line. In addition to this we use an optional "written by" line to give attribution to the files original developer if they wish to have it.

- Add links to the SPDX website in the readme
- Add SPDX line to files with no license blurb
- Shorten the author section to a single line while maintaining the authors (add Sanket's email address to one attribution line)
- Remove all the licence information in each file and replace it with an SPDX ID (see https://spdx.dev/ids/#how)