### PR TITLE
Remove `DummyKey`

### DIFF
--- a/fuzz/fuzz_targets/compile_descriptor.rs
+++ b/fuzz/fuzz_targets/compile_descriptor.rs
@@ -1,24 +1,24 @@
 extern crate miniscript;
 
 use miniscript::Segwitv0;
-use miniscript::{policy, DummyKey, Miniscript};
+use miniscript::{policy, Miniscript};
 use policy::Liftable;
 
 use std::str::FromStr;
 
-type DummyScript = Miniscript<DummyKey, Segwitv0>;
-type DummyPolicy = policy::Concrete<DummyKey>;
+type Script = Miniscript<String, Segwitv0>;
+type Policy = policy::Concrete<String>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
-    if let Ok(pol) = DummyPolicy::from_str(&data_str) {
+    if let Ok(pol) = Policy::from_str(&data_str) {
         // Compile
         if let Ok(desc) = pol.compile::<Segwitv0>() {
             // Lift
             assert_eq!(desc.clone().lift().unwrap().sorted(), pol.clone().lift().unwrap().sorted());
             // Try to roundtrip the output of the compiler
             let output = desc.to_string();
-            if let Ok(desc) = DummyScript::from_str(&output) {
+            if let Ok(desc) = Script::from_str(&output) {
                 let rtt = desc.to_string();
                 assert_eq!(output.to_lowercase(), rtt.to_lowercase());
             } else {

--- a/fuzz/fuzz_targets/roundtrip_concrete.rs
+++ b/fuzz/fuzz_targets/roundtrip_concrete.rs
@@ -1,14 +1,14 @@
 extern crate miniscript;
 extern crate regex;
-use miniscript::{policy, DummyKey};
+use miniscript::policy;
 use regex::Regex;
 use std::str::FromStr;
 
-type DummyPolicy = policy::Concrete<DummyKey>;
+type Policy = policy::Concrete<String>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
-    if let Ok(pol) = DummyPolicy::from_str(&data_str) {
+    if let Ok(pol) = Policy::from_str(&data_str) {
         let output = pol.to_string();
         //remove all instances of 1@
         let re = Regex::new("(\\D)1@").unwrap();

--- a/fuzz/fuzz_targets/roundtrip_descriptor.rs
+++ b/fuzz/fuzz_targets/roundtrip_descriptor.rs
@@ -1,15 +1,15 @@
 extern crate miniscript;
 extern crate regex;
 
-use miniscript::{Descriptor, DummyKey};
+use miniscript::Descriptor;
 use regex::Regex;
 use std::str::FromStr;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
-    if let Ok(desc) = Descriptor::<DummyKey>::from_str(&s) {
+    if let Ok(desc) = Descriptor::<String>::from_str(&s) {
         let str2 = desc.to_string();
-        let desc2 = Descriptor::<DummyKey>::from_str(&str2).unwrap();
+        let desc2 = Descriptor::<String>::from_str(&str2).unwrap();
 
         assert_eq!(desc, desc2);
     }

--- a/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
@@ -4,15 +4,14 @@ extern crate regex;
 use regex::Regex;
 use std::str::FromStr;
 
-use miniscript::DummyKey;
 use miniscript::Miniscript;
 use miniscript::Segwitv0;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
-    if let Ok(desc) = Miniscript::<DummyKey, Segwitv0>::from_str(&s) {
+    if let Ok(desc) = Miniscript::<String, Segwitv0>::from_str(&s) {
         let str2 = desc.to_string();
-        let desc2 = Miniscript::<DummyKey, Segwitv0>::from_str(&str2).unwrap();
+        let desc2 = Miniscript::<String, Segwitv0>::from_str(&str2).unwrap();
 
         assert_eq!(desc, desc2);
     }

--- a/fuzz/fuzz_targets/roundtrip_semantic.rs
+++ b/fuzz/fuzz_targets/roundtrip_semantic.rs
@@ -1,13 +1,13 @@
 extern crate miniscript;
 
-use miniscript::{policy, DummyKey};
+use miniscript::policy;
 use std::str::FromStr;
 
-type DummyPolicy = policy::Semantic<DummyKey>;
+type Policy = policy::Semantic<String>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);
-    if let Ok(pol) = DummyPolicy::from_str(&data_str) {
+    if let Ok(pol) = Policy::from_str(&data_str) {
         let output = pol.to_string();
         assert_eq!(data_str.to_lowercase(), output.to_lowercase());
     }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -951,13 +951,13 @@ mod tests {
     use crate::descriptor::{DescriptorPublicKey, DescriptorXKey, SinglePub};
     #[cfg(feature = "compiler")]
     use crate::policy;
-    use crate::{hex_script, Descriptor, DummyKey, Error, Miniscript, Satisfier};
+    use crate::{hex_script, Descriptor, Error, Miniscript, Satisfier};
 
     type StdDescriptor = Descriptor<PublicKey>;
     const TEST_PK: &str = "pk(020000000000000000000000000000000000000000000000000000000000000002)";
 
     fn roundtrip_descriptor(s: &str) {
-        let desc = Descriptor::<DummyKey>::from_str(s).unwrap();
+        let desc = Descriptor::<String>::from_str(s).unwrap();
         let output = desc.to_string();
         let normalize_aliases = s.replace("c:pk_k(", "pk(").replace("c:pk_h(", "pkh(");
         assert_eq!(
@@ -984,7 +984,7 @@ mod tests {
         StdDescriptor::from_str("(\u{7f}()3").unwrap_err();
         StdDescriptor::from_str("pk()").unwrap_err();
         StdDescriptor::from_str("nl:0").unwrap_err(); //issue 63
-        let compressed_pk = DummyKey.to_string();
+        let compressed_pk = String::from("");
         assert_eq!(
             StdDescriptor::from_str("sh(sortedmulti)")
                 .unwrap_err()
@@ -1368,13 +1368,13 @@ mod tests {
 
     #[test]
     fn tr_roundtrip_key() {
-        let script = Tr::<DummyKey>::from_str("tr()").unwrap().to_string();
+        let script = Tr::<String>::from_str("tr()").unwrap().to_string();
         assert_eq!(script, format!("tr()#x4ml3kxd"))
     }
 
     #[test]
     fn tr_roundtrip_script() {
-        let descriptor = Tr::<DummyKey>::from_str("tr(,{pk(),pk()})")
+        let descriptor = Tr::<String>::from_str("tr(,{pk(),pk()})")
             .unwrap()
             .to_string();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,6 @@ pub mod psbt;
 mod test_utils;
 mod util;
 
-use core::str::FromStr;
 use core::{fmt, hash, str};
 #[cfg(feature = "std")]
 use std::error;
@@ -334,204 +333,6 @@ impl ToPublicKey for bitcoin::secp256k1::XOnlyPublicKey {
     }
 }
 
-/// Dummy key which de/serializes to the empty string; useful sometimes for testing
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Default)]
-pub struct DummyKey;
-
-impl str::FromStr for DummyKey {
-    type Err = &'static str;
-    fn from_str(x: &str) -> Result<DummyKey, &'static str> {
-        if x.is_empty() {
-            Ok(DummyKey)
-        } else {
-            Err("non empty dummy key")
-        }
-    }
-}
-
-impl MiniscriptKey for DummyKey {
-    type Sha256 = DummySha256Hash;
-    type Hash256 = DummyHash256Hash;
-    type Ripemd160 = DummyRipemd160Hash;
-    type Hash160 = DummyHash160Hash;
-
-    fn num_der_paths(&self) -> usize {
-        0
-    }
-}
-
-impl hash::Hash for DummyKey {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        "DummyKey".hash(state);
-    }
-}
-
-impl fmt::Display for DummyKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("")
-    }
-}
-
-impl ToPublicKey for DummyKey {
-    fn to_public_key(&self) -> bitcoin::PublicKey {
-        bitcoin::PublicKey::from_str(
-            "0250863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352",
-        )
-        .unwrap()
-    }
-
-    fn to_sha256(_hash: &DummySha256Hash) -> sha256::Hash {
-        sha256::Hash::from_str("50863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352")
-            .unwrap()
-    }
-
-    fn to_hash256(_hash: &DummyHash256Hash) -> hash256::Hash {
-        hash256::Hash::from_str("50863ad64a87ae8a2fe83c1af1a8403cb53f53e486d8511dad8a04887e5b2352")
-            .unwrap()
-    }
-
-    fn to_ripemd160(_: &DummyRipemd160Hash) -> ripemd160::Hash {
-        ripemd160::Hash::from_str("f54a5851e9372b87810a8e60cdd2e7cfd80b6e31").unwrap()
-    }
-
-    fn to_hash160(_: &DummyHash160Hash) -> hash160::Hash {
-        hash160::Hash::from_str("f54a5851e9372b87810a8e60cdd2e7cfd80b6e31").unwrap()
-    }
-}
-
-/// Dummy keyhash which de/serializes to the empty string; useful sometimes for testing
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Default)]
-pub struct DummyKeyHash;
-
-impl str::FromStr for DummyKeyHash {
-    type Err = &'static str;
-    fn from_str(x: &str) -> Result<DummyKeyHash, &'static str> {
-        if x.is_empty() {
-            Ok(DummyKeyHash)
-        } else {
-            Err("non empty dummy key")
-        }
-    }
-}
-
-impl fmt::Display for DummyKeyHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("")
-    }
-}
-
-impl hash::Hash for DummyKeyHash {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        "DummyKeyHash".hash(state);
-    }
-}
-
-/// Dummy keyhash which de/serializes to the empty string; useful for testing
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Default)]
-pub struct DummySha256Hash;
-
-impl str::FromStr for DummySha256Hash {
-    type Err = &'static str;
-    fn from_str(x: &str) -> Result<DummySha256Hash, &'static str> {
-        if x.is_empty() {
-            Ok(DummySha256Hash)
-        } else {
-            Err("non empty dummy hash")
-        }
-    }
-}
-
-impl fmt::Display for DummySha256Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("")
-    }
-}
-
-impl hash::Hash for DummySha256Hash {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        "DummySha256Hash".hash(state);
-    }
-}
-
-/// Dummy keyhash which de/serializes to the empty string; useful for testing
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Default)]
-pub struct DummyHash256Hash;
-
-impl str::FromStr for DummyHash256Hash {
-    type Err = &'static str;
-    fn from_str(x: &str) -> Result<DummyHash256Hash, &'static str> {
-        if x.is_empty() {
-            Ok(DummyHash256Hash)
-        } else {
-            Err("non empty dummy hash")
-        }
-    }
-}
-
-/// Dummy keyhash which de/serializes to the empty string; useful for testing
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Default)]
-pub struct DummyRipemd160Hash;
-
-impl str::FromStr for DummyRipemd160Hash {
-    type Err = &'static str;
-    fn from_str(x: &str) -> Result<DummyRipemd160Hash, &'static str> {
-        if x.is_empty() {
-            Ok(DummyRipemd160Hash)
-        } else {
-            Err("non empty dummy hash")
-        }
-    }
-}
-
-impl fmt::Display for DummyHash256Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("")
-    }
-}
-impl fmt::Display for DummyRipemd160Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("")
-    }
-}
-
-impl hash::Hash for DummyHash256Hash {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        "DummySha256Hash".hash(state);
-    }
-}
-
-impl hash::Hash for DummyRipemd160Hash {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        "DummyRipemd160Hash".hash(state);
-    }
-}
-
-/// Dummy keyhash which de/serializes to the empty string; useful for testing
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Default)]
-pub struct DummyHash160Hash;
-
-impl str::FromStr for DummyHash160Hash {
-    type Err = &'static str;
-    fn from_str(x: &str) -> Result<DummyHash160Hash, &'static str> {
-        if x.is_empty() {
-            Ok(DummyHash160Hash)
-        } else {
-            Err("non empty dummy hash")
-        }
-    }
-}
-
-impl fmt::Display for DummyHash160Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("")
-    }
-}
-
-impl hash::Hash for DummyHash160Hash {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        "DummyHash160Hash".hash(state);
-    }
-}
 /// Describes an object that can translate various keys and hashes from one key to the type
 /// associated with the other key. Used by the [`TranslatePk`] trait to do the actual translations.
 pub trait Translator<P, Q, E>
@@ -926,6 +727,8 @@ fn hex_script(s: &str) -> bitcoin::Script {
 
 #[cfg(test)]
 mod tests {
+    use core::str::FromStr;
+
     use super::*;
 
     #[test]

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -478,7 +478,7 @@ mod tests {
     use crate::policy::Liftable;
     use crate::prelude::*;
     use crate::test_utils::{StrKeyTranslator, StrXOnlyKeyTranslator};
-    use crate::{hex_script, DummyKey, ExtParams, Satisfier, ToPublicKey, TranslatePk};
+    use crate::{hex_script, ExtParams, Satisfier, ToPublicKey, TranslatePk};
 
     type Segwitv0Script = Miniscript<bitcoin::PublicKey, Segwitv0>;
     type Tapscript = Miniscript<bitcoin::secp256k1::XOnlyPublicKey, Tap>;
@@ -539,7 +539,7 @@ mod tests {
     }
 
     fn dummy_string_rtt<Ctx: ScriptContext>(
-        script: Miniscript<DummyKey, Ctx>,
+        script: Miniscript<String, Ctx>,
         expected_debug: &str,
         expected_display: &str,
     ) {
@@ -659,9 +659,9 @@ mod tests {
         .unwrap();
         let hash = hash160::Hash::from_inner([17; 20]);
 
-        let pkk_ms: Miniscript<DummyKey, Segwitv0> = Miniscript {
+        let pkk_ms: Miniscript<String, Segwitv0> = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
-                node: Terminal::PkK(DummyKey),
+                node: Terminal::PkK(String::from("")),
                 ty: Type::from_pk_k::<Segwitv0>(),
                 ext: types::extra_props::ExtData::from_pk_k::<Segwitv0>(),
                 phantom: PhantomData,
@@ -670,11 +670,11 @@ mod tests {
             ext: ExtData::cast_check(ExtData::from_pk_k::<Segwitv0>()).unwrap(),
             phantom: PhantomData,
         };
-        dummy_string_rtt(pkk_ms, "[B/onduesm]c:[K/onduesm]pk_k(DummyKey)", "pk()");
+        dummy_string_rtt(pkk_ms, "[B/onduesm]c:[K/onduesm]pk_k(\"\")", "pk()");
 
-        let pkh_ms: Miniscript<DummyKey, Segwitv0> = Miniscript {
+        let pkh_ms: Miniscript<String, Segwitv0> = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
-                node: Terminal::PkH(DummyKey),
+                node: Terminal::PkH(String::from("")),
                 ty: Type::from_pk_h::<Segwitv0>(),
                 ext: types::extra_props::ExtData::from_pk_h::<Segwitv0>(),
                 phantom: PhantomData,
@@ -684,7 +684,7 @@ mod tests {
             phantom: PhantomData,
         };
 
-        let expected_debug = "[B/nduesm]c:[K/nduesm]pk_h(DummyKey)";
+        let expected_debug = "[B/nduesm]c:[K/nduesm]pk_h(\"\")";
         let expected_display = "pkh()";
 
         assert_eq!(pkh_ms.ty.corr.base, types::Base::B);

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1200,7 +1200,7 @@ mod tests {
 
     type SPolicy = Concrete<String>;
     type BPolicy = Concrete<bitcoin::PublicKey>;
-    type DummyTapAstElemExt = policy::compiler::AstElemExt<String, Tap>;
+    type TapAstElemExt = policy::compiler::AstElemExt<String, Tap>;
     type SegwitMiniScript = Miniscript<bitcoin::PublicKey, Segwitv0>;
 
     fn pubkeys_and_a_sig(n: usize) -> (Vec<bitcoin::PublicKey>, secp256k1::ecdsa::Signature) {
@@ -1290,8 +1290,7 @@ mod tests {
     #[test]
     fn compile_q() {
         let policy = SPolicy::from_str("or(1@and(pk(A),pk(B)),127@pk(C))").expect("parsing");
-        let compilation: DummyTapAstElemExt =
-            best_t(&mut BTreeMap::new(), &policy, 1.0, None).unwrap();
+        let compilation: TapAstElemExt = best_t(&mut BTreeMap::new(), &policy, 1.0, None).unwrap();
 
         assert_eq!(compilation.cost_1d(1.0, None), 87.0 + 67.0390625);
         assert_eq!(
@@ -1303,8 +1302,7 @@ mod tests {
         let policy = SPolicy::from_str(
                 "and(and(and(or(127@thresh(2,pk(A),pk(B),thresh(2,or(127@pk(A),1@pk(B)),after(100),or(and(pk(C),after(200)),and(pk(D),sha256(66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925))),pk(E))),1@pk(F)),sha256(66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925)),or(127@pk(G),1@after(300))),or(127@after(400),pk(H)))"
             ).expect("parsing");
-        let compilation: DummyTapAstElemExt =
-            best_t(&mut BTreeMap::new(), &policy, 1.0, None).unwrap();
+        let compilation: TapAstElemExt = best_t(&mut BTreeMap::new(), &policy, 1.0, None).unwrap();
 
         assert_eq!(compilation.cost_1d(1.0, None), 433.0 + 275.7909749348958);
         assert_eq!(

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -231,12 +231,11 @@ mod tests {
     #[cfg(feature = "compiler")]
     use crate::descriptor::Tr;
     use crate::prelude::*;
-    use crate::DummyKey;
     #[cfg(feature = "compiler")]
     use crate::{descriptor::TapTree, Descriptor, Tap};
 
-    type ConcretePol = Concrete<DummyKey>;
-    type SemanticPol = Semantic<DummyKey>;
+    type ConcretePol = Concrete<String>;
+    type SemanticPol = Semantic<String>;
 
     fn concrete_policy_rtt(s: &str) {
         let conc = ConcretePol::from_str(s).unwrap();


### PR DESCRIPTION
An alternative to #500 (because I just saw the issue #437)

As described in issue #437 we can use `String` in place of the `DummyKey` in all current test use cases.

Use `String` in tests and remove the `DummyKey` along with all the other (currently unused) `DummyFoo` types.

Fix: #437