### PR TITLE
fix formatting after #507

### DIFF
--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -22,10 +22,9 @@ use crate::miniscript::types::extra_props::ExtData;
 use crate::miniscript::types::{Property, Type};
 use crate::miniscript::ScriptContext;
 use crate::prelude::*;
-use crate::{bitcoin, hash256, Error, Miniscript, MiniscriptKey, ToPublicKey};
-
 #[cfg(doc)]
 use crate::Descriptor;
+use crate::{bitcoin, hash256, Error, Miniscript, MiniscriptKey, ToPublicKey};
 
 fn return_none<T>(_: usize) -> Option<T> {
     None

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -27,10 +27,9 @@ use super::ENTAILMENT_MAX_TERMINALS;
 use crate::expression::{self, FromTree};
 use crate::miniscript::types::extra_props::TimelockInfo;
 use crate::prelude::*;
-use crate::{errstr, Error, ForEachKey, MiniscriptKey, Translator};
-
 #[cfg(all(doc, not(feature = "compiler")))]
 use crate::Descriptor;
+use crate::{errstr, Error, ForEachKey, MiniscriptKey, Translator};
 
 /// Maximum TapLeafs allowed in a compiled TapTree
 #[cfg(feature = "compiler")]


### PR DESCRIPTION
I merged #507 without checking CI, and it turns out there was a rustfmt issue. FIx that.