### PR TITLE
Add base64 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ trace = []
 unstable = []
 serde = ["actual-serde", "bitcoin/serde"]
 rand = ["bitcoin/rand"]
+base64 = ["bitcoin/base64"]
 
 [dependencies]
 bitcoin = { version = "0.29.1", default-features = false }

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-FEATURES="compiler serde rand"
+FEATURES="compiler serde rand base64"
 
 cargo update -p serde --precise 1.0.142
 cargo update -p serde_derive --precise 1.0.142


### PR DESCRIPTION
Add a "base64" feature that enables the `base64` dependency in `rust-bitcoin`. This enables `Psbt::from_str()`.

Fix: #480