### PR TITLE
Remove fixed TODO

### DIFF
--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -709,7 +709,6 @@ impl Property for ExtData {
                 (None, None) => None,
             },
             timelock_info: TimelockInfo::combine_or(l.timelock_info, r.timelock_info),
-            // TODO: fix elem count dissat bug
             exec_stack_elem_count_sat: cmp::max(
                 l.exec_stack_elem_count_sat,
                 r.exec_stack_elem_count_sat,


### PR DESCRIPTION
This TODO was actually from 255 where the bug was in cast_unlikely, even though the issue is labeled with or_i (my bad for not checking). There is no code for `cast_unlikely` as it is treated as or_i.

Addressed in 239efd55387f1d893e6ac4e602ca11454785c375

Fixes #268 