### PR TITLE
Fixing the Inclusivity of Z in StrKeyTranslator

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -16,6 +16,7 @@ if cargo --version | grep "1\.41\.0"; then
     cargo update -p form_urlencoded --precise 1.0.1
     cargo update -p once_cell --precise 1.13.1
     cargo update -p bzip2 --precise 0.4.2
+    cargo update -p which --precise 4.3.0
 fi
 
 # Pin dependencies required to build with Rust 1.47.0

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -136,7 +136,7 @@ impl StrKeyTranslator {
             .collect();
         let mut pk_map = HashMap::new();
         let mut pkh_map = HashMap::new();
-        for (i, c) in (b'A'..b'Z').enumerate() {
+        for (i, c) in (b'A'..=b'Z').enumerate() {
             let key = String::from_utf8(vec![c]).unwrap();
             pk_map.insert(key.clone(), pks[i]);
             pkh_map.insert(key, pks[i].to_pubkeyhash(SigType::Ecdsa));


### PR DESCRIPTION
Fixing `StrKeyTranslator` in `test_utils.rs` where Z was not included. 
Closes #496 
Signed-off-by: Harshil Jani <harshiljani2002@gmail.com>