### PR TITLE
Update multi_a to not include n wrapper

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1136,4 +1136,14 @@ mod tests {
         SegwitMs::parse_insane(&script).unwrap_err();
         SegwitMs::parse_with_ext(&script, &ExtParams::allow_all()).unwrap();
     }
+
+    #[test]
+    fn tr_multi_a_j_wrapper() {
+        // Reported by darosior
+        // `multi_a` fragment may require the top stack element to be the empty vector.
+        // Previous version had incorrectly copied this code from multi.
+        type TapMs = Miniscript<String, Tap>;
+        let ms_str = TapMs::from_str_insane("j:multi_a(1,A,B,C)");
+        assert!(ms_str.is_err());
+    }
 }

--- a/src/miniscript/types/correctness.rs
+++ b/src/miniscript/types/correctness.rs
@@ -159,6 +159,15 @@ impl Property for Correctness {
         }
     }
 
+    fn from_multi_a(_: usize, _: usize) -> Self {
+        Correctness {
+            base: Base::B,
+            input: Input::Any,
+            dissatisfiable: true,
+            unit: true,
+        }
+    }
+
     fn from_hash() -> Self {
         Correctness {
             base: Base::B,

--- a/src/miniscript/types/malleability.rs
+++ b/src/miniscript/types/malleability.rs
@@ -108,6 +108,14 @@ impl Property for Malleability {
         }
     }
 
+    fn from_multi_a(_: usize, _: usize) -> Self {
+        Malleability {
+            dissat: Dissat::Unique,
+            safe: true,
+            non_malleable: true,
+        }
+    }
+
     fn from_hash() -> Self {
         Malleability {
             dissat: Dissat::Unknown,

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -256,10 +256,7 @@ pub trait Property: Sized {
     fn from_multi(k: usize, n: usize) -> Self;
 
     /// Type property of a `MultiA` fragment
-    fn from_multi_a(k: usize, n: usize) -> Self {
-        // default impl same as multi
-        Self::from_multi(k, n)
-    }
+    fn from_multi_a(k: usize, n: usize) -> Self;
 
     /// Type property of a hash fragment
     fn from_hash() -> Self;
@@ -569,6 +566,13 @@ impl Property for Type {
         Type {
             corr: Property::from_multi(k, n),
             mall: Property::from_multi(k, n),
+        }
+    }
+
+    fn from_multi_a(k: usize, n: usize) -> Self {
+        Type {
+            corr: Property::from_multi_a(k, n),
+            mall: Property::from_multi_a(k, n),
         }
     }
 

--- a/tests/test_desc.rs
+++ b/tests/test_desc.rs
@@ -395,6 +395,10 @@ fn test_descs(cl: &Client, testdata: &TestData) {
     let result = test_desc_satisfy(cl, testdata, "tr(X!,{pk(X1!),pk(X2!)})");
     assert_eq!(result, Err(DescError::PsbtFinalizeError));
 
+    // Test 10: Test taproot desc with ZERO known keys
+    let result = test_desc_satisfy(cl, testdata, "tr(X!,j:multi_a(3,X1!,X2,X3,X4))");
+    assert_eq!(result, Err(DescError::DescParseError));
+
     // Test 11: Test taproot with insufficient known keys
     let result = test_desc_satisfy(cl, testdata, "tr(X!,{pk(X1!),multi_a(3,X2!,X3,X4)})");
     assert_eq!(result, Err(DescError::PsbtFinalizeError));


### PR DESCRIPTION
While we are at it, do not use the default impl. This makes these types
of errors easy to make. I think this could have easily been prevented if
I was forced to explicitly write AnyNonZero in front of multi_a.


Reported by darosior. 