### PR TITLE
Serde for DescriptorPublicKey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ actual-serde = { package = "serde", version = "1.0", optional = true }
 bitcoind = { version = "0.27.0", features=["23_0"] }
 actual-rand = { package = "rand", version = "0.8.4"}
 secp256k1 = {version = "0.24.0", features = ["rand-std"]}
+serde_test = "1.0.147"
 
 [[example]]
 name = "htlc"


### PR DESCRIPTION
Save me from ever writing the following code again:

```rust
pub mod serde_descriptor_key {
    use std::str::FromStr;

    use miniscript::DescriptorPublicKey;
    use serde::{Deserialize, Deserializer, Serializer};

    pub fn serialize<S>(dpk: &DescriptorPublicKey, serializer: S) -> Result<S::Ok, S::Error>
    where
        S: Serializer,
    {
        serializer.serialize_str(&dpk.to_string())
    }

    pub fn deserialize<'de, D>(deserializer: D) -> Result<DescriptorPublicKey, D::Error>
    where
        D: Deserializer<'de>,
    {
        let s = String::deserialize(deserializer)?;
        DescriptorPublicKey::from_str(&s).map_err(serde::de::Error::custom)
    }
}
```