### PR TITLE
Upgrade bitcoin to upcoming 0.30.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,11 @@ serde = ["actual-serde", "bitcoin/serde"]
 rand = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
 
+[patch.crates-io.bitcoin_hashes]
+path = "../rust-bitcoin/hashes"
+
 [dependencies]
-bitcoin = { version = "0.29.1", default-features = false }
+bitcoin = { path = "../rust-bitcoin/bitcoin", default-features = false }
 hashbrown = { version = "0.11", optional = true }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -133,7 +133,7 @@ fn main() {
         .to_secp_msg();
 
     // Fixme: Take a parameter
-    let hash_ty = bitcoin::EcdsaSighashType::All;
+    let hash_ty = bitcoin::sighash::EcdsaSighashType::All;
 
     let sk1 = backup1_private.inner;
     let sk2 = backup2_private.inner;
@@ -150,7 +150,7 @@ fn main() {
 
     psbt.inputs[0].partial_sigs.insert(
         pk1,
-        bitcoin::EcdsaSig {
+        bitcoin::crypto::ecdsa::Signature {
             sig: sig1,
             hash_ty: hash_ty,
         },

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use bitcoin::blockdata::witness::Witness;
-use bitcoin::{secp256k1, PackedLockTime, Sequence};
+use bitcoin::{secp256k1, absolute, Sequence};
 
 fn main() {
     let mut tx = spending_transaction();
@@ -63,7 +63,7 @@ fn main() {
     // Attempt to satisfy at age 0, height 0.
     let original_txin = tx.input[0].clone();
 
-    let mut sigs = HashMap::<bitcoin::PublicKey, miniscript::bitcoin::EcdsaSig>::new();
+    let mut sigs = HashMap::<bitcoin::PublicKey, miniscript::bitcoin::crypto::ecdsa::Signature>::new();
 
     // Doesn't work with no signatures.
     assert!(descriptor.satisfy(&mut tx.input[0], &sigs).is_err());
@@ -91,7 +91,7 @@ fn main() {
 fn spending_transaction() -> bitcoin::Transaction {
     bitcoin::Transaction {
         version: 2,
-        lock_time: PackedLockTime::ZERO,
+        lock_time: absolute::LockTime::ZERO,
         input: vec![bitcoin::TxIn {
             previous_output: Default::default(),
             script_sig: bitcoin::Script::new(),
@@ -128,8 +128,8 @@ fn list_of_three_arbitrary_public_keys() -> Vec<bitcoin::PublicKey> {
 
 // Returns a signature copied at random off the blockchain; this is not actually
 // a valid signature for this transaction; Miniscript does not verify the validity.
-fn random_signature_from_the_blockchain() -> bitcoin::EcdsaSig {
-    bitcoin::EcdsaSig {
+fn random_signature_from_the_blockchain() -> bitcoin::crypto::ecdsa::Signature {
+    bitcoin::crypto::ecdsa::Signature {
         sig: secp256k1::ecdsa::Signature::from_str(
             "3045\
              0221\
@@ -138,6 +138,6 @@ fn random_signature_from_the_blockchain() -> bitcoin::EcdsaSig {
              531d75c136272f127a5dc14acc0722301cbddc222262934151f140da345af177",
         )
         .unwrap(),
-        hash_ty: bitcoin::EcdsaSighashType::All,
+        hash_ty: bitcoin::sighash::EcdsaSighashType::All,
     }
 }

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -102,7 +102,7 @@ fn main() {
 
     let iter = interpreter.iter_custom(Box::new(|key_sig: &KeySigPair| {
         let (pk, ecdsa_sig) = key_sig.as_ecdsa().expect("Ecdsa Sig");
-        ecdsa_sig.hash_ty == bitcoin::EcdsaSighashType::All
+        ecdsa_sig.hash_ty == bitcoin::sighash::EcdsaSighashType::All
             && secp
                 .verify_ecdsa(&message, &ecdsa_sig.sig, &pk.inner)
                 .is_ok()

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -9,9 +9,10 @@
 //!
 
 use core::fmt;
+use core::convert::TryFrom;
 
-use bitcoin::blockdata::script;
-use bitcoin::{Address, Network, Script};
+use bitcoin::{Address, Network, ScriptBuf};
+use bitcoin::script::{self, PushBytesBuf};
 
 use super::checksum::{self, verify_checksum};
 use crate::expression::{self, FromTree};
@@ -94,24 +95,24 @@ impl<Pk: MiniscriptKey> Bare<Pk> {
 
 impl<Pk: MiniscriptKey + ToPublicKey> Bare<Pk> {
     /// Obtains the corresponding script pubkey for this descriptor.
-    pub fn script_pubkey(&self) -> Script {
+    pub fn script_pubkey(&self) -> ScriptBuf {
         self.ms.encode()
     }
 
     /// Obtains the underlying miniscript for this descriptor.
-    pub fn inner_script(&self) -> Script {
+    pub fn inner_script(&self) -> ScriptBuf {
         self.script_pubkey()
     }
 
     /// Obtains the pre bip-340 signature script code for this descriptor.
-    pub fn ecdsa_sighash_script_code(&self) -> Script {
+    pub fn ecdsa_sighash_script_code(&self) -> ScriptBuf {
         self.script_pubkey()
     }
 
     /// Returns satisfying non-malleable witness and scriptSig with minimum
     /// weight to spend an output controlled by the given descriptor if it is
     /// possible to construct one using the `satisfier`.
-    pub fn get_satisfaction<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, Script), Error>
+    pub fn get_satisfaction<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error>
     where
         S: Satisfier<Pk>,
     {
@@ -124,7 +125,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Bare<Pk> {
     /// Returns satisfying, possibly malleable, witness and scriptSig with
     /// minimum weight to spend an output controlled by the given descriptor if
     /// it is possible to construct one using the `satisfier`.
-    pub fn get_satisfaction_mall<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, Script), Error>
+    pub fn get_satisfaction_mall<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error>
     where
         S: Satisfier<Pk>,
     {
@@ -257,7 +258,7 @@ impl<Pk: MiniscriptKey> Pkh<Pk> {
 
 impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
     /// Obtains the corresponding script pubkey for this descriptor.
-    pub fn script_pubkey(&self) -> Script {
+    pub fn script_pubkey(&self) -> ScriptBuf {
         // Fine to hard code the `Network` here because we immediately call
         // `script_pubkey` which does not use the `network` field of `Address`.
         let addr = self.address(Network::Bitcoin);
@@ -270,26 +271,25 @@ impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
     }
 
     /// Obtains the underlying miniscript for this descriptor.
-    pub fn inner_script(&self) -> Script {
+    pub fn inner_script(&self) -> ScriptBuf {
         self.script_pubkey()
     }
 
     /// Obtains the pre bip-340 signature script code for this descriptor.
-    pub fn ecdsa_sighash_script_code(&self) -> Script {
+    pub fn ecdsa_sighash_script_code(&self) -> ScriptBuf {
         self.script_pubkey()
     }
 
     /// Returns satisfying non-malleable witness and scriptSig with minimum
     /// weight to spend an output controlled by the given descriptor if it is
     /// possible to construct one using the `satisfier`.
-    pub fn get_satisfaction<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, Script), Error>
+    pub fn get_satisfaction<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error>
     where
         S: Satisfier<Pk>,
     {
         if let Some(sig) = satisfier.lookup_ecdsa_sig(&self.pk) {
-            let sig_vec = sig.to_vec();
             let script_sig = script::Builder::new()
-                .push_slice(&sig_vec[..])
+                .push_slice(PushBytesBuf::try_from(sig.to_vec()).expect("TODO: Add error variant"))
                 .push_key(&self.pk.to_public_key())
                 .into_script();
             let witness = vec![];
@@ -302,7 +302,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
     /// Returns satisfying, possibly malleable, witness and scriptSig with
     /// minimum weight to spend an output controlled by the given descriptor if
     /// it is possible to construct one using the `satisfier`.
-    pub fn get_satisfaction_mall<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, Script), Error>
+    pub fn get_satisfaction_mall<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error>
     where
         S: Satisfier<Pk>,
     {

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 
 use core::fmt;
+use core::convert::TryInto;
 use core::str::FromStr;
 #[cfg(feature = "std")]
 use std::error;
 
+use bitcoin::bip32;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash, HashEngine};
+use bitcoin::hash_types::XpubIdentifier;
+use bitcoin::key::XOnlyPublicKey;
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};
-use bitcoin::util::bip32;
-use bitcoin::{self, XOnlyPublicKey, XpubIdentifier};
 
 use crate::prelude::*;
 use crate::{hash256, MiniscriptKey, ToPublicKey};
@@ -389,7 +391,7 @@ fn maybe_fmt_master_id(
 ) -> fmt::Result {
     if let Some((ref master_id, ref master_deriv)) = *origin {
         fmt::Formatter::write_str(f, "[")?;
-        for byte in master_id.into_bytes().iter() {
+        for byte in master_id.to_bytes().iter() {
             write!(f, "{:02x}", byte)?;
         }
         fmt_derivation_path(f, master_deriv)?;
@@ -550,7 +552,7 @@ impl DescriptorPublicKey {
                         }
                         SinglePubKey::XOnly(x_only_pk) => engine.input(&x_only_pk.serialize()),
                     };
-                    bip32::Fingerprint::from(&XpubIdentifier::from_engine(engine)[..4])
+                    bip32::Fingerprint::from(&XpubIdentifier::from_engine(engine)[..4].try_into().expect("4 byte slice"))
                 }
             }
         }

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -10,7 +10,7 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::str::FromStr;
 
-use bitcoin::blockdata::script;
+use bitcoin::script;
 
 use crate::miniscript::context::ScriptContext;
 use crate::miniscript::decode::Terminal;
@@ -141,7 +141,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     }
 
     /// Encode as a Bitcoin script
-    pub fn encode(&self) -> script::Script
+    pub fn encode(&self) -> script::ScriptBuf
     where
         Pk: ToPublicKey,
     {

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -4,12 +4,12 @@ use core::cmp::{self, max};
 use core::str::FromStr;
 use core::{fmt, hash};
 
-use bitcoin::blockdata::opcodes;
-use bitcoin::util::taproot::{
+use bitcoin::taproot::{
     LeafVersion, TaprootBuilder, TaprootSpendInfo, TAPROOT_CONTROL_BASE_SIZE,
     TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_NODE_SIZE,
 };
-use bitcoin::{secp256k1, Address, Network, Script};
+use bitcoin::{secp256k1, opcodes, Address, Network, ScriptBuf};
+
 use sync::Arc;
 
 use super::checksum::{self, verify_checksum};
@@ -344,7 +344,7 @@ impl<Pk: MiniscriptKey> Tr<Pk> {
 
 impl<Pk: MiniscriptKey + ToPublicKey> Tr<Pk> {
     /// Obtains the corresponding script pubkey for this descriptor.
-    pub fn script_pubkey(&self) -> Script {
+    pub fn script_pubkey(&self) -> ScriptBuf {
         let output_key = self.spend_info().output_key();
         let builder = bitcoin::blockdata::script::Builder::new();
         builder
@@ -362,7 +362,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Tr<Pk> {
     /// Returns satisfying non-malleable witness and scriptSig with minimum
     /// weight to spend an output controlled by the given descriptor if it is
     /// possible to construct one using the `satisfier`.
-    pub fn get_satisfaction<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, Script), Error>
+    pub fn get_satisfaction<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error>
     where
         S: Satisfier<Pk>,
     {
@@ -372,7 +372,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Tr<Pk> {
     /// Returns satisfying, possibly malleable, witness and scriptSig with
     /// minimum weight to spend an output controlled by the given descriptor if
     /// it is possible to construct one using the `satisfier`.
-    pub fn get_satisfaction_mall<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, Script), Error>
+    pub fn get_satisfaction_mall<S>(&self, satisfier: S) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error>
     where
         S: Satisfier<Pk>,
     {
@@ -660,7 +660,7 @@ fn best_tap_spend<Pk, S>(
     desc: &Tr<Pk>,
     satisfier: S,
     allow_mall: bool,
-) -> Result<(Vec<Vec<u8>>, Script), Error>
+) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error>
 where
     Pk: ToPublicKey,
     S: Satisfier<Pk>,
@@ -668,7 +668,7 @@ where
     let spend_info = desc.spend_info();
     // First try the key spend path
     if let Some(sig) = satisfier.lookup_tap_key_spend_sig() {
-        Ok((vec![sig.to_vec()], Script::new()))
+        Ok((vec![sig.to_vec()], ScriptBuf::new()))
     } else {
         // Since we have the complete descriptor we can ignore the satisfier. We don't use the control block
         // map (lookup_control_block) from the satisfier here.
@@ -709,7 +709,7 @@ where
             }
         }
         match min_wit {
-            Some(wit) => Ok((wit, Script::new())),
+            Some(wit) => Ok((wit, ScriptBuf::new())),
             None => Err(Error::CouldNotSatisfy), // Could not satisfy all miniscripts inside Tr
         }
     }

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -6,9 +6,8 @@ use core::fmt;
 use std::error;
 
 use bitcoin::hashes::hash160;
-use bitcoin::hashes::hex::ToHex;
-use bitcoin::util::taproot;
-use bitcoin::{self, secp256k1};
+use bitcoin::hex::DisplayHex;
+use bitcoin::{secp256k1, taproot};
 
 use super::BitcoinKey;
 use crate::prelude::*;
@@ -31,8 +30,8 @@ pub enum Error {
     ControlBlockVerificationError,
     /// General Interpreter error.
     CouldNotEvaluate,
-    /// EcdsaSig related error
-    EcdsaSig(bitcoin::EcdsaSigError),
+    /// ECDSA Signature related error
+    EcdsaSig(bitcoin::crypto::ecdsa::Error),
     /// We expected a push (including a `OP_1` but no other numeric pushes)
     ExpectedPush,
     /// The preimage to the hash function must be exactly 32 bytes.
@@ -52,7 +51,7 @@ pub enum Error {
     /// ecdsa Signature failed to verify
     InvalidEcdsaSignature(bitcoin::PublicKey),
     /// Signature failed to verify
-    InvalidSchnorrSignature(bitcoin::XOnlyPublicKey),
+    InvalidSchnorrSignature(bitcoin::key::XOnlyPublicKey),
     /// Last byte of this signature isn't a standard sighash type
     NonStandardSighash(Vec<u8>),
     /// Miniscript error
@@ -90,9 +89,9 @@ pub enum Error {
     /// Miniscript requires the entire top level script to be satisfied.
     ScriptSatisfactionError,
     /// Schnorr Signature error
-    SchnorrSig(bitcoin::SchnorrSigError),
-    /// Errors in signature hash calculations
-    SighashError(bitcoin::util::sighash::Error),
+    SchnorrSig(bitcoin::crypto::taproot::Error),
+    /// Errors in signaturpe hash calculations
+    SighashError(bitcoin::sighash::Error),
     /// Taproot Annex Unsupported
     TapAnnexUnsupported,
     /// An uncompressed public key was encountered in a context where it is
@@ -143,15 +142,15 @@ impl fmt::Display for Error {
             Error::InsufficientSignaturesMultiSig => f.write_str("Insufficient signatures for CMS"),
             Error::InvalidSchnorrSighashType(ref sig) => write!(
                 f,
-                "Invalid sighash type for schnorr signature '{}'",
-                sig.to_hex()
+                "Invalid sighash type for schnorr signature '{:x}'",
+                sig.as_hex()
             ),
             Error::InvalidEcdsaSignature(pk) => write!(f, "bad ecdsa signature with pk {}", pk),
             Error::InvalidSchnorrSignature(pk) => write!(f, "bad schnorr signature with pk {}", pk),
             Error::NonStandardSighash(ref sig) => write!(
                 f,
-                "Non standard sighash type for signature '{}'",
-                sig.to_hex()
+                "Non standard sighash type for signature '{:x}'",
+                sig.as_hex()
             ),
             Error::NonEmptyWitness => f.write_str("legacy spend had nonempty witness"),
             Error::NonEmptyScriptSig => f.write_str("segwit spend had nonempty scriptsig"),
@@ -243,22 +242,22 @@ impl From<secp256k1::Error> for Error {
 }
 
 #[doc(hidden)]
-impl From<bitcoin::util::sighash::Error> for Error {
-    fn from(e: bitcoin::util::sighash::Error) -> Error {
+impl From<bitcoin::crypto::sighash::Error> for Error {
+    fn from(e: bitcoin::crypto::sighash::Error) -> Error {
         Error::SighashError(e)
     }
 }
 
 #[doc(hidden)]
-impl From<bitcoin::EcdsaSigError> for Error {
-    fn from(e: bitcoin::EcdsaSigError) -> Error {
+impl From<bitcoin::crypto::ecdsa::Error> for Error {
+    fn from(e: bitcoin::crypto::ecdsa::Error) -> Error {
         Error::EcdsaSig(e)
     }
 }
 
 #[doc(hidden)]
-impl From<bitcoin::SchnorrSigError> for Error {
-    fn from(e: bitcoin::SchnorrSigError) -> Error {
+impl From<bitcoin::crypto::taproot::Error> for Error {
+    fn from(e: bitcoin::crypto::taproot::Error) -> Error {
         Error::SchnorrSig(e)
     }
 }
@@ -277,7 +276,7 @@ pub enum PkEvalErrInner {
     /// Full Key
     FullKey(bitcoin::PublicKey),
     /// XOnly Key
-    XOnlyKey(bitcoin::XOnlyPublicKey),
+    XOnlyKey(bitcoin::key::XOnlyPublicKey),
 }
 
 impl From<BitcoinKey> for PkEvalErrInner {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -11,10 +11,8 @@
 use core::fmt;
 use core::str::FromStr;
 
-use bitcoin::blockdata::witness::Witness;
-use bitcoin::hashes::{hash160, ripemd160, sha256};
-use bitcoin::util::{sighash, taproot};
-use bitcoin::{self, secp256k1, LockTime, Sequence, TxOut};
+use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
+use bitcoin::{absolute, secp256k1, sighash, taproot, Sequence, TxOut, Witness};
 
 use crate::miniscript::context::{NoChecks, SigType};
 use crate::miniscript::ScriptContext;
@@ -36,9 +34,9 @@ pub struct Interpreter<'txin> {
     stack: Stack<'txin>,
     /// For non-Taproot spends, the scriptCode; for Taproot script-spends, this
     /// is the leaf script; for key-spends it is `None`.
-    script_code: Option<bitcoin::Script>,
+    script_code: Option<bitcoin::ScriptBuf>,
     age: Sequence,
-    lock_time: LockTime,
+    lock_time: absolute::LockTime,
 }
 
 // A type representing functions for checking signatures that accept both
@@ -48,22 +46,22 @@ pub struct Interpreter<'txin> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeySigPair {
     /// A Full public key and corresponding Ecdsa signature
-    Ecdsa(bitcoin::PublicKey, bitcoin::EcdsaSig),
+    Ecdsa(bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature),
     /// A x-only key and corresponding Schnorr signature
-    Schnorr(bitcoin::XOnlyPublicKey, bitcoin::SchnorrSig),
+    Schnorr(bitcoin::key::XOnlyPublicKey, bitcoin::crypto::taproot::Signature),
 }
 
 impl KeySigPair {
     /// Obtain a pair of ([`bitcoin::PublicKey`], [`bitcoin::EcdsaSig`]) from [`KeySigPair`]
-    pub fn as_ecdsa(&self) -> Option<(bitcoin::PublicKey, bitcoin::EcdsaSig)> {
+    pub fn as_ecdsa(&self) -> Option<(bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature)> {
         match self {
             KeySigPair::Ecdsa(pk, sig) => Some((*pk, *sig)),
             KeySigPair::Schnorr(_, _) => None,
         }
     }
 
-    /// Obtain a pair of ([`bitcoin::XOnlyPublicKey`], [`bitcoin::SchnorrSig`]) from [`KeySigPair`]
-    pub fn as_schnorr(&self) -> Option<(bitcoin::XOnlyPublicKey, bitcoin::SchnorrSig)> {
+    /// Obtain a pair of ([`bitcoin::XOnlyPublicKey`], [`bitcoin::crypto::taproot::Signature`]) from [`KeySigPair`]
+    pub fn as_schnorr(&self) -> Option<(bitcoin::key::XOnlyPublicKey, bitcoin::crypto::taproot::Signature)> {
         match self {
             KeySigPair::Ecdsa(_, _) => None,
             KeySigPair::Schnorr(pk, sig) => Some((*pk, *sig)),
@@ -88,7 +86,7 @@ enum BitcoinKey {
     // Full key
     Fullkey(bitcoin::PublicKey),
     // Xonly key
-    XOnlyPublicKey(bitcoin::XOnlyPublicKey),
+    XOnlyPublicKey(bitcoin::key::XOnlyPublicKey),
 }
 
 impl BitcoinKey {
@@ -116,8 +114,8 @@ impl From<bitcoin::PublicKey> for BitcoinKey {
     }
 }
 
-impl From<bitcoin::XOnlyPublicKey> for BitcoinKey {
-    fn from(xpk: bitcoin::XOnlyPublicKey) -> Self {
+impl From<bitcoin::key::XOnlyPublicKey> for BitcoinKey {
+    fn from(xpk: bitcoin::key::XOnlyPublicKey) -> Self {
         BitcoinKey::XOnlyPublicKey(xpk)
     }
 }
@@ -141,11 +139,11 @@ impl<'txin> Interpreter<'txin> {
     /// function; otherwise, it should be a closure containing a sighash and
     /// secp context, which can actually verify a given signature.
     pub fn from_txdata(
-        spk: &bitcoin::Script,
+        spk: &bitcoin::ScriptBuf,
         script_sig: &'txin bitcoin::Script,
         witness: &'txin Witness,
         age: Sequence,       // CSV, relative lock time.
-        lock_time: LockTime, // CLTV, absolute lock time.
+        lock_time: absolute::LockTime, // CLTV, absolute lock time.
     ) -> Result<Self, Error> {
         let (inner, stack, script_code) = inner::from_txdata(spk, script_sig, witness)?;
         Ok(Interpreter {
@@ -222,25 +220,26 @@ impl<'txin> Interpreter<'txin> {
                 sighash::Prevouts::All(prevouts) => prevouts.get(input_index),
             }
         }
-        let mut cache = bitcoin::util::sighash::SighashCache::new(tx);
+        let mut cache = bitcoin::sighash::SighashCache::new(tx);
         match sig {
             KeySigPair::Ecdsa(key, ecdsa_sig) => {
                 let script_pubkey = self.script_code.as_ref().expect("Legacy have script code");
-                let sighash = if self.is_legacy() {
+                let msg = if self.is_legacy() {
                     let sighash_u32 = ecdsa_sig.hash_ty.to_u32();
-                    cache.legacy_signature_hash(input_idx, script_pubkey, sighash_u32)
+                    let sighash = cache.legacy_signature_hash(input_idx, script_pubkey, sighash_u32);
+                    sighash.map(|hash| secp256k1::Message::from_slice(hash.as_inner()).expect("32 byte"))
                 } else if self.is_segwit_v0() {
                     let amt = match get_prevout(prevouts, input_idx) {
                         Some(txout) => txout.borrow().value,
                         None => return false,
                     };
-                    cache.segwit_signature_hash(input_idx, script_pubkey, amt, ecdsa_sig.hash_ty)
+                    let sighash = cache.segwit_signature_hash(input_idx, script_pubkey, amt, ecdsa_sig.hash_ty);
+                    sighash.map(|hash| secp256k1::Message::from_slice(hash.as_inner()).expect("32 byte"))
                 } else {
                     // taproot(or future) signatures in segwitv0 context
                     return false;
                 };
-                let msg =
-                    sighash.map(|hash| secp256k1::Message::from_slice(&hash).expect("32 byte"));
+
                 let success =
                     msg.map(|msg| secp.verify_ecdsa(&msg, &ecdsa_sig.sig, &key.inner).is_ok());
                 success.unwrap_or(false) // unwrap_or checks for errors, while success would have checksig results
@@ -268,7 +267,7 @@ impl<'txin> Interpreter<'txin> {
                     return false;
                 };
                 let msg =
-                    sighash_msg.map(|hash| secp256k1::Message::from_slice(&hash).expect("32 byte"));
+                    sighash_msg.map(|hash| secp256k1::Message::from_slice(hash.as_inner()).expect("32 byte"));
                 let success =
                     msg.map(|msg| secp.verify_schnorr(&schnorr_sig.sig, &msg, xpk).is_ok());
                 success.unwrap_or(false) // unwrap_or_default checks for errors, while success would have checksig results
@@ -484,7 +483,7 @@ pub enum SatisfiedConstraint {
     ///Absolute Timelock for CLTV.
     AbsoluteTimelock {
         /// The value of Absolute timelock
-        n: LockTime,
+        n: absolute::LockTime,
     },
 }
 
@@ -520,7 +519,7 @@ pub struct Iter<'intp, 'txin: 'intp> {
     state: Vec<NodeEvaluationState<'intp>>,
     stack: Stack<'txin>,
     age: Sequence,
-    lock_time: LockTime,
+    lock_time: absolute::LockTime,
     has_errored: bool,
     sig_type: SigType,
 }
@@ -612,7 +611,7 @@ where
                 Terminal::After(ref n) => {
                     debug_assert_eq!(node_state.n_evaluated, 0);
                     debug_assert_eq!(node_state.n_satisfied, 0);
-                    let res = self.stack.evaluate_after(&n.into(), self.lock_time);
+                    let res = self.stack.evaluate_after(&absolute::LockTime::from(*n), self.lock_time);
                     if res.is_some() {
                         return res;
                     }
@@ -1012,7 +1011,7 @@ fn verify_sersig<'txin>(
 ) -> Result<KeySigPair, Error> {
     match pk {
         BitcoinKey::Fullkey(pk) => {
-            let ecdsa_sig = bitcoin::EcdsaSig::from_slice(sigser)?;
+            let ecdsa_sig = bitcoin::crypto::ecdsa::Signature::from_slice(sigser)?;
             let key_sig_pair = KeySigPair::Ecdsa(*pk, ecdsa_sig);
             if verify_sig(&key_sig_pair) {
                 Ok(key_sig_pair)
@@ -1021,7 +1020,7 @@ fn verify_sersig<'txin>(
             }
         }
         BitcoinKey::XOnlyPublicKey(x_only_pk) => {
-            let schnorr_sig = bitcoin::SchnorrSig::from_slice(sigser)?;
+            let schnorr_sig = bitcoin::crypto::taproot::Signature::from_slice(sigser)?;
             let key_sig_pair = KeySigPair::Schnorr(*x_only_pk, schnorr_sig);
             if verify_sig(&key_sig_pair) {
                 Ok(key_sig_pair)
@@ -1050,11 +1049,11 @@ mod tests {
     ) -> (
         Vec<bitcoin::PublicKey>,
         Vec<Vec<u8>>,
-        Vec<bitcoin::EcdsaSig>,
+        Vec<bitcoin::crypto::ecdsa::Signature>,
         secp256k1::Message,
         Secp256k1<secp256k1::All>,
-        Vec<bitcoin::XOnlyPublicKey>,
-        Vec<bitcoin::SchnorrSig>,
+        Vec<bitcoin::key::XOnlyPublicKey>,
+        Vec<bitcoin::crypto::taproot::Signature>,
         Vec<Vec<u8>>,
     ) {
         let secp = secp256k1::Secp256k1::new();
@@ -1079,22 +1078,22 @@ mod tests {
                 compressed: true,
             };
             let sig = secp.sign_ecdsa(&msg, &sk);
-            ecdsa_sigs.push(bitcoin::EcdsaSig {
+            ecdsa_sigs.push(bitcoin::crypto::ecdsa::Signature {
                 sig,
-                hash_ty: bitcoin::EcdsaSighashType::All,
+                hash_ty: bitcoin::sighash::EcdsaSighashType::All,
             });
             let mut sigser = sig.serialize_der().to_vec();
             sigser.push(0x01); // sighash_all
             pks.push(pk);
             der_sigs.push(sigser);
 
-            let keypair = bitcoin::KeyPair::from_secret_key(&secp, &sk);
-            let (x_only_pk, _parity) = bitcoin::XOnlyPublicKey::from_keypair(&keypair);
+            let keypair = bitcoin::key::KeyPair::from_secret_key(&secp, &sk);
+            let (x_only_pk, _parity) = bitcoin::key::XOnlyPublicKey::from_keypair(&keypair);
             x_only_pks.push(x_only_pk);
             let schnorr_sig = secp.sign_schnorr_with_aux_rand(&msg, &keypair, &[0u8; 32]);
-            let schnorr_sig = bitcoin::SchnorrSig {
+            let schnorr_sig = bitcoin::crypto::taproot::Signature {
                 sig: schnorr_sig,
-                hash_ty: bitcoin::SchnorrSighashType::Default,
+                hash_ty: bitcoin::sighash::TapSighashType::Default,
             };
             ser_schnorr_sigs.push(schnorr_sig.to_vec());
             schnorr_sigs.push(schnorr_sig);
@@ -1140,7 +1139,7 @@ mod tests {
                     n_satisfied: 0,
                 }],
                 age: Sequence::from_height(1002),
-                lock_time: LockTime::from_height(1002).unwrap(),
+                lock_time: absolute::LockTime::from_height(1002).unwrap(),
                 has_errored: false,
                 sig_type: SigType::Ecdsa,
             }
@@ -1201,7 +1200,7 @@ mod tests {
         assert_eq!(
             after_satisfied.unwrap(),
             vec![SatisfiedConstraint::AbsoluteTimelock {
-                n: LockTime::from_height(1000).unwrap()
+                n: absolute::LockTime::from_height(1000).unwrap()
             }]
         );
 
@@ -1585,7 +1584,7 @@ mod tests {
     }
 
     fn x_only_no_checks_ms(ms: &str) -> Miniscript<BitcoinKey, NoChecks> {
-        let elem: Miniscript<bitcoin::XOnlyPublicKey, NoChecks> =
+        let elem: Miniscript<bitcoin::key::XOnlyPublicKey, NoChecks> =
             Miniscript::from_str_ext(ms, &ExtParams::allow_all()).unwrap();
         elem.to_no_checks_ms()
     }

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -11,9 +11,8 @@
 use core::fmt;
 use core::str::FromStr;
 
-use bitcoin::blockdata::{opcodes, script};
-use bitcoin::hashes::hash160;
-use bitcoin::{LockTime, Sequence};
+use bitcoin::{absolute, opcodes, script, Sequence};
+use bitcoin::hashes::{hash160, Hash};
 use sync::Arc;
 
 use crate::miniscript::context::SigType;
@@ -22,7 +21,7 @@ use crate::miniscript::ScriptContext;
 use crate::prelude::*;
 use crate::util::MsKeyBuilder;
 use crate::{
-    errstr, expression, script_num_size, Error, ForEachKey, Miniscript, MiniscriptKey, Terminal,
+    errstr, expression, script_num_size, AbsLockTime ,Error, ForEachKey, Miniscript, MiniscriptKey, Terminal,
     ToPublicKey, TranslatePk, Translator,
 };
 
@@ -453,7 +452,7 @@ impl_from_tree!(
             }
             ("pk_h", 1) => expression::terminal(&top.args[0], |x| Pk::from_str(x).map(Terminal::PkH)),
             ("after", 1) => expression::terminal(&top.args[0], |x| {
-                expression::parse_num(x).map(|x| Terminal::After(LockTime::from_consensus(x).into()))
+                expression::parse_num(x).map(|x| Terminal::After(AbsLockTime::from(absolute::LockTime::from_consensus(x))))
             }),
             ("older", 1) => expression::terminal(&top.args[0], |x| {
                 expression::parse_num(x).map(|x| Terminal::Older(Sequence::from_consensus(x)))
@@ -611,10 +610,10 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             Terminal::RawPkH(ref hash) => builder
                 .push_opcode(opcodes::all::OP_DUP)
                 .push_opcode(opcodes::all::OP_HASH160)
-                .push_slice(hash)
+                .push_slice(hash.as_inner())
                 .push_opcode(opcodes::all::OP_EQUALVERIFY),
             Terminal::After(t) => builder
-                .push_int(t.to_u32().into())
+                .push_int(absolute::LockTime::from(t).to_consensus_u32() as i64)
                 .push_opcode(opcodes::all::OP_CLTV),
             Terminal::Older(t) => builder
                 .push_int(t.to_consensus_u32().into())
@@ -624,28 +623,28 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
                 .push_int(32)
                 .push_opcode(opcodes::all::OP_EQUALVERIFY)
                 .push_opcode(opcodes::all::OP_SHA256)
-                .push_slice(&Pk::to_sha256(h))
+                .push_slice(Pk::to_sha256(h).as_inner())
                 .push_opcode(opcodes::all::OP_EQUAL),
             Terminal::Hash256(ref h) => builder
                 .push_opcode(opcodes::all::OP_SIZE)
                 .push_int(32)
                 .push_opcode(opcodes::all::OP_EQUALVERIFY)
                 .push_opcode(opcodes::all::OP_HASH256)
-                .push_slice(&Pk::to_hash256(h))
+                .push_slice(Pk::to_hash256(h).as_inner())
                 .push_opcode(opcodes::all::OP_EQUAL),
             Terminal::Ripemd160(ref h) => builder
                 .push_opcode(opcodes::all::OP_SIZE)
                 .push_int(32)
                 .push_opcode(opcodes::all::OP_EQUALVERIFY)
                 .push_opcode(opcodes::all::OP_RIPEMD160)
-                .push_slice(&Pk::to_ripemd160(h))
+                .push_slice(Pk::to_ripemd160(h).as_inner())
                 .push_opcode(opcodes::all::OP_EQUAL),
             Terminal::Hash160(ref h) => builder
                 .push_opcode(opcodes::all::OP_SIZE)
                 .push_int(32)
                 .push_opcode(opcodes::all::OP_EQUALVERIFY)
                 .push_opcode(opcodes::all::OP_HASH160)
-                .push_slice(&Pk::to_hash160(h))
+                .push_slice(Pk::to_hash160(h).as_inner())
                 .push_opcode(opcodes::all::OP_EQUAL),
             Terminal::True => builder.push_opcode(opcodes::OP_TRUE),
             Terminal::False => builder.push_opcode(opcodes::OP_FALSE),
@@ -751,7 +750,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
         match *self {
             Terminal::PkK(ref pk) => Ctx::pk_len(pk),
             Terminal::PkH(..) | Terminal::RawPkH(..) => 24,
-            Terminal::After(n) => script_num_size(n.to_u32() as usize) + 1,
+            Terminal::After(n) => script_num_size(n.to_consensus_u32() as usize) + 1,
             Terminal::Older(n) => script_num_size(n.to_consensus_u32() as usize) + 1,
             Terminal::Sha256(..) => 33 + 6,
             Terminal::Hash256(..) => 33 + 6,

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -5,8 +5,7 @@ use core::{fmt, hash};
 #[cfg(feature = "std")]
 use std::error;
 
-use bitcoin;
-use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
+use bitcoin::constants::MAX_BLOCK_WEIGHT;
 use bitcoin::hashes::{hash160, ripemd160, sha256};
 
 use super::decode::ParseableKey;

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -11,11 +11,12 @@ use core::marker::PhantomData;
 #[cfg(feature = "std")]
 use std::error;
 
-use bitcoin::blockdata::constants::MAX_BLOCK_WEIGHT;
+use bitcoin::constants::MAX_BLOCK_WEIGHT;
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
+use bitcoin::{Sequence};
+
 use sync::Arc;
 
-use crate::bitcoin::{LockTime, PackedLockTime, Sequence};
 use crate::miniscript::lex::{Token as Tk, TokenIter};
 use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
 use crate::miniscript::types::extra_props::ExtData;
@@ -24,7 +25,7 @@ use crate::miniscript::ScriptContext;
 use crate::prelude::*;
 #[cfg(doc)]
 use crate::Descriptor;
-use crate::{bitcoin, hash256, Error, Miniscript, MiniscriptKey, ToPublicKey};
+use crate::{bitcoin, hash256, AbsLockTime, Error, Miniscript, MiniscriptKey, ToPublicKey};
 
 fn return_none<T>(_: usize) -> Option<T> {
     None
@@ -53,7 +54,7 @@ impl ParseableKey for bitcoin::secp256k1::XOnlyPublicKey {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum KeyParseError {
     /// Bitcoin PublicKey parse error
-    FullKeyParseError(bitcoin::util::key::Error),
+    FullKeyParseError(bitcoin::key::Error),
     /// Xonly key parse Error
     XonlyKeyParseError(bitcoin::secp256k1::Error),
 }
@@ -141,7 +142,7 @@ pub enum Terminal<Pk: MiniscriptKey, Ctx: ScriptContext> {
     RawPkH(hash160::Hash),
     // timelocks
     /// `n CHECKLOCKTIMEVERIFY`
-    After(PackedLockTime),
+    After(AbsLockTime),
     /// `n CHECKSEQUENCEVERIFY`
     Older(Sequence),
     // hashlocks
@@ -396,7 +397,7 @@ pub fn parse<Ctx: ScriptContext>(
                     Tk::CheckSequenceVerify, Tk::Num(n)
                         => term.reduce0(Terminal::Older(Sequence::from_consensus(n)))?,
                     Tk::CheckLockTimeVerify, Tk::Num(n)
-                        => term.reduce0(Terminal::After(LockTime::from_consensus(n).into()))?,
+                        => term.reduce0(Terminal::After(AbsLockTime::from_consensus(n)))?,
                     // hashlocks
                     Tk::Equal => match_token!(
                         tokens,

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -221,20 +221,20 @@ pub fn lex(script: &'_ script::Script) -> Result<Vec<Token<'_>>, Error> {
             }
             script::Instruction::PushBytes(bytes) => {
                 match bytes.len() {
-                    20 => ret.push(Token::Hash20(bytes)),
-                    32 => ret.push(Token::Bytes32(bytes)),
-                    33 => ret.push(Token::Bytes33(bytes)),
-                    65 => ret.push(Token::Bytes65(bytes)),
+                    20 => ret.push(Token::Hash20(bytes.as_bytes())),
+                    32 => ret.push(Token::Bytes32(bytes.as_bytes())),
+                    33 => ret.push(Token::Bytes33(bytes.as_bytes())),
+                    65 => ret.push(Token::Bytes65(bytes.as_bytes())),
                     _ => {
-                        match script::read_scriptint(bytes) {
+                        match script::read_scriptint(bytes.as_bytes()) {
                             Ok(v) if v >= 0 => {
                                 // check minimality of the number
-                                if &script::Builder::new().push_int(v).into_script()[1..] != bytes {
-                                    return Err(Error::InvalidPush(bytes.to_owned()));
+                                if script::Builder::new().push_int(v).into_script()[1..].as_bytes() != bytes.as_bytes() {
+                                    return Err(Error::InvalidPush(bytes.to_vec()));
                                 }
                                 ret.push(Token::Num(v as u32));
                             }
-                            Ok(_) => return Err(Error::InvalidPush(bytes.to_owned())),
+                            Ok(_) => return Err(Error::InvalidPush(bytes.to_vec())),
                             Err(e) => return Err(Error::Script(e)),
                         }
                     }

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -16,8 +16,8 @@
 use core::marker::PhantomData;
 use core::{fmt, hash, str};
 
-use bitcoin::blockdata::script;
-use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
+use bitcoin::script;
+use bitcoin::taproot::{LeafVersion, TapLeafHash};
 
 use self::analyzable::ExtParams;
 pub use self::context::{BareCtx, Legacy, Segwitv0, Tap};
@@ -221,7 +221,7 @@ where
     Ctx: ScriptContext,
 {
     /// Encode as a Bitcoin script
-    pub fn encode(&self) -> script::Script
+    pub fn encode(&self) -> script::ScriptBuf
     where
         Pk: ToPublicKey,
     {
@@ -1091,10 +1091,10 @@ mod tests {
                 &self,
                 _pk: &Pk,
                 _h: &TapLeafHash,
-            ) -> Option<bitcoin::SchnorrSig> {
-                Some(bitcoin::SchnorrSig {
+            ) -> Option<bitcoin::crypto::taproot::Signature> {
+                Some(bitcoin::crypto::taproot::Signature {
                     sig: self.0,
-                    hash_ty: bitcoin::SchnorrSighashType::Default,
+                    hash_ty: bitcoin::sighash::TapSighashType::Default,
                 })
             }
         }

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -10,9 +10,10 @@
 use core::{cmp, i64, mem};
 
 use bitcoin::hashes::hash160;
-use bitcoin::secp256k1::XOnlyPublicKey;
-use bitcoin::util::taproot::{ControlBlock, LeafVersion, TapLeafHash};
-use bitcoin::{LockTime, Sequence};
+use bitcoin::key::XOnlyPublicKey;
+use bitcoin::taproot::{ControlBlock, LeafVersion, TapLeafHash};
+use bitcoin::{absolute, Sequence};
+
 use sync::Arc;
 
 use super::context::SigType;
@@ -28,24 +29,24 @@ pub type Preimage32 = [u8; 32];
 /// have data for.
 pub trait Satisfier<Pk: MiniscriptKey + ToPublicKey> {
     /// Given a public key, look up an ECDSA signature with that key
-    fn lookup_ecdsa_sig(&self, _: &Pk) -> Option<bitcoin::EcdsaSig> {
+    fn lookup_ecdsa_sig(&self, _: &Pk) -> Option<bitcoin::crypto::ecdsa::Signature> {
         None
     }
 
     /// Lookup the tap key spend sig
-    fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::SchnorrSig> {
+    fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::crypto::taproot::Signature> {
         None
     }
 
     /// Given a public key and a associated leaf hash, look up an schnorr signature with that key
-    fn lookup_tap_leaf_script_sig(&self, _: &Pk, _: &TapLeafHash) -> Option<bitcoin::SchnorrSig> {
+    fn lookup_tap_leaf_script_sig(&self, _: &Pk, _: &TapLeafHash) -> Option<bitcoin::crypto::taproot::Signature> {
         None
     }
 
     /// Obtain a reference to the control block for a ver and script
     fn lookup_tap_control_block_map(
         &self,
-    ) -> Option<&BTreeMap<ControlBlock, (bitcoin::Script, LeafVersion)>> {
+    ) -> Option<&BTreeMap<ControlBlock, (bitcoin::ScriptBuf, LeafVersion)>> {
         None
     }
 
@@ -66,7 +67,7 @@ pub trait Satisfier<Pk: MiniscriptKey + ToPublicKey> {
     fn lookup_raw_pkh_ecdsa_sig(
         &self,
         _: &hash160::Hash,
-    ) -> Option<(bitcoin::PublicKey, bitcoin::EcdsaSig)> {
+    ) -> Option<(bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature)> {
         None
     }
 
@@ -77,7 +78,7 @@ pub trait Satisfier<Pk: MiniscriptKey + ToPublicKey> {
     fn lookup_raw_pkh_tap_leaf_script_sig(
         &self,
         _: &(hash160::Hash, TapLeafHash),
-    ) -> Option<(XOnlyPublicKey, bitcoin::SchnorrSig)> {
+    ) -> Option<(XOnlyPublicKey, bitcoin::crypto::taproot::Signature)> {
         None
     }
 
@@ -107,7 +108,7 @@ pub trait Satisfier<Pk: MiniscriptKey + ToPublicKey> {
     }
 
     /// Assert whether a absolute locktime is satisfied
-    fn check_after(&self, _: LockTime) -> bool {
+    fn check_after(&self, _: absolute::LockTime) -> bool {
         false
     }
 }
@@ -139,9 +140,9 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for Sequence {
     }
 }
 
-impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for LockTime {
-    fn check_after(&self, n: LockTime) -> bool {
-        use LockTime::*;
+impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for absolute::LockTime {
+    fn check_after(&self, n: absolute::LockTime) -> bool {
+        use absolute::LockTime::*;
 
         match (n, *self) {
             (Blocks(n), Blocks(lock_time)) => n <= lock_time,
@@ -150,16 +151,16 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for LockTime {
         }
     }
 }
-impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for HashMap<Pk, bitcoin::EcdsaSig> {
-    fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::EcdsaSig> {
+impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for HashMap<Pk, bitcoin::crypto::ecdsa::Signature> {
+    fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::crypto::ecdsa::Signature> {
         self.get(key).copied()
     }
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>
-    for HashMap<(Pk, TapLeafHash), bitcoin::SchnorrSig>
+    for HashMap<(Pk, TapLeafHash), bitcoin::crypto::taproot::Signature>
 {
-    fn lookup_tap_leaf_script_sig(&self, key: &Pk, h: &TapLeafHash) -> Option<bitcoin::SchnorrSig> {
+    fn lookup_tap_leaf_script_sig(&self, key: &Pk, h: &TapLeafHash) -> Option<bitcoin::crypto::taproot::Signature> {
         // Unfortunately, there is no way to get a &(a, b) from &a and &b without allocating
         // If we change the signature the of lookup_tap_leaf_script_sig to accept a tuple. We would
         // face the same problem while satisfying PkK.
@@ -169,11 +170,11 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>
-    for HashMap<hash160::Hash, (Pk, bitcoin::EcdsaSig)>
+    for HashMap<hash160::Hash, (Pk, bitcoin::crypto::ecdsa::Signature)>
 where
     Pk: MiniscriptKey + ToPublicKey,
 {
-    fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::EcdsaSig> {
+    fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::crypto::ecdsa::Signature> {
         self.get(&key.to_pubkeyhash(SigType::Ecdsa)).map(|x| x.1)
     }
 
@@ -184,18 +185,18 @@ where
     fn lookup_raw_pkh_ecdsa_sig(
         &self,
         pk_hash: &hash160::Hash,
-    ) -> Option<(bitcoin::PublicKey, bitcoin::EcdsaSig)> {
+    ) -> Option<(bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature)> {
         self.get(pk_hash)
             .map(|&(ref pk, sig)| (pk.to_public_key(), sig))
     }
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>
-    for HashMap<(hash160::Hash, TapLeafHash), (Pk, bitcoin::SchnorrSig)>
+    for HashMap<(hash160::Hash, TapLeafHash), (Pk, bitcoin::crypto::taproot::Signature)>
 where
     Pk: MiniscriptKey + ToPublicKey,
 {
-    fn lookup_tap_leaf_script_sig(&self, key: &Pk, h: &TapLeafHash) -> Option<bitcoin::SchnorrSig> {
+    fn lookup_tap_leaf_script_sig(&self, key: &Pk, h: &TapLeafHash) -> Option<bitcoin::crypto::taproot::Signature> {
         self.get(&(key.to_pubkeyhash(SigType::Schnorr), *h))
             .map(|x| x.1)
     }
@@ -203,18 +204,18 @@ where
     fn lookup_raw_pkh_tap_leaf_script_sig(
         &self,
         pk_hash: &(hash160::Hash, TapLeafHash),
-    ) -> Option<(XOnlyPublicKey, bitcoin::SchnorrSig)> {
+    ) -> Option<(XOnlyPublicKey, bitcoin::crypto::taproot::Signature)> {
         self.get(pk_hash)
             .map(|&(ref pk, sig)| (pk.to_x_only_pubkey(), sig))
     }
 }
 
 impl<'a, Pk: MiniscriptKey + ToPublicKey, S: Satisfier<Pk>> Satisfier<Pk> for &'a S {
-    fn lookup_ecdsa_sig(&self, p: &Pk) -> Option<bitcoin::EcdsaSig> {
+    fn lookup_ecdsa_sig(&self, p: &Pk) -> Option<bitcoin::crypto::ecdsa::Signature> {
         (**self).lookup_ecdsa_sig(p)
     }
 
-    fn lookup_tap_leaf_script_sig(&self, p: &Pk, h: &TapLeafHash) -> Option<bitcoin::SchnorrSig> {
+    fn lookup_tap_leaf_script_sig(&self, p: &Pk, h: &TapLeafHash) -> Option<bitcoin::crypto::taproot::Signature> {
         (**self).lookup_tap_leaf_script_sig(p, h)
     }
 
@@ -229,24 +230,24 @@ impl<'a, Pk: MiniscriptKey + ToPublicKey, S: Satisfier<Pk>> Satisfier<Pk> for &'
     fn lookup_raw_pkh_ecdsa_sig(
         &self,
         pkh: &hash160::Hash,
-    ) -> Option<(bitcoin::PublicKey, bitcoin::EcdsaSig)> {
+    ) -> Option<(bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature)> {
         (**self).lookup_raw_pkh_ecdsa_sig(pkh)
     }
 
-    fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::SchnorrSig> {
+    fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::crypto::taproot::Signature> {
         (**self).lookup_tap_key_spend_sig()
     }
 
     fn lookup_raw_pkh_tap_leaf_script_sig(
         &self,
         pkh: &(hash160::Hash, TapLeafHash),
-    ) -> Option<(XOnlyPublicKey, bitcoin::SchnorrSig)> {
+    ) -> Option<(XOnlyPublicKey, bitcoin::crypto::taproot::Signature)> {
         (**self).lookup_raw_pkh_tap_leaf_script_sig(pkh)
     }
 
     fn lookup_tap_control_block_map(
         &self,
-    ) -> Option<&BTreeMap<ControlBlock, (bitcoin::Script, LeafVersion)>> {
+    ) -> Option<&BTreeMap<ControlBlock, (bitcoin::ScriptBuf, LeafVersion)>> {
         (**self).lookup_tap_control_block_map()
     }
 
@@ -270,21 +271,21 @@ impl<'a, Pk: MiniscriptKey + ToPublicKey, S: Satisfier<Pk>> Satisfier<Pk> for &'
         (**self).check_older(t)
     }
 
-    fn check_after(&self, n: LockTime) -> bool {
+    fn check_after(&self, n: absolute::LockTime) -> bool {
         (**self).check_after(n)
     }
 }
 
 impl<'a, Pk: MiniscriptKey + ToPublicKey, S: Satisfier<Pk>> Satisfier<Pk> for &'a mut S {
-    fn lookup_ecdsa_sig(&self, p: &Pk) -> Option<bitcoin::EcdsaSig> {
+    fn lookup_ecdsa_sig(&self, p: &Pk) -> Option<bitcoin::crypto::ecdsa::Signature> {
         (**self).lookup_ecdsa_sig(p)
     }
 
-    fn lookup_tap_leaf_script_sig(&self, p: &Pk, h: &TapLeafHash) -> Option<bitcoin::SchnorrSig> {
+    fn lookup_tap_leaf_script_sig(&self, p: &Pk, h: &TapLeafHash) -> Option<bitcoin::crypto::taproot::Signature> {
         (**self).lookup_tap_leaf_script_sig(p, h)
     }
 
-    fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::SchnorrSig> {
+    fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::crypto::taproot::Signature> {
         (**self).lookup_tap_key_spend_sig()
     }
 
@@ -299,20 +300,20 @@ impl<'a, Pk: MiniscriptKey + ToPublicKey, S: Satisfier<Pk>> Satisfier<Pk> for &'
     fn lookup_raw_pkh_ecdsa_sig(
         &self,
         pkh: &hash160::Hash,
-    ) -> Option<(bitcoin::PublicKey, bitcoin::EcdsaSig)> {
+    ) -> Option<(bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature)> {
         (**self).lookup_raw_pkh_ecdsa_sig(pkh)
     }
 
     fn lookup_raw_pkh_tap_leaf_script_sig(
         &self,
         pkh: &(hash160::Hash, TapLeafHash),
-    ) -> Option<(XOnlyPublicKey, bitcoin::SchnorrSig)> {
+    ) -> Option<(XOnlyPublicKey, bitcoin::crypto::taproot::Signature)> {
         (**self).lookup_raw_pkh_tap_leaf_script_sig(pkh)
     }
 
     fn lookup_tap_control_block_map(
         &self,
-    ) -> Option<&BTreeMap<ControlBlock, (bitcoin::Script, LeafVersion)>> {
+    ) -> Option<&BTreeMap<ControlBlock, (bitcoin::ScriptBuf, LeafVersion)>> {
         (**self).lookup_tap_control_block_map()
     }
 
@@ -336,7 +337,7 @@ impl<'a, Pk: MiniscriptKey + ToPublicKey, S: Satisfier<Pk>> Satisfier<Pk> for &'
         (**self).check_older(t)
     }
 
-    fn check_after(&self, n: LockTime) -> bool {
+    fn check_after(&self, n: absolute::LockTime) -> bool {
         (**self).check_after(n)
     }
 }
@@ -349,7 +350,7 @@ macro_rules! impl_tuple_satisfier {
             Pk: MiniscriptKey + ToPublicKey,
             $($ty: Satisfier< Pk>,)*
         {
-            fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::EcdsaSig> {
+            fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::crypto::ecdsa::Signature> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_ecdsa_sig(key) {
@@ -359,7 +360,7 @@ macro_rules! impl_tuple_satisfier {
                 None
             }
 
-            fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::SchnorrSig> {
+            fn lookup_tap_key_spend_sig(&self) -> Option<bitcoin::crypto::taproot::Signature> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_tap_key_spend_sig() {
@@ -369,7 +370,7 @@ macro_rules! impl_tuple_satisfier {
                 None
             }
 
-            fn lookup_tap_leaf_script_sig(&self, key: &Pk, h: &TapLeafHash) -> Option<bitcoin::SchnorrSig> {
+            fn lookup_tap_leaf_script_sig(&self, key: &Pk, h: &TapLeafHash) -> Option<bitcoin::crypto::taproot::Signature> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_tap_leaf_script_sig(key, h) {
@@ -382,7 +383,7 @@ macro_rules! impl_tuple_satisfier {
             fn lookup_raw_pkh_ecdsa_sig(
                 &self,
                 key_hash: &hash160::Hash,
-            ) -> Option<(bitcoin::PublicKey, bitcoin::EcdsaSig)> {
+            ) -> Option<(bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature)> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_raw_pkh_ecdsa_sig(key_hash) {
@@ -395,7 +396,7 @@ macro_rules! impl_tuple_satisfier {
             fn lookup_raw_pkh_tap_leaf_script_sig(
                 &self,
                 key_hash: &(hash160::Hash, TapLeafHash),
-            ) -> Option<(XOnlyPublicKey, bitcoin::SchnorrSig)> {
+            ) -> Option<(XOnlyPublicKey, bitcoin::crypto::taproot::Signature)> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_raw_pkh_tap_leaf_script_sig(key_hash) {
@@ -433,7 +434,7 @@ macro_rules! impl_tuple_satisfier {
 
             fn lookup_tap_control_block_map(
                 &self,
-            ) -> Option<&BTreeMap<ControlBlock, (bitcoin::Script, LeafVersion)>> {
+            ) -> Option<&BTreeMap<ControlBlock, (bitcoin::ScriptBuf, LeafVersion)>> {
                 let &($(ref $ty,)*) = self;
                 $(
                     if let Some(result) = $ty.lookup_tap_control_block_map() {
@@ -493,7 +494,7 @@ macro_rules! impl_tuple_satisfier {
                 false
             }
 
-            fn check_after(&self, n: LockTime) -> bool {
+            fn check_after(&self, n: absolute::LockTime) -> bool {
                 let &($(ref $ty,)*) = self;
                 $(
                     if $ty.check_after(n) {

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -6,7 +6,7 @@
 use core::cmp;
 use core::iter::once;
 
-use bitcoin::{LockTime, PackedLockTime, Sequence};
+use bitcoin::{absolute, Sequence};
 
 use super::{Error, ErrorKind, Property, ScriptContext};
 use crate::miniscript::context::SigType;
@@ -339,7 +339,7 @@ impl Property for ExtData {
         unreachable!()
     }
 
-    fn from_after(t: LockTime) -> Self {
+    fn from_after(t: absolute::LockTime) -> Self {
         ExtData {
             pk_cost: script_num_size(t.to_consensus_u32() as usize) + 1,
             has_free_verify: false,
@@ -934,7 +934,7 @@ impl Property for ExtData {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
                 // number on the stack would be a 5 bytes signed integer but Miniscript's B type
                 // only consumes 4 bytes from the stack.
-                if t == PackedLockTime::ZERO {
+                if t == absolute::LockTime::ZERO.into() {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -13,7 +13,7 @@ use core::fmt;
 #[cfg(feature = "std")]
 use std::error;
 
-use bitcoin::{LockTime, PackedLockTime, Sequence};
+use bitcoin::{absolute, Sequence};
 
 pub use self::correctness::{Base, Correctness, Input};
 pub use self::extra_props::ExtData;
@@ -293,7 +293,7 @@ pub trait Property: Sized {
 
     /// Type property of an absolute timelock. Default implementation simply
     /// passes through to `from_time`
-    fn from_after(t: LockTime) -> Self {
+    fn from_after(t: absolute::LockTime) -> Self {
         Self::from_time(t.to_consensus_u32())
     }
 
@@ -427,7 +427,7 @@ pub trait Property: Sized {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
                 // number on the stack would be a 5 bytes signed integer but Miniscript's B type
                 // only consumes 4 bytes from the stack.
-                if t == PackedLockTime::ZERO {
+                if t == absolute::LockTime::ZERO.into() {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,
@@ -614,7 +614,7 @@ impl Property for Type {
         }
     }
 
-    fn from_after(t: LockTime) -> Self {
+    fn from_after(t: absolute::LockTime) -> Self {
         Type {
             corr: Property::from_after(t),
             mall: Property::from_after(t),
@@ -810,7 +810,7 @@ impl Property for Type {
                 // Note that for CLTV this is a limitation not of Bitcoin but Miniscript. The
                 // number on the stack would be a 5 bytes signed integer but Miniscript's B type
                 // only consumes 4 bytes from the stack.
-                if t == PackedLockTime::ZERO {
+                if t == absolute::LockTime::ZERO.into() {
                     return Err(Error {
                         fragment: fragment.clone(),
                         error: ErrorKind::InvalidTime,

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1391,16 +1391,16 @@ mod tests {
         assert_eq!(abs.n_keys(), 5);
         assert_eq!(abs.minimum_n_keys(), Some(3));
 
-        let bitcoinsig = bitcoin::EcdsaSig {
+        let bitcoinsig = bitcoin::crypto::ecdsa::Signature {
             sig,
             hash_ty: bitcoin::EcdsaSighashType::All,
         };
         let sigvec = bitcoinsig.to_vec();
 
-        let no_sat = HashMap::<bitcoin::PublicKey, bitcoin::EcdsaSig>::new();
-        let mut left_sat = HashMap::<bitcoin::PublicKey, bitcoin::EcdsaSig>::new();
+        let no_sat = HashMap::<bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature>::new();
+        let mut left_sat = HashMap::<bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature>::new();
         let mut right_sat =
-            HashMap::<hashes::hash160::Hash, (bitcoin::PublicKey, bitcoin::EcdsaSig)>::new();
+            HashMap::<hashes::hash160::Hash, (bitcoin::PublicKey, bitcoin::crypto::ecdsa::Signature)>::new();
 
         for i in 0..5 {
             left_sat.insert(keys[i], bitcoinsig);

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -8,7 +8,8 @@ use core::{fmt, str};
 #[cfg(feature = "std")]
 use std::error;
 
-use bitcoin::{LockTime, PackedLockTime, Sequence};
+use bitcoin::{absolute, Sequence};
+
 #[cfg(feature = "compiler")]
 use {
     crate::descriptor::TapTree,
@@ -23,13 +24,13 @@ use {
     sync::Arc,
 };
 
-use super::ENTAILMENT_MAX_TERMINALS;
+use super::{ENTAILMENT_MAX_TERMINALS};
 use crate::expression::{self, FromTree};
 use crate::miniscript::types::extra_props::TimelockInfo;
 use crate::prelude::*;
 #[cfg(all(doc, not(feature = "compiler")))]
 use crate::Descriptor;
-use crate::{errstr, Error, ForEachKey, MiniscriptKey, Translator};
+use crate::{errstr, AbsLockTime, Error, ForEachKey, MiniscriptKey, Translator};
 
 /// Maximum TapLeafs allowed in a compiled TapTree
 #[cfg(feature = "compiler")]
@@ -47,7 +48,7 @@ pub enum Policy<Pk: MiniscriptKey> {
     /// A public key which must sign to satisfy the descriptor
     Key(Pk),
     /// An absolute locktime restriction
-    After(PackedLockTime),
+    After(AbsLockTime),
     /// A relative locktime restriction
     Older(Sequence),
     /// A SHA256 whose preimage must be provided to satisfy the descriptor
@@ -72,9 +73,9 @@ where
     Pk: MiniscriptKey,
 {
     /// Construct a `Policy::After` from `n`. Helper function equivalent to
-    /// `Policy::After(PackedLockTime::from(LockTime::from_consensus(n)))`.
+    /// `Policy::After(absolute::LockTime::from_consensus(n))`.
     pub fn after(n: u32) -> Policy<Pk> {
-        Policy::After(PackedLockTime::from(LockTime::from_consensus(n)))
+        Policy::After(AbsLockTime::from(absolute::LockTime::from_consensus(n)))
     }
 
     /// Construct a `Policy::Older` from `n`. Helper function equivalent to
@@ -97,7 +98,7 @@ enum PolicyArc<Pk: MiniscriptKey> {
     /// A public key which must sign to satisfy the descriptor
     Key(Pk),
     /// An absolute locktime restriction
-    After(u32),
+    After(AbsLockTime),
     /// A relative locktime restriction
     Older(u32),
     /// A SHA256 whose preimage must be provided to satisfy the descriptor
@@ -124,7 +125,7 @@ impl<Pk: MiniscriptKey> From<PolicyArc<Pk>> for Policy<Pk> {
             PolicyArc::Unsatisfiable => Policy::Unsatisfiable,
             PolicyArc::Trivial => Policy::Trivial,
             PolicyArc::Key(pk) => Policy::Key(pk),
-            PolicyArc::After(t) => Policy::After(PackedLockTime::from(LockTime::from_consensus(t))),
+            PolicyArc::After(t) => Policy::After(t),
             PolicyArc::Older(t) => Policy::Older(Sequence::from_consensus(t)),
             PolicyArc::Sha256(hash) => Policy::Sha256(hash),
             PolicyArc::Hash256(hash) => Policy::Hash256(hash),
@@ -157,7 +158,7 @@ impl<Pk: MiniscriptKey> From<Policy<Pk>> for PolicyArc<Pk> {
             Policy::Unsatisfiable => PolicyArc::Unsatisfiable,
             Policy::Trivial => PolicyArc::Trivial,
             Policy::Key(pk) => PolicyArc::Key(pk),
-            Policy::After(PackedLockTime(t)) => PolicyArc::After(t),
+            Policy::After(lock_time) => PolicyArc::After(lock_time),
             Policy::Older(Sequence(t)) => PolicyArc::Older(t),
             Policy::Sha256(hash) => PolicyArc::Sha256(hash),
             Policy::Hash256(hash) => PolicyArc::Hash256(hash),
@@ -874,8 +875,8 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             Policy::After(t) => TimelockInfo {
                 csv_with_height: false,
                 csv_with_time: false,
-                cltv_with_height: LockTime::from(t).is_block_height(),
-                cltv_with_time: LockTime::from(t).is_block_time(),
+                cltv_with_height: absolute::LockTime::from(t).is_block_height(),
+                cltv_with_time: absolute::LockTime::from(t).is_block_time(),
                 contains_combination: false,
             },
             Policy::Older(t) => TimelockInfo {
@@ -941,7 +942,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                 }
             }
             Policy::After(n) => {
-                if n == PackedLockTime::ZERO {
+                if n == absolute::LockTime::ZERO.into() {
                     Err(PolicyError::ZeroTime)
                 } else if n.to_u32() > 2u32.pow(31) {
                     Err(PolicyError::TimeTooFar)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use bitcoin::blockdata::script;
+use core::convert::TryFrom;
+
 use bitcoin::hashes::Hash;
-use bitcoin::{PubkeyHash, Script};
+use bitcoin::PubkeyHash;
+use bitcoin::script::{self, ScriptBuf, PushBytesBuf};
 
 use crate::miniscript::context;
 use crate::prelude::*;
@@ -16,13 +18,15 @@ pub(crate) fn witness_size(wit: &[Vec<u8>]) -> usize {
     wit.iter().map(Vec::len).sum::<usize>() + varint_len(wit.len())
 }
 
-pub(crate) fn witness_to_scriptsig(witness: &[Vec<u8>]) -> Script {
+pub(crate) fn witness_to_scriptsig(witness: &[Vec<u8>]) -> ScriptBuf {
     let mut b = script::Builder::new();
     for wit in witness {
         if let Ok(n) = script::read_scriptint(wit) {
             b = b.push_int(n);
         } else {
-            b = b.push_slice(wit);
+            // FIXME: There has to be a better way than this.
+            let push = PushBytesBuf::try_from(wit.clone()).expect("FIXME: Handle error");
+            b = b.push_slice(&push)
         }
     }
     b.into_script()

--- a/tests/test_cpp.rs
+++ b/tests/test_cpp.rs
@@ -184,7 +184,7 @@ pub fn test_from_cpp_ms(cl: &Client, testdata: &TestData) {
             let pk = pks[sks.iter().position(|&x| x == sk).unwrap()];
             psbts[i].inputs[0].partial_sigs.insert(
                 pk,
-                bitcoin::EcdsaSig {
+                bitcoin::crypto::ecdsa::Signature {
                     sig,
                     hash_ty: sighash_ty,
                 },

--- a/tests/test_desc.rs
+++ b/tests/test_desc.rs
@@ -15,7 +15,7 @@ use bitcoin::util::sighash::SighashCache;
 use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
 use bitcoin::util::{psbt, sighash};
 use bitcoin::{
-    self, secp256k1, Amount, LockTime, OutPoint, SchnorrSig, Script, Sequence, Transaction, TxIn,
+    self, secp256k1, Amount, LockTime, OutPoint, Script, Sequence, Transaction, TxIn,
     TxOut, Txid,
 };
 use bitcoind::bitcoincore_rpc::{json, Client, RpcApi};
@@ -180,7 +180,7 @@ pub fn test_desc_satisfy(
                 rand::thread_rng().fill_bytes(&mut aux_rand);
                 let schnorr_sig =
                     secp.sign_schnorr_with_aux_rand(&msg, &internal_keypair, &aux_rand);
-                psbt.inputs[0].tap_key_sig = Some(SchnorrSig {
+                psbt.inputs[0].tap_key_sig = Some(bitcoin::crypto::taproot::Signature {
                     sig: schnorr_sig,
                     hash_ty: hash_ty,
                 });
@@ -212,7 +212,7 @@ pub fn test_desc_satisfy(
                 let (x_only_pk, _parity) = secp256k1::XOnlyPublicKey::from_keypair(&keypair);
                 psbt.inputs[0].tap_script_sigs.insert(
                     (x_only_pk, leaf_hash),
-                    bitcoin::SchnorrSig {
+                    bitcoin::crypto::taproot::Signature {
                         sig,
                         hash_ty: hash_ty,
                     },
@@ -267,7 +267,7 @@ pub fn test_desc_satisfy(
                 assert!(secp.verify_ecdsa(&msg, &sig, &pk.inner).is_ok());
                 psbt.inputs[0].partial_sigs.insert(
                     pk,
-                    bitcoin::EcdsaSig {
+                    bitcoin::crypto::ecdsa::Signature {
                         sig,
                         hash_ty: hash_ty,
                     },


### PR DESCRIPTION
**This is not a merge candidate**

To get a feel for using the code we are about to release I hacked up an upgrade to something resembling the upcoming `rust-bitcoin` 0.30.0 release.

FTR I found this upgrade painful, some pain points were:

- API methods missing or hard to use (or I'm being braindead), specifically:
  - `PushBytes::to_vec()`
  - `script::Builder::push_script()` (to handle `PushBytes`)

- New paths/re-exports don't match with current usage i.e., here in miniscript we tend to include `bitcoin::` on types, this upgrade removed a few types from the crate root so now we have long fully qualified paths instead e.g., `bitcoin::crypto::ecdsa::Signature` instead of `bitcoin::EcdsaSig`.

- The "don't implement `Ord` thing" from `absolute::LockTime` means we need some way to order absolute lock times, here we use a wrapper type.