### PR TITLE
Add build error and README docs for proper use of std and no-std features

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ coins in a given Bitcoin transaction
 More information can be found in [the documentation](https://docs.rs/miniscript)
 or in [the `examples/` directory](https://github.com/apoelstra/rust-miniscript/tree/master/examples)
 
+## Building
+
+The cargo feature `std` is enabled by default. At least one of the features `std` or `no-std` or both must be enabled.
+
+Enabling the `no-std` feature does not disable `std`. To disable the `std` feature you must disable default features. The `no-std` feature only enables additional features required for this crate to be usable without `std`. Both can be enabled without conflict.
 
 ## Minimum Supported Rust Version (MSRV)
 This library should always compile with any combination of features (minus

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ compile_error!(
     "rust-miniscript currently only supports architectures with pointers wider than 16 bits"
 );
 
+#[cfg(not(any(feature = "std", feature = "no-std")))]
+compile_error!("at least one of the `std` or `no-std` features must be enabled");
+
 pub use bitcoin;
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Building this crate requires the std and/or no-std features be enabled. This PR documents this build constraint in the README and gives an error is anyone tries to build without enabling one or both of these features.

See discussion in #533.