### PR TITLE
Various fixes for Nix compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,7 @@ required-features = ["compiler","std"]
 [[example]]
 name = "psbt_sign_finalize"
 required-features = ["std", "base64"]
+
+[workspace]
+members = ["bitcoind-tests", "fuzz"]
+exclude = ["embedded"]

--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "bitcoind-tests"
 version = "0.1.0"
 authors = ["sanket1729 <sanket1729@gmail.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/bitcoind-tests/tests/setup/mod.rs
+++ b/bitcoind-tests/tests/setup/mod.rs
@@ -18,7 +18,10 @@ pub fn setup() -> BitcoinD {
             }
         }
 
-        let bitcoind_path = root_path.join("bitcoind-tests").join("bin").join("bitcoind");
+        let bitcoind_path = root_path
+            .join("bitcoind-tests")
+            .join("bin")
+            .join("bitcoind");
         std::env::set_var(key, bitcoind_path);
     }
 

--- a/bitcoind-tests/tests/setup/mod.rs
+++ b/bitcoind-tests/tests/setup/mod.rs
@@ -10,9 +10,11 @@ pub mod test_util;
 pub fn setup() -> BitcoinD {
     // Create env var BITCOIND_EXE_PATH to point to the ../bitcoind/bin/bitcoind binary
     let key = "BITCOIND_EXE";
-    let curr_dir_path = std::env::current_dir().unwrap();
-    let bitcoind_path = curr_dir_path.join("bin").join("bitcoind");
-    std::env::set_var(key, bitcoind_path);
+    if std::env::var(key).is_err() {
+        let curr_dir_path = std::env::current_dir().unwrap();
+        let bitcoind_path = curr_dir_path.join("bin").join("bitcoind");
+        std::env::set_var(key, bitcoind_path);
+    }
 
     let exe_path = bitcoind::exe_path().unwrap();
     let bitcoind = bitcoind::BitcoinD::new(exe_path).unwrap();

--- a/bitcoind-tests/tests/setup/mod.rs
+++ b/bitcoind-tests/tests/setup/mod.rs
@@ -11,8 +11,14 @@ pub fn setup() -> BitcoinD {
     // Create env var BITCOIND_EXE_PATH to point to the ../bitcoind/bin/bitcoind binary
     let key = "BITCOIND_EXE";
     if std::env::var(key).is_err() {
-        let curr_dir_path = std::env::current_dir().unwrap();
-        let bitcoind_path = curr_dir_path.join("bin").join("bitcoind");
+        let mut root_path = std::env::current_dir().unwrap();
+        while std::fs::metadata(root_path.join("LICENSE")).is_err() {
+            if !root_path.pop() {
+                panic!("Could not find LICENSE file; do not know where repo root is.");
+            }
+        }
+
+        let bitcoind_path = root_path.join("bitcoind-tests").join("bin").join("bitcoind");
         std::env::set_var(key, bitcoind_path);
     }
 

--- a/bitcoind-tests/tests/setup/test_util.rs
+++ b/bitcoind-tests/tests/setup/test_util.rs
@@ -19,15 +19,14 @@
 
 use std::str::FromStr;
 
-use miniscript::bitcoin;
 use actual_rand as rand;
 use bitcoin::hashes::hex::ToHex;
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 use bitcoin::secp256k1;
 use miniscript::descriptor::{SinglePub, SinglePubKey};
 use miniscript::{
-    hash256, Descriptor, DescriptorPublicKey, Error, Miniscript, ScriptContext, TranslatePk,
-    Translator,
+    bitcoin, hash256, Descriptor, DescriptorPublicKey, Error, Miniscript, ScriptContext,
+    TranslatePk, Translator,
 };
 use rand::RngCore;
 

--- a/bitcoind-tests/tests/test_cpp.rs
+++ b/bitcoind-tests/tests/test_cpp.rs
@@ -15,9 +15,8 @@ use bitcoin::util::psbt;
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::{Amount, LockTime, OutPoint, Sequence, Transaction, TxIn, TxOut, Txid};
 use bitcoind::bitcoincore_rpc::{json, Client, RpcApi};
-use miniscript::bitcoin;
 use miniscript::psbt::PsbtExt;
-use miniscript::Descriptor;
+use miniscript::{bitcoin, Descriptor};
 
 mod setup;
 use setup::test_util::{self, PubData, TestData};

--- a/bitcoind-tests/tests/test_desc.rs
+++ b/bitcoind-tests/tests/test_desc.rs
@@ -7,7 +7,6 @@
 use std::collections::BTreeMap;
 use std::{error, fmt};
 
-use miniscript::bitcoin;
 use actual_rand as rand;
 use bitcoin::blockdata::witness::Witness;
 use bitcoin::hashes::{sha256d, Hash};
@@ -16,12 +15,12 @@ use bitcoin::util::sighash::SighashCache;
 use bitcoin::util::taproot::{LeafVersion, TapLeafHash};
 use bitcoin::util::{psbt, sighash};
 use bitcoin::{
-    secp256k1, Amount, LockTime, OutPoint, SchnorrSig, Script, Sequence, Transaction, TxIn,
-    TxOut, Txid,
+    secp256k1, Amount, LockTime, OutPoint, SchnorrSig, Script, Sequence, Transaction, TxIn, TxOut,
+    Txid,
 };
 use bitcoind::bitcoincore_rpc::{json, Client, RpcApi};
 use miniscript::psbt::{PsbtExt, PsbtInputExt};
-use miniscript::{Descriptor, Miniscript, ScriptContext, ToPublicKey};
+use miniscript::{bitcoin, Descriptor, Miniscript, ScriptContext, ToPublicKey};
 mod setup;
 
 use rand::RngCore;

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -40,6 +40,7 @@ fi
 # Test bitcoind integration tests if told to (this only works with the stable toolchain)
 if [ "$DO_BITCOIND_TESTS" = true ]; then
     cd bitcoind-tests
+    BITCOIND_EXE="$(git rev-parse --show-toplevel)/bitcoind-tests/bin/bitcoind" \
     cargo test --verbose
 
     # Exit integration tests, do not run other tests.

--- a/embedded/Cargo.toml
+++ b/embedded/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 readme = "README.md"
 name = "embedded"
 version = "0.1.0"
+publish = false
 
 [dependencies]
 cortex-m = "0.6.0"

--- a/embedded/src/main.rs
+++ b/embedded/src/main.rs
@@ -8,11 +8,9 @@ extern crate alloc;
 use alloc::string::ToString;
 use core::alloc::Layout;
 use core::panic::PanicInfo;
-
-use alloc_cortex_m::CortexMHeap;
-
 use core::str::FromStr;
 
+use alloc_cortex_m::CortexMHeap;
 use cortex_m::asm;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::{debug, hprintln};

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ afl_fuzz = ["afl"]
 honggfuzz_fuzz = ["honggfuzz"]
 
 [dependencies]
-honggfuzz = { version = "0.5", default-features = false, optional = true }
+honggfuzz = { version = "0.5.55", default-features = false, optional = true }
 afl = { version = "0.8", optional = true }
 regex = { version = "1.4"}
 miniscript = { path = "..", features = ["compiler"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,10 +17,6 @@ afl = { version = "0.8", optional = true }
 regex = { version = "1.4"}
 miniscript = { path = "..", features = ["compiler"] }
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
 [[bin]]
 name = "roundtrip_descriptor"
 path = "fuzz_targets/roundtrip_descriptor.rs"

--- a/fuzz/fuzz_targets/compile_descriptor.rs
+++ b/fuzz/fuzz_targets/compile_descriptor.rs
@@ -1,10 +1,9 @@
 extern crate miniscript;
 
-use miniscript::Segwitv0;
-use miniscript::{policy, Miniscript};
-use policy::Liftable;
-
 use std::str::FromStr;
+
+use miniscript::{policy, Miniscript, Segwitv0};
+use policy::Liftable;
 
 type Script = Miniscript<String, Segwitv0>;
 type Policy = policy::Concrete<String>;
@@ -15,7 +14,10 @@ fn do_test(data: &[u8]) {
         // Compile
         if let Ok(desc) = pol.compile::<Segwitv0>() {
             // Lift
-            assert_eq!(desc.clone().lift().unwrap().sorted(), pol.clone().lift().unwrap().sorted());
+            assert_eq!(
+                desc.clone().lift().unwrap().sorted(),
+                pol.clone().lift().unwrap().sorted()
+            );
             // Try to roundtrip the output of the compiler
             let output = desc.to_string();
             if let Ok(desc) = Script::from_str(&output) {

--- a/fuzz/fuzz_targets/parse_descriptor.rs
+++ b/fuzz/fuzz_targets/parse_descriptor.rs
@@ -1,7 +1,8 @@
 extern crate miniscript;
 
-use miniscript::DescriptorPublicKey;
 use std::str::FromStr;
+
+use miniscript::DescriptorPublicKey;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/parse_descriptor_secret.rs
+++ b/fuzz/fuzz_targets/parse_descriptor_secret.rs
@@ -1,7 +1,8 @@
 extern crate miniscript;
 
-use miniscript::descriptor::DescriptorSecretKey;
 use std::str::FromStr;
+
+use miniscript::descriptor::DescriptorSecretKey;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/roundtrip_concrete.rs
+++ b/fuzz/fuzz_targets/roundtrip_concrete.rs
@@ -1,8 +1,9 @@
 extern crate miniscript;
 extern crate regex;
+use std::str::FromStr;
+
 use miniscript::policy;
 use regex::Regex;
-use std::str::FromStr;
 
 type Policy = policy::Concrete<String>;
 

--- a/fuzz/fuzz_targets/roundtrip_descriptor.rs
+++ b/fuzz/fuzz_targets/roundtrip_descriptor.rs
@@ -1,9 +1,10 @@
 extern crate miniscript;
 extern crate regex;
 
+use std::str::FromStr;
+
 use miniscript::Descriptor;
 use regex::Regex;
-use std::str::FromStr;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
@@ -1,8 +1,7 @@
 extern crate miniscript;
 
 use miniscript::bitcoin::blockdata::script;
-use miniscript::Miniscript;
-use miniscript::Segwitv0;
+use miniscript::{Miniscript, Segwitv0};
 
 fn do_test(data: &[u8]) {
     // Try round-tripping as a script

--- a/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
@@ -1,11 +1,10 @@
 extern crate miniscript;
 extern crate regex;
 
-use regex::Regex;
 use std::str::FromStr;
 
-use miniscript::Miniscript;
-use miniscript::Segwitv0;
+use miniscript::{Miniscript, Segwitv0};
+use regex::Regex;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/roundtrip_semantic.rs
+++ b/fuzz/fuzz_targets/roundtrip_semantic.rs
@@ -1,7 +1,8 @@
 extern crate miniscript;
 
-use miniscript::policy;
 use std::str::FromStr;
+
+use miniscript::policy;
 
 type Policy = policy::Semantic<String>;
 


### PR DESCRIPTION
This brings the fuzztests and bitcoind-tests into workspaces along with the root crate. This means they are covered by `cargo test --all` and `cargo fmt --all` without any special action, and also means that `crate2nix` can test them independently without my manually messing around with directories. I run `cargo +nightly fmt` to bring the two new workspaces into proper formatting -- there were no changes that I'd consider controversial.

It also allows the `bitcoin-tests` directory to be run with a custom `BITCOIND_EXE` variable, and computes the default version more flexibly so that you can run the tests from any directory.

Finally I set the minimum honggfuzz version to 0.5.55, since the dep currently was set to 0.5.0, which definitely did not work.

With these changes, everything in this repo should work with a lockfile generated by `cargo +nightly update -Z minimal-versions`, and I am able to run both the bitcoind and fuzz tests (for five minutes per unit locally). I'll push some code to my [local-nix-ci repo](https://github.com/apoelstra/local-nix-ci) tomorrow to demonstrate whan I'm doing.

This PR does **not** do more dramatic rearrangemeent of the fuzztests ... though when https://github.com/rust-bitcoin/rust-bitcoin/pull/1732 gets merged I will open a similar PR here which does that.