### PR TITLE
Remove fuzz from the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,5 +69,5 @@ name = "psbt_sign_finalize"
 required-features = ["std", "base64"]
 
 [workspace]
-members = ["bitcoind-tests", "fuzz"]
+members = ["bitcoind-tests"]
 exclude = ["embedded"]


### PR DESCRIPTION
I think that the fuzz crate is messing with the 1.41/1.47 builds. There is no need for fuzzing to work with MSRV toolchain so instead of pinning deps from fuzzing just remove the `fuzz` crate from the workspace.

Note chat `cargo check` from the crate root does not check the `fuzz_target` source files like we hoped when adding `fuzz` to the workspace.

I am not entirely sure why `cargo check` does not work but dependencies from `fuzz` are still in the lock file.

Draft to see if this passes CI and to rebase other [failing PRs](https://github.com/rust-bitcoin/rust-miniscript/pull/560).