### PR TITLE
Pin `serde_json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,7 @@ This library should always compile with any combination of features (minus
 `no-std`) on **Rust 1.41.1** or **Rust 1.47** with `no-std`.
 
 Some dependencies do not play nicely with our MSRV, if you are running the tests
-you may need to pin as follows:
-
-```
-cargo update --package url --precise 2.2.2
-cargo update --package form_urlencoded --precise 1.0.1
-cargo update -p once_cell --precise 1.13.1
-cargo update -p bzip2 --precise 0.4.2
-```
+you may need to pin some dependencies. See `./contrib/test.sh` for current pinning.
 
 ## Contributing
 

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -17,12 +17,14 @@ fi
 # Pin dependencies required to build with Rust 1.41.1
 if cargo --version | grep "1\.41\.0"; then
     cargo update -p once_cell --precise 1.13.1
+    cargo update -p serde_json --precise 1.0.99
     cargo update -p serde --precise 1.0.156
 fi
 
 # Pin dependencies required to build with Rust 1.47.0
 if cargo --version | grep "1\.47\.0"; then
     cargo update -p once_cell --precise 1.13.1
+    cargo update -p serde_json --precise 1.0.99
     cargo update -p serde --precise 1.0.156
 fi
 


### PR DESCRIPTION
Pin `serde_json` for 1.41 and 1.47 CI runs. Remove the pinning docs from the README and instead point devs to the CI script. (The docs are stale currently and are an unnecessary maintenance burden.)