### PR TITLE
Remove hashbrown dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [features]
 default = ["std"]
 std = ["bitcoin/std", "bitcoin/secp-recovery"]
-no-std = ["hashbrown", "bitcoin/no-std"]
+no-std = ["bitcoin/no-std"]
 compiler = []
 trace = []
 
@@ -23,7 +23,6 @@ base64 = ["bitcoin/base64"]
 
 [dependencies]
 bitcoin = { version = "0.30.0", default-features = false }
-hashbrown = { version = "0.11", optional = true }
 internals = { package = "bitcoin-private", version = "0.1.0", default_features = false }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -57,7 +57,7 @@ pub use self::key::{
 /// [`Descriptor::parse_descriptor`], since the descriptor will always only contain
 /// public keys. This map allows looking up the corresponding secret key given a
 /// public key from the descriptor.
-pub type KeyMap = HashMap<DescriptorPublicKey, DescriptorSecretKey>;
+pub type KeyMap = BTreeMap<DescriptorPublicKey, DescriptorSecretKey>;
 
 /// Script descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -656,7 +656,7 @@ impl Descriptor<DescriptorPublicKey> {
             Ok(public_key)
         }
 
-        let mut keymap_pk = KeyMapWrapper(HashMap::new(), secp);
+        let mut keymap_pk = KeyMapWrapper(BTreeMap::new(), secp);
 
         struct KeyMapWrapper<'a, C: secp256k1::Signing>(KeyMap, &'a secp256k1::Secp256k1<C>);
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1501,7 +1501,7 @@ mod tests {
             witness: Witness::default(),
         };
         let satisfier = {
-            let mut satisfier = HashMap::with_capacity(2);
+            let mut satisfier = BTreeMap::new();
 
             satisfier.insert(
                 a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,6 @@ pub use bitcoin;
 #[macro_use]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
-extern crate hashbrown;
-
 #[cfg(any(feature = "std", test))]
 extern crate core;
 
@@ -960,9 +957,6 @@ mod prelude {
         sync::Mutex,
         vec::Vec,
     };
-
-    #[cfg(all(not(feature = "std"), not(test)))]
-    pub use hashbrown::{HashMap, HashSet};
 
     #[cfg(all(not(feature = "std"), not(test)))]
     pub use self::mutex::Mutex;

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -213,7 +213,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         // to have an iterator
         let all_pkhs_len = self.iter_pk().count();
 
-        let unique_pkhs_len = self.iter_pk().collect::<HashSet<_>>().len();
+        let unique_pkhs_len = self.iter_pk().collect::<BTreeSet<_>>().len();
 
         unique_pkhs_len != all_pkhs_len
     }

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -204,26 +204,39 @@ impl_satisfier_for_map_key_hash_to_taproot_sig! {
     impl Satisfier<Pk> for HashMap<(Pk, TapLeafHash), bitcoin::taproot::Signature>
 }
 
-impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>
-    for HashMap<hash160::Hash, (Pk, bitcoin::ecdsa::Signature)>
-where
-    Pk: MiniscriptKey + ToPublicKey,
-{
-    fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::ecdsa::Signature> {
-        self.get(&key.to_pubkeyhash(SigType::Ecdsa)).map(|x| x.1)
-    }
+macro_rules! impl_satisfier_for_map_hash_to_key_ecdsa_sig {
+    ($(#[$($attr:meta)*])* impl Satisfier<Pk> for $map:ident<$key:ty, $val:ty>) => {
+        $(#[$($attr)*])*
+        impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>
+            for $map<hash160::Hash, (Pk, bitcoin::ecdsa::Signature)>
+        where
+            Pk: MiniscriptKey + ToPublicKey,
+        {
+            fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::ecdsa::Signature> {
+                self.get(&key.to_pubkeyhash(SigType::Ecdsa)).map(|x| x.1)
+            }
 
-    fn lookup_raw_pkh_pk(&self, pk_hash: &hash160::Hash) -> Option<bitcoin::PublicKey> {
-        self.get(pk_hash).map(|x| x.0.to_public_key())
-    }
+            fn lookup_raw_pkh_pk(&self, pk_hash: &hash160::Hash) -> Option<bitcoin::PublicKey> {
+                self.get(pk_hash).map(|x| x.0.to_public_key())
+            }
 
-    fn lookup_raw_pkh_ecdsa_sig(
-        &self,
-        pk_hash: &hash160::Hash,
-    ) -> Option<(bitcoin::PublicKey, bitcoin::ecdsa::Signature)> {
-        self.get(pk_hash)
-            .map(|&(ref pk, sig)| (pk.to_public_key(), sig))
-    }
+            fn lookup_raw_pkh_ecdsa_sig(
+                &self,
+                pk_hash: &hash160::Hash,
+            ) -> Option<(bitcoin::PublicKey, bitcoin::ecdsa::Signature)> {
+                self.get(pk_hash)
+                    .map(|&(ref pk, sig)| (pk.to_public_key(), sig))
+            }
+        }
+    };
+}
+
+impl_satisfier_for_map_hash_to_key_ecdsa_sig! {
+    impl Satisfier<Pk> for BTreeMap<hash160::Hash, (Pk, bitcoin::ecdsa::Signature)>
+}
+
+impl_satisfier_for_map_hash_to_key_ecdsa_sig! {
+    impl Satisfier<Pk> for HashMap<hash160::Hash, (Pk, bitcoin::ecdsa::Signature)>
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -153,10 +153,26 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for absolute::LockTime {
         }
     }
 }
-impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for HashMap<Pk, bitcoin::ecdsa::Signature> {
-    fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::ecdsa::Signature> {
-        self.get(key).copied()
-    }
+
+macro_rules! impl_satisfier_for_map_key_to_ecdsa_sig {
+    ($(#[$($attr:meta)*])* impl Satisfier<Pk> for $map:ident<$key:ty, $val:ty>) => {
+        $(#[$($attr)*])*
+        impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>
+            for $map<Pk, bitcoin::ecdsa::Signature>
+        {
+            fn lookup_ecdsa_sig(&self, key: &Pk) -> Option<bitcoin::ecdsa::Signature> {
+                self.get(key).copied()
+            }
+        }
+    };
+}
+
+impl_satisfier_for_map_key_to_ecdsa_sig! {
+    impl Satisfier<Pk> for BTreeMap<Pk, bitcoin::ecdsa::Signature>
+}
+
+impl_satisfier_for_map_key_to_ecdsa_sig! {
+    impl Satisfier<Pk> for HashMap<Pk, bitcoin::ecdsa::Signature>
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk>

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -172,6 +172,7 @@ impl_satisfier_for_map_key_to_ecdsa_sig! {
 }
 
 impl_satisfier_for_map_key_to_ecdsa_sig! {
+    #[cfg(feature = "std")]
     impl Satisfier<Pk> for HashMap<Pk, bitcoin::ecdsa::Signature>
 }
 
@@ -201,6 +202,7 @@ impl_satisfier_for_map_key_hash_to_taproot_sig! {
 }
 
 impl_satisfier_for_map_key_hash_to_taproot_sig! {
+    #[cfg(feature = "std")]
     impl Satisfier<Pk> for HashMap<(Pk, TapLeafHash), bitcoin::taproot::Signature>
 }
 
@@ -236,6 +238,7 @@ impl_satisfier_for_map_hash_to_key_ecdsa_sig! {
 }
 
 impl_satisfier_for_map_hash_to_key_ecdsa_sig! {
+    #[cfg(feature = "std")]
     impl Satisfier<Pk> for HashMap<hash160::Hash, (Pk, bitcoin::ecdsa::Signature)>
 }
 
@@ -272,6 +275,7 @@ impl_satisfier_for_map_hash_tapleafhash_to_key_taproot_sig! {
 }
 
 impl_satisfier_for_map_hash_tapleafhash_to_key_taproot_sig! {
+    #[cfg(feature = "std")]
     impl Satisfier<Pk> for HashMap<(hash160::Hash, TapLeafHash), (Pk, bitcoin::taproot::Signature)>
 }
 

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1393,11 +1393,12 @@ mod tests {
         };
         let sigvec = bitcoinsig.to_vec();
 
-        let no_sat = HashMap::<bitcoin::PublicKey, bitcoin::ecdsa::Signature>::new();
-        let mut left_sat = HashMap::<bitcoin::PublicKey, bitcoin::ecdsa::Signature>::new();
-        let mut right_sat =
-            HashMap::<hashes::hash160::Hash, (bitcoin::PublicKey, bitcoin::ecdsa::Signature)>::new(
-            );
+        let no_sat = BTreeMap::<bitcoin::PublicKey, bitcoin::ecdsa::Signature>::new();
+        let mut left_sat = BTreeMap::<bitcoin::PublicKey, bitcoin::ecdsa::Signature>::new();
+        let mut right_sat = BTreeMap::<
+            hashes::hash160::Hash,
+            (bitcoin::PublicKey, bitcoin::ecdsa::Signature),
+        >::new();
 
         for i in 0..5 {
             left_sat.insert(keys[i], bitcoinsig);

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -791,7 +791,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     pub fn check_duplicate_keys(&self) -> Result<(), PolicyError> {
         let pks = self.keys();
         let pks_len = pks.len();
-        let unique_pks_len = pks.into_iter().collect::<HashSet<_>>().len();
+        let unique_pks_len = pks.into_iter().collect::<BTreeSet<_>>().len();
 
         if pks_len > unique_pks_len {
             Err(PolicyError::DuplicatePubKeys)

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -327,7 +327,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             let mut prob = 0.;
             let semantic_policy = self.lift()?;
             let concrete_keys = self.keys();
-            let key_prob_map: HashMap<_, _> = self
+            let key_prob_map: BTreeMap<_, _> = self
                 .to_tapleaf_prob_vec(1.0)
                 .into_iter()
                 .filter(|(_, ref pol)| matches!(*pol, Concrete::Key(..)))
@@ -347,7 +347,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                                 internal_key = Some(key.clone());
                             }
                         }
-                        None => return Err(errstr("Key should have existed in the HashMap!")),
+                        None => return Err(errstr("Key should have existed in the BTreeMap!")),
                     }
                 }
             }
@@ -563,7 +563,7 @@ impl<Pk: MiniscriptKey> PolicyArc<Pk> {
         // owing to the current [policy element enumeration algorithm][`Policy::enumerate_pol`],
         // two passes of the algorithm might result in same sub-policy showing up. Currently, we
         // merge the nodes by adding up the corresponding probabilities for the same policy.
-        let mut pol_prob_map = HashMap::<Arc<Self>, OrdF64>::new();
+        let mut pol_prob_map = BTreeMap::<Arc<Self>, OrdF64>::new();
 
         let arc_self = Arc::new(self);
         tapleaf_prob_vec.insert((Reverse(OrdF64(prob)), Arc::clone(&arc_self)));


### PR DESCRIPTION
We can use `BTreeSet` instead of `HashSet` and `BTreeMap` instead of `HashMap` to remove the `hashbrown` dependency.
