### PR TITLE
Implement From<Foo> for Descriptor<Pk> using macro

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -76,47 +76,18 @@ pub enum Descriptor<Pk: MiniscriptKey> {
     Tr(Tr<Pk>),
 }
 
-impl<Pk: MiniscriptKey> From<Bare<Pk>> for Descriptor<Pk> {
-    #[inline]
-    fn from(inner: Bare<Pk>) -> Self {
-        Descriptor::Bare(inner)
-    }
-}
+macro_rules! impl_from_for_descriptor {
+    ($($from:ident),*) => {
+        $(
+            impl<Pk: MiniscriptKey> From<$from<Pk>> for Descriptor<Pk> {
 
-impl<Pk: MiniscriptKey> From<Pkh<Pk>> for Descriptor<Pk> {
-    #[inline]
-    fn from(inner: Pkh<Pk>) -> Self {
-        Descriptor::Pkh(inner)
+                #[inline]
+                fn from(inner: $from<Pk>) -> Self { Descriptor::$from(inner) }
+            }
+        )*
     }
 }
-
-impl<Pk: MiniscriptKey> From<Wpkh<Pk>> for Descriptor<Pk> {
-    #[inline]
-    fn from(inner: Wpkh<Pk>) -> Self {
-        Descriptor::Wpkh(inner)
-    }
-}
-
-impl<Pk: MiniscriptKey> From<Sh<Pk>> for Descriptor<Pk> {
-    #[inline]
-    fn from(inner: Sh<Pk>) -> Self {
-        Descriptor::Sh(inner)
-    }
-}
-
-impl<Pk: MiniscriptKey> From<Wsh<Pk>> for Descriptor<Pk> {
-    #[inline]
-    fn from(inner: Wsh<Pk>) -> Self {
-        Descriptor::Wsh(inner)
-    }
-}
-
-impl<Pk: MiniscriptKey> From<Tr<Pk>> for Descriptor<Pk> {
-    #[inline]
-    fn from(inner: Tr<Pk>) -> Self {
-        Descriptor::Tr(inner)
-    }
-}
+impl_from_for_descriptor!(Bare, Pkh, Wpkh, Sh, Wsh, Tr);
 
 /// Descriptor Type of the descriptor
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]


### PR DESCRIPTION
Add a macro and remove all the individual from impls.

Refactor only, no logic changes.