### PR TITLE
Add call_through macro

### DIFF
--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -223,6 +223,11 @@ impl<Pk: MiniscriptKey> Pkh<Pk> {
         self.pk
     }
 
+    /// Always succeeds, this is just provided for uniformity with the other descriptors.
+    pub fn sanity_check(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
     /// Computes an upper bound on the difference between a non-satisfied
     /// `TxIn`'s `segwit_weight` and a satisfied `TxIn`'s `segwit_weight`
     ///

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -296,14 +296,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
     /// In general, all the guarantees of miniscript hold only for safe scripts.
     /// The signer may not be able to find satisfactions even if one exists.
     pub fn sanity_check(&self) -> Result<(), Error> {
-        match *self {
-            Descriptor::Bare(ref bare) => bare.sanity_check(),
-            Descriptor::Pkh(_) => Ok(()),
-            Descriptor::Wpkh(ref wpkh) => wpkh.sanity_check(),
-            Descriptor::Wsh(ref wsh) => wsh.sanity_check(),
-            Descriptor::Sh(ref sh) => sh.sanity_check(),
-            Descriptor::Tr(ref tr) => tr.sanity_check(),
-        }
+        crate::macros::call_through!(self, sanity_check, Descriptor, Bare, Pkh, Wpkh, Wsh, Sh, Tr)
     }
 
     /// Computes an upper bound on the difference between a non-satisfied

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -210,3 +210,15 @@ macro_rules! serde_string_impl_pk {
         }
     };
 }
+
+/// Calls through to `fn` for each `variant` on `enum` (expects `self` to be a reference).
+macro_rules! call_through {
+    ($self:expr, $fn:ident, $enum:ident, $($variant:ident),*) => {
+        match *$self {
+            $(
+                $enum::$variant(ref inner) => inner.$fn(),
+            )*
+        }
+    }
+}
+pub(crate) use call_through;


### PR DESCRIPTION
Draft to see what you guys think of this. It could be used all over the place but its non trivial because loads of the call through functions differ in return type, mostly erroring vs infallible.

Add a macro that calls through to a function for each variant of an enum.

Add a single example usage of the new macro.