### PR TITLE
Remove the `Liftable` trait

### DIFF
--- a/examples/htlc.rs
+++ b/examples/htlc.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 use miniscript::bitcoin::Network;
 use miniscript::descriptor::Wsh;
-use miniscript::policy::{Concrete, Liftable};
+use miniscript::policy::Concrete;
 
 fn main() {
     // HTLC policy with 10:1 odds for happy (co-operative) case compared to uncooperative case.

--- a/fuzz/fuzz_targets/compile_descriptor.rs
+++ b/fuzz/fuzz_targets/compile_descriptor.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use honggfuzz::fuzz;
 use miniscript::{policy, Miniscript, Segwitv0};
-use policy::Liftable;
 
 type Script = Miniscript<String, Segwitv0>;
 type Policy = policy::Concrete<String>;

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -16,7 +16,7 @@ use bitcoin::{Address, Network, ScriptBuf};
 use super::checksum::{self, verify_checksum};
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::{ScriptContext, ScriptContextError};
-use crate::policy::{semantic, Liftable};
+use crate::policy::Semantic;
 use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
@@ -90,6 +90,11 @@ impl<Pk: MiniscriptKey> Bare<Pk> {
         let scriptsig_len = self.ms.max_satisfaction_size()?;
         Ok(4 * (varint_len(scriptsig_len) + scriptsig_len))
     }
+
+    /// TODO: Write lift rustdocs.
+    pub fn lift(&self) -> Result<Semantic<Pk>, Error> {
+        self.ms.lift()
+    }
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Bare<Pk> {
@@ -147,12 +152,6 @@ impl<Pk: MiniscriptKey> fmt::Display for Bare<Pk> {
         let mut wrapped_f = checksum::Formatter::new(f);
         write!(wrapped_f, "{}", self.ms)?;
         wrapped_f.write_checksum_if_not_alt()
-    }
-}
-
-impl<Pk: MiniscriptKey> Liftable<Pk> for Bare<Pk> {
-    fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
-        self.ms.lift()
     }
 }
 
@@ -253,6 +252,11 @@ impl<Pk: MiniscriptKey> Pkh<Pk> {
     pub fn max_satisfaction_weight(&self) -> usize {
         4 * (1 + 73 + BareCtx::pk_len(&self.pk))
     }
+
+    /// TODO: Write lift rustdocs.
+    pub fn lift(&self) -> Semantic<Pk> {
+        Semantic::Key(self.pk.clone())
+    }
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
@@ -324,12 +328,6 @@ impl<Pk: MiniscriptKey> fmt::Display for Pkh<Pk> {
         let mut wrapped_f = checksum::Formatter::new(f);
         write!(wrapped_f, "pkh({})", self.pk)?;
         wrapped_f.write_checksum_if_not_alt()
-    }
-}
-
-impl<Pk: MiniscriptKey> Liftable<Pk> for Pkh<Pk> {
-    fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
-        Ok(semantic::Policy::Key(self.pk.clone()))
     }
 }
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -23,6 +23,7 @@ use sync::Arc;
 
 use self::checksum::verify_checksum;
 use crate::miniscript::{Legacy, Miniscript, Segwitv0};
+use crate::policy::Semantic;
 use crate::prelude::*;
 use crate::{
     expression, hash256, miniscript, BareCtx, Error, ForEachKey, MiniscriptKey, Satisfier,
@@ -377,6 +378,18 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
             Descriptor::Tr(ref tr) => tr.max_satisfaction_weight()?,
         };
         Ok(weight)
+    }
+
+    /// TODO: Write lift rustdocs.
+    pub fn lift(&self) -> Result<Semantic<Pk>, Error> {
+        match *self {
+            Descriptor::Bare(ref bare) => bare.lift(),
+            Descriptor::Pkh(ref pkh) => Ok(pkh.lift()),
+            Descriptor::Wpkh(ref wpkh) => Ok(wpkh.lift()),
+            Descriptor::Wsh(ref wsh) => wsh.lift(),
+            Descriptor::Sh(ref sh) => sh.lift(),
+            Descriptor::Tr(ref tr) => tr.lift(),
+        }
     }
 }
 

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -18,7 +18,7 @@ use super::checksum::{self, verify_checksum};
 use super::{SortedMultiVec, Wpkh, Wsh};
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::ScriptContext;
-use crate::policy::{semantic, Liftable};
+use crate::policy::Semantic;
 use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
@@ -44,17 +44,6 @@ pub enum ShInner<Pk: MiniscriptKey> {
     SortedMulti(SortedMultiVec<Pk, Legacy>),
     /// p2sh miniscript
     Ms(Miniscript<Pk, Legacy>),
-}
-
-impl<Pk: MiniscriptKey> Liftable<Pk> for Sh<Pk> {
-    fn lift(&self) -> Result<semantic::Policy<Pk>, Error> {
-        match self.inner {
-            ShInner::Wsh(ref wsh) => wsh.lift(),
-            ShInner::Wpkh(ref pk) => Ok(semantic::Policy::Key(pk.as_inner().clone())),
-            ShInner::SortedMulti(ref smv) => smv.lift(),
-            ShInner::Ms(ref ms) => ms.lift(),
-        }
-    }
 }
 
 impl<Pk: MiniscriptKey> fmt::Debug for Sh<Pk> {
@@ -276,6 +265,16 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
                 4 * (varint_len(scriptsig_len) + scriptsig_len)
             }
         })
+    }
+
+    /// TODO: Write lift rustdocs.
+    pub fn lift(&self) -> Result<Semantic<Pk>, Error> {
+        match self.inner {
+            ShInner::Wsh(ref wsh) => wsh.lift(),
+            ShInner::Wpkh(ref pk) => Ok(Semantic::Key(pk.as_inner().clone())),
+            ShInner::SortedMulti(ref smv) => smv.lift(),
+            ShInner::Ms(ref ms) => ms.lift(),
+        }
     }
 }
 

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -192,10 +192,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
     pub fn max_satisfaction_size(&self) -> usize {
         1 + 73 * self.k
     }
-}
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> policy::Liftable<Pk> for SortedMultiVec<Pk, Ctx> {
-    fn lift(&self) -> Result<policy::semantic::Policy<Pk>, Error> {
+    /// TODO: Write lift rustdocs.
+    pub fn lift(&self) -> Result<policy::semantic::Policy<Pk>, Error> {
         let ret = policy::semantic::Policy::Threshold(
             self.k,
             self.pks

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -619,7 +619,6 @@ mod tests {
     use super::{Miniscript, ScriptContext, Segwitv0, Tap};
     use crate::miniscript::types::{self, ExtData, Property, Type};
     use crate::miniscript::Terminal;
-    use crate::policy::Liftable;
     use crate::prelude::*;
     use crate::test_utils::{StrKeyTranslator, StrXOnlyKeyTranslator};
     use crate::{hex_script, ExtParams, Satisfier, ToPublicKey, TranslatePk};

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1192,7 +1192,6 @@ mod tests {
 
     use super::*;
     use crate::miniscript::{Legacy, Segwitv0, Tap};
-    use crate::policy::Liftable;
     use crate::{script_num_size, ToPublicKey};
 
     type SPolicy = Concrete<String>;


### PR DESCRIPTION
Draft to showcase this idea, I'm not sure how to write the function docs just yet.

This trait is never used as a trait bound, there is no obvious reason for its existence.

Remove the `Liftable` trait and implement `lift` on each type directly.