### PR TITLE
Remove written in clause

### DIFF
--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -1,4 +1,3 @@
-// Written in 2020 by the rust-miniscript developers
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Bare Output Descriptors

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Output Descriptors

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -1,4 +1,3 @@
-// Written in 2020 by the rust-miniscript developers
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Segwit Output Descriptors

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -1,4 +1,3 @@
-// Written in 2020 by the rust-miniscript developers
 // SPDX-License-Identifier: CC0-1.0
 
 //! # P2SH Descriptors

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -1,4 +1,3 @@
-// Written in 2020 by the rust-miniscript developers
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Sorted Multi

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Function-like Expression Language

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2023 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Abstract Tree Iteration

--- a/src/iter/tree.rs
+++ b/src/iter/tree.rs
@@ -1,4 +1,3 @@
-// Written in 2023 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Abstract Trees

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -1,4 +1,3 @@
-// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //!  Miniscript Analysis

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! AST Elements

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Script Decoder

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -1,4 +1,3 @@
-// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Lexer

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Abstract Syntax Tree

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -1,4 +1,3 @@
-// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Satisfaction and Dissatisfaction

--- a/src/miniscript/types/correctness.rs
+++ b/src/miniscript/types/correctness.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Correctness/Soundness type properties

--- a/src/miniscript/types/malleability.rs
+++ b/src/miniscript/types/malleability.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Malleability-related Type properties

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Miniscript Types

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Policy Compiler

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Concrete Policies

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2018 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //!  Script Policies

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! Abstract Policies

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1,4 +1,3 @@
-// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
 // SPDX-License-Identifier: CC0-1.0
 
 //! # Partially-Signed Bitcoin Transactions


### PR DESCRIPTION
Recently we discussed in `rust-bitcoin` the pointlessness of the `\\ Written in ...` clause above the license terms. We came to the conclusion that:

- It probably wasn't written then and who cares anyway because we patch files all the time
- It almost certainly wasn't written by just this person because we have a bunch of contributors
- Use of "the rust bitcoin devs" is just noise and no signal

Remove the "written in" clause if it contains "the rust bitcoin devs" or Andrew's name (because he was part of the conversation in rust-bitcoin)

Do no remove clauses that have Sanket's name or Maxim's. Its up to them if they want attribution so we leave it there for now.

Leave Andrew's name in `lib.rs` as a little nod-of-the-head to him as the original author. I do not know the full relationship between Sanket and Andrew and who did what so please forgive me Sanket if this is wrong.