### PR TITLE
Clean up `miniscript/mod.rs`

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -64,8 +64,8 @@ pub struct Miniscript<Pk: MiniscriptKey, Ctx: ScriptContext> {
 }
 
 /// `PartialOrd` of `Miniscript` must depend only on node and not the type information.
-/// The type information and extra_properties can be deterministically determined
-/// by the ast.
+///
+/// The type information and extra properties are implied by the AST.
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialOrd for Miniscript<Pk, Ctx> {
     fn partial_cmp(&self, other: &Miniscript<Pk, Ctx>) -> Option<cmp::Ordering> {
         Some(self.node.cmp(&other.node))
@@ -73,8 +73,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialOrd for Miniscript<Pk, Ctx> {
 }
 
 /// `Ord` of `Miniscript` must depend only on node and not the type information.
-/// The type information and extra_properties can be deterministically determined
-/// by the ast.
+///
+/// The type information and extra properties are implied by the AST.
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Ord for Miniscript<Pk, Ctx> {
     fn cmp(&self, other: &Miniscript<Pk, Ctx>) -> cmp::Ordering {
         self.node.cmp(&other.node)
@@ -82,8 +82,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Ord for Miniscript<Pk, Ctx> {
 }
 
 /// `PartialEq` of `Miniscript` must depend only on node and not the type information.
-/// The type information and extra_properties can be deterministically determined
-/// by the ast.
+///
+/// The type information and extra properties are implied by the AST.
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialEq for Miniscript<Pk, Ctx> {
     fn eq(&self, other: &Miniscript<Pk, Ctx>) -> bool {
         self.node.eq(&other.node)
@@ -91,10 +91,13 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialEq for Miniscript<Pk, Ctx> {
 }
 
 /// `Eq` of `Miniscript` must depend only on node and not the type information.
-/// The type information and extra_properties can be deterministically determined
-/// by the ast.
+///
+/// The type information and extra properties are implied by the AST.
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Eq for Miniscript<Pk, Ctx> {}
 
+/// `Hash` of `Miniscript` must depend only on node and not the type information.
+///
+/// The type information and extra properties are implied by the AST.
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> hash::Hash for Miniscript<Pk, Ctx> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.node.hash(state);

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -50,14 +50,14 @@ use crate::{expression, Error, ForEachKey, MiniscriptKey, ToPublicKey, Translate
 #[cfg(test)]
 mod ms_tests;
 
-/// Top-level script AST type
+/// The top-level miniscript abstract syntax tree (AST).
 #[derive(Clone)]
 pub struct Miniscript<Pk: MiniscriptKey, Ctx: ScriptContext> {
-    ///A node in the Abstract Syntax Tree(
+    /// A node in the AST.
     pub node: Terminal<Pk, Ctx>,
-    ///The correctness and malleability type information for the AST node
+    /// The correctness and malleability type information for the AST node.
     pub ty: types::Type,
-    ///Additional information helpful for extra analysis.
+    /// Additional information helpful for extra analysis.
     pub ext: types::extra_props::ExtData,
     /// Context PhantomData. Only accessible inside this crate
     phantom: PhantomData<Ctx>,

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -95,15 +95,15 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialEq for Miniscript<Pk, Ctx> {
 /// by the ast.
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Eq for Miniscript<Pk, Ctx> {}
 
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Miniscript<Pk, Ctx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.node)
-    }
-}
-
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> hash::Hash for Miniscript<Pk, Ctx> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.node.hash(state);
+    }
+}
+
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Miniscript<Pk, Ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.node)
     }
 }
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -122,33 +122,24 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// to instead call the corresponding function on a `Descriptor`, which
     /// will handle the segwit/non-segwit technicalities for you.
     pub fn script_size(&self) -> usize {
+        use Terminal::*;
+
         let mut len = 0;
         for ms in self.pre_order_iter() {
             len += match ms.node {
+                AndV(..) => 0,
+                True | False | Swap(..) | Check(..) | ZeroNotEqual(..) | AndB(..) | OrB(..) => 1,
+                Alt(..) | OrC(..) => 2,
+                DupIf(..) | AndOr(..) | OrD(..) | OrI(..) => 3,
+                NonZero(..) => 4,
+                PkH(..) | RawPkH(..) => 24,
+                Ripemd160(..) | Hash160(..) => 21 + 6,
+                Sha256(..) | Hash256(..) => 33 + 6,
+
                 Terminal::PkK(ref pk) => Ctx::pk_len(pk),
-                Terminal::PkH(..) | Terminal::RawPkH(..) => 24,
                 Terminal::After(n) => script_num_size(n.to_consensus_u32() as usize) + 1,
                 Terminal::Older(n) => script_num_size(n.to_consensus_u32() as usize) + 1,
-                Terminal::Sha256(..) => 33 + 6,
-                Terminal::Hash256(..) => 33 + 6,
-                Terminal::Ripemd160(..) => 21 + 6,
-                Terminal::Hash160(..) => 21 + 6,
-                Terminal::True => 1,
-                Terminal::False => 1,
-                Terminal::Alt(..) => 2,
-                Terminal::Swap(..) => 1,
-                Terminal::Check(..) => 1,
-                Terminal::DupIf(..) => 3,
                 Terminal::Verify(ref sub) => usize::from(!sub.ext.has_free_verify),
-                Terminal::NonZero(..) => 4,
-                Terminal::ZeroNotEqual(..) => 1,
-                Terminal::AndV(..) => 0,
-                Terminal::AndB(..) => 1,
-                Terminal::AndOr(..) => 3,
-                Terminal::OrB(..) => 1,
-                Terminal::OrD(..) => 3,
-                Terminal::OrC(..) => 2,
-                Terminal::OrI(..) => 3,
                 Terminal::Thresh(k, ref subs) => {
                     assert!(!subs.is_empty(), "threshold must be nonempty");
                     script_num_size(k) // k

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -253,59 +253,6 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     }
 }
 
-/// `PartialOrd` of `Miniscript` must depend only on node and not the type information.
-///
-/// The type information and extra properties are implied by the AST.
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialOrd for Miniscript<Pk, Ctx> {
-    fn partial_cmp(&self, other: &Miniscript<Pk, Ctx>) -> Option<cmp::Ordering> {
-        Some(self.node.cmp(&other.node))
-    }
-}
-
-/// `Ord` of `Miniscript` must depend only on node and not the type information.
-///
-/// The type information and extra properties are implied by the AST.
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Ord for Miniscript<Pk, Ctx> {
-    fn cmp(&self, other: &Miniscript<Pk, Ctx>) -> cmp::Ordering {
-        self.node.cmp(&other.node)
-    }
-}
-
-/// `PartialEq` of `Miniscript` must depend only on node and not the type information.
-///
-/// The type information and extra properties are implied by the AST.
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialEq for Miniscript<Pk, Ctx> {
-    fn eq(&self, other: &Miniscript<Pk, Ctx>) -> bool {
-        self.node.eq(&other.node)
-    }
-}
-
-/// `Eq` of `Miniscript` must depend only on node and not the type information.
-///
-/// The type information and extra properties are implied by the AST.
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Eq for Miniscript<Pk, Ctx> {}
-
-/// `Hash` of `Miniscript` must depend only on node and not the type information.
-///
-/// The type information and extra properties are implied by the AST.
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> hash::Hash for Miniscript<Pk, Ctx> {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.node.hash(state);
-    }
-}
-
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Miniscript<Pk, Ctx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.node)
-    }
-}
-
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Miniscript<Pk, Ctx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.node)
-    }
-}
-
 impl<Ctx: ScriptContext> Miniscript<Ctx::Key, Ctx> {
     /// Attempt to parse an insane(scripts don't clear sanity checks)
     /// script into a Miniscript representation.
@@ -382,6 +329,59 @@ impl<Ctx: ScriptContext> Miniscript<Ctx::Key, Ctx> {
     pub fn parse(script: &script::Script) -> Result<Miniscript<Ctx::Key, Ctx>, Error> {
         let ms = Self::parse_with_ext(script, &ExtParams::sane())?;
         Ok(ms)
+    }
+}
+
+/// `PartialOrd` of `Miniscript` must depend only on node and not the type information.
+///
+/// The type information and extra properties are implied by the AST.
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialOrd for Miniscript<Pk, Ctx> {
+    fn partial_cmp(&self, other: &Miniscript<Pk, Ctx>) -> Option<cmp::Ordering> {
+        Some(self.node.cmp(&other.node))
+    }
+}
+
+/// `Ord` of `Miniscript` must depend only on node and not the type information.
+///
+/// The type information and extra properties are implied by the AST.
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> Ord for Miniscript<Pk, Ctx> {
+    fn cmp(&self, other: &Miniscript<Pk, Ctx>) -> cmp::Ordering {
+        self.node.cmp(&other.node)
+    }
+}
+
+/// `PartialEq` of `Miniscript` must depend only on node and not the type information.
+///
+/// The type information and extra properties are implied by the AST.
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialEq for Miniscript<Pk, Ctx> {
+    fn eq(&self, other: &Miniscript<Pk, Ctx>) -> bool {
+        self.node.eq(&other.node)
+    }
+}
+
+/// `Eq` of `Miniscript` must depend only on node and not the type information.
+///
+/// The type information and extra properties are implied by the AST.
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> Eq for Miniscript<Pk, Ctx> {}
+
+/// `Hash` of `Miniscript` must depend only on node and not the type information.
+///
+/// The type information and extra properties are implied by the AST.
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> hash::Hash for Miniscript<Pk, Ctx> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.node.hash(state);
+    }
+}
+
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Miniscript<Pk, Ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.node)
+    }
+}
+
+impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Miniscript<Pk, Ctx> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.node)
     }
 }
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -95,6 +95,16 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
             phantom: PhantomData,
         }
     }
+
+    /// Extracts the `AstElem` representing the root of the miniscript
+    pub fn into_inner(self) -> Terminal<Pk, Ctx> {
+        self.node
+    }
+
+    /// Get a reference to the inner `AstElem` representing the root of miniscript
+    pub fn as_inner(&self) -> &Terminal<Pk, Ctx> {
+        &self.node
+    }
 }
 
 /// `PartialOrd` of `Miniscript` must depend only on node and not the type information.
@@ -147,18 +157,6 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Miniscript<Pk, Ctx> {
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Miniscript<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.node)
-    }
-}
-
-impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
-    /// Extracts the `AstElem` representing the root of the miniscript
-    pub fn into_inner(self) -> Terminal<Pk, Ctx> {
-        self.node
-    }
-
-    /// Get a reference to the inner `AstElem` representing the root of miniscript
-    pub fn as_inner(&self) -> &Terminal<Pk, Ctx> {
-        &self.node
     }
 }
 


### PR DESCRIPTION
Make an effort to clean up the `miniscript/mod.rs` file. I could not see a reason for all the separate impl blocks, is there one? Please note this PR does not fix all the docs, just does ones that should not be too hard to review.