### PR TITLE
 Inline descriptor inner types

### DIFF
--- a/bitcoind-tests/tests/test_cpp.rs
+++ b/bitcoind-tests/tests/test_cpp.rs
@@ -150,8 +150,8 @@ pub fn test_from_cpp_ms(cl: &Client, testdata: &TestData) {
     for i in 0..psbts.len() {
         let wsh_derived = desc_vec[i].derived_descriptor(&secp).unwrap();
         let ms = if let Descriptor::Wsh(wsh) = &wsh_derived {
-            match wsh.as_inner() {
-                miniscript::descriptor::WshInner::Ms(ms) => ms,
+            match wsh {
+                miniscript::descriptor::Wsh::Ms(ms) => ms,
                 _ => unreachable!(),
             }
         } else {

--- a/bitcoind-tests/tests/test_desc.rs
+++ b/bitcoind-tests/tests/test_desc.rs
@@ -215,29 +215,29 @@ pub fn test_desc_satisfy(
                 Descriptor::Bare(bare) => find_sks_ms(&bare.as_inner(), testdata),
                 Descriptor::Pkh(pk) => find_sk_single_key(*pk.as_inner(), testdata),
                 Descriptor::Wpkh(pk) => find_sk_single_key(*pk.as_inner(), testdata),
-                Descriptor::Sh(sh) => match sh.as_inner() {
-                    miniscript::descriptor::ShInner::Wsh(wsh) => match wsh.as_inner() {
-                        miniscript::descriptor::WshInner::SortedMulti(ref smv) => {
+                Descriptor::Sh(sh) => match sh {
+                    miniscript::descriptor::Sh::Wsh(wsh) => match wsh {
+                        miniscript::descriptor::Wsh::SortedMulti(ref smv) => {
                             let ms = Miniscript::from_ast(smv.sorted_node()).unwrap();
                             find_sks_ms(&ms, testdata)
                         }
-                        miniscript::descriptor::WshInner::Ms(ref ms) => find_sks_ms(&ms, testdata),
+                        miniscript::descriptor::Wsh::Ms(ref ms) => find_sks_ms(&ms, testdata),
                     },
-                    miniscript::descriptor::ShInner::Wpkh(pk) => {
+                    miniscript::descriptor::Sh::Wpkh(pk) => {
                         find_sk_single_key(*pk.as_inner(), testdata)
                     }
-                    miniscript::descriptor::ShInner::SortedMulti(smv) => {
+                    miniscript::descriptor::Sh::SortedMulti(smv) => {
                         let ms = Miniscript::from_ast(smv.sorted_node()).unwrap();
                         find_sks_ms(&ms, testdata)
                     }
-                    miniscript::descriptor::ShInner::Ms(ms) => find_sks_ms(&ms, testdata),
+                    miniscript::descriptor::Sh::Ms(ms) => find_sks_ms(&ms, testdata),
                 },
-                Descriptor::Wsh(wsh) => match wsh.as_inner() {
-                    miniscript::descriptor::WshInner::SortedMulti(ref smv) => {
+                Descriptor::Wsh(wsh) => match wsh {
+                    miniscript::descriptor::Wsh::SortedMulti(ref smv) => {
                         let ms = Miniscript::from_ast(smv.sorted_node()).unwrap();
                         find_sks_ms(&ms, testdata)
                     }
-                    miniscript::descriptor::WshInner::Ms(ref ms) => find_sks_ms(&ms, testdata),
+                    miniscript::descriptor::Wsh::Ms(ref ms) => find_sks_ms(&ms, testdata),
                 },
                 Descriptor::Tr(_tr) => unreachable!("Tr checked earlier"),
             };

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -38,8 +38,8 @@ mod tr;
 
 // Descriptor Exports
 pub use self::bare::{Bare, Pkh};
-pub use self::segwitv0::{Wpkh, Wsh, WshInner};
-pub use self::sh::{Sh, ShInner};
+pub use self::segwitv0::{Wpkh, Wsh};
+pub use self::sh::Sh;
 pub use self::sortedmulti::SortedMultiVec;
 pub use self::tr::{TapTree, Tr};
 
@@ -246,18 +246,18 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
             Descriptor::Bare(ref _bare) => DescriptorType::Bare,
             Descriptor::Pkh(ref _pkh) => DescriptorType::Pkh,
             Descriptor::Wpkh(ref _wpkh) => DescriptorType::Wpkh,
-            Descriptor::Sh(ref sh) => match sh.as_inner() {
-                ShInner::Wsh(ref wsh) => match wsh.as_inner() {
-                    WshInner::SortedMulti(ref _smv) => DescriptorType::ShWshSortedMulti,
-                    WshInner::Ms(ref _ms) => DescriptorType::ShWsh,
+            Descriptor::Sh(ref sh) => match sh {
+                Sh::Wsh(ref wsh) => match wsh {
+                    Wsh::SortedMulti(ref _smv) => DescriptorType::ShWshSortedMulti,
+                    Wsh::Ms(ref _ms) => DescriptorType::ShWsh,
                 },
-                ShInner::Wpkh(ref _wpkh) => DescriptorType::ShWpkh,
-                ShInner::SortedMulti(ref _smv) => DescriptorType::ShSortedMulti,
-                ShInner::Ms(ref _ms) => DescriptorType::Sh,
+                Sh::Wpkh(ref _wpkh) => DescriptorType::ShWpkh,
+                Sh::SortedMulti(ref _smv) => DescriptorType::ShSortedMulti,
+                Sh::Ms(ref _ms) => DescriptorType::Sh,
             },
-            Descriptor::Wsh(ref wsh) => match wsh.as_inner() {
-                WshInner::SortedMulti(ref _smv) => DescriptorType::WshSortedMulti,
-                WshInner::Ms(ref _ms) => DescriptorType::Wsh,
+            Descriptor::Wsh(ref wsh) => match wsh {
+                Wsh::SortedMulti(ref _smv) => DescriptorType::WshSortedMulti,
+                Wsh::Ms(ref _ms) => DescriptorType::Wsh,
             },
             Descriptor::Tr(ref _tr) => DescriptorType::Tr,
         }

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -23,6 +23,7 @@ use crate::{
     Error, ForEachKey, Miniscript, MiniscriptKey, Satisfier, Segwitv0, ToPublicKey, TranslateErr,
     TranslatePk, Translator,
 };
+
 /// A Segwitv0 wsh descriptor
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Wsh<Pk: MiniscriptKey> {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -413,13 +413,13 @@ impl Plan {
 
             match &self.descriptor {
                 Descriptor::Bare(_) | Descriptor::Pkh(_) | Descriptor::Wpkh(_) => {}
-                Descriptor::Sh(sh) => match sh.as_inner() {
-                    descriptor::ShInner::Wsh(wsh) => {
+                Descriptor::Sh(sh) => match sh {
+                    descriptor::Sh::Wsh(wsh) => {
                         input.witness_script = Some(wsh.inner_script());
                         input.redeem_script = Some(wsh.inner_script().to_v0_p2wsh());
                     }
-                    descriptor::ShInner::Wpkh(..) => input.redeem_script = Some(sh.inner_script()),
-                    descriptor::ShInner::SortedMulti(_) | descriptor::ShInner::Ms(_) => {
+                    descriptor::Sh::Wpkh(..) => input.redeem_script = Some(sh.inner_script()),
+                    descriptor::Sh::SortedMulti(_) | descriptor::Sh::Ms(_) => {
                         input.redeem_script = Some(sh.inner_script())
                     }
                 },

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1194,13 +1194,13 @@ fn update_item_with_descriptor_helper<F: PsbtFields>(
 
         match &derived {
             Descriptor::Bare(_) | Descriptor::Pkh(_) | Descriptor::Wpkh(_) => {}
-            Descriptor::Sh(sh) => match sh.as_inner() {
-                descriptor::ShInner::Wsh(wsh) => {
+            Descriptor::Sh(sh) => match sh {
+                descriptor::Sh::Wsh(wsh) => {
                     *item.witness_script() = Some(wsh.inner_script());
                     *item.redeem_script() = Some(wsh.inner_script().to_v0_p2wsh());
                 }
-                descriptor::ShInner::Wpkh(..) => *item.redeem_script() = Some(sh.inner_script()),
-                descriptor::ShInner::SortedMulti(_) | descriptor::ShInner::Ms(_) => {
+                descriptor::Sh::Wpkh(..) => *item.redeem_script() = Some(sh.inner_script()),
+                descriptor::Sh::SortedMulti(_) | descriptor::Sh::Ms(_) => {
                     *item.redeem_script() = Some(sh.inner_script())
                 }
             },


### PR DESCRIPTION
Patch 1 is trivial cleanup

From commit log of patch 2
    
    The `ShInner` and `WshInner` enum's provide no benefit that I can
    discern. Both include only tuple variants with private tuple fields. We
    can therefore inline the enums into `Sh` and `Wsh` respectively with no
    loss of type safety. Doing so marginally simplifies the code, the
    biggest benefit is it stops devs wondering why there is an inner type.
 
