### PR TITLE
Implement `TreeLike` for `policy::Concrete`

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -15,7 +15,7 @@ pub use tree::{
 };
 
 use crate::sync::Arc;
-use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal};
+use crate::{policy, Miniscript, MiniscriptKey, ScriptContext, Terminal};
 
 impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> TreeLike for &'a Miniscript<Pk, Ctx> {
     fn as_node(&self) -> Tree<Self> {
@@ -65,6 +65,32 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TreeLike for Arc<Miniscript<Pk, Ctx>
                 Tree::Nary(Arc::from([Arc::clone(a), Arc::clone(b), Arc::clone(c)]))
             }
             Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
+        }
+    }
+}
+
+impl<'a, Pk: MiniscriptKey> TreeLike for &'a policy::Concrete<Pk> {
+    fn as_node(&self) -> Tree<Self> {
+        use policy::Concrete::*;
+        match *self {
+            Unsatisfiable | Trivial | Key(_) | After(_) | Older(_) | Sha256(_) | Hash256(_)
+            | Ripemd160(_) | Hash160(_) => Tree::Nullary,
+            And(ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
+            Or(ref v) => Tree::Nary(v.iter().map(|(_, p)| p.as_ref()).collect()),
+            Threshold(_, ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
+        }
+    }
+}
+
+impl<'a, Pk: MiniscriptKey> TreeLike for Arc<policy::Concrete<Pk>> {
+    fn as_node(&self) -> Tree<Self> {
+        use policy::Concrete::*;
+        match self.as_ref() {
+            Unsatisfiable | Trivial | Key(_) | After(_) | Older(_) | Sha256(_) | Hash256(_)
+            | Ripemd160(_) | Hash160(_) => Tree::Nullary,
+            And(ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
+            Or(ref v) => Tree::Nary(v.iter().map(|(_, p)| Arc::clone(p)).collect()),
+            Threshold(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
         }
     }
 }

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -441,7 +441,6 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     {
         let mut translated = vec![];
         for data in Arc::new(self.clone()).post_order_iter() {
-            // convenience method to reduce typing
             let child_n = |n| Arc::clone(&translated[data.child_indices[n]]);
 
             let new_term = match data.node.node {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1241,4 +1241,11 @@ mod tests {
         let policy = Policy::<String>::from_str("or(and(pk(A),pk(B)),pk(C))").unwrap();
         assert_eq!(policy.num_tap_leaves(), 2);
     }
+
+    #[test]
+    #[should_panic]
+    fn check_timelocks() {
+        // This implicitly tests the check_timelocks API (has height and time locks).
+        let _ = Policy::<String>::from_str("and(after(10),after(500000000))").unwrap();
+    }
 }

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1206,6 +1206,30 @@ mod tests {
     }
 
     #[test]
+    fn tranaslate_pk() {
+        pub struct TestTranslator;
+        impl Translator<String, String, ()> for TestTranslator {
+            fn pk(&mut self, pk: &String) -> Result<String, ()> {
+                let new = format!("NEW-{}", pk);
+                Ok(new.to_string())
+            }
+            fn sha256(&mut self, hash: &String) -> Result<String, ()> { Ok(hash.to_string()) }
+            fn hash256(&mut self, hash: &String) -> Result<String, ()> { Ok(hash.to_string()) }
+            fn ripemd160(&mut self, hash: &String) -> Result<String, ()> { Ok(hash.to_string()) }
+            fn hash160(&mut self, hash: &String) -> Result<String, ()> { Ok(hash.to_string()) }
+        }
+        let policy = Policy::<String>::from_str("or(and(pk(A),pk(B)),pk(C))").unwrap();
+        let mut t = TestTranslator;
+
+        let want = Policy::<String>::from_str("or(and(pk(NEW-A),pk(NEW-B)),pk(NEW-C))").unwrap();
+        let got = policy
+            .translate_pk(&mut t)
+            .expect("failed to translate keys");
+
+        assert_eq!(got, want);
+    }
+
+    #[test]
     fn translate_unsatisfiable_pk() {
         let policy = Policy::<String>::from_str("or(and(pk(A),pk(B)),pk(C))").unwrap();
 

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -560,50 +560,36 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         T: Translator<Pk, Q, E>,
         Q: MiniscriptKey,
     {
-        self._translate_pk(t)
-    }
+        use Policy::*;
 
-    fn _translate_pk<Q, E, T>(&self, t: &mut T) -> Result<Policy<Q>, E>
-    where
-        T: Translator<Pk, Q, E>,
-        Q: MiniscriptKey,
-    {
-        match *self {
-            Policy::Unsatisfiable => Ok(Policy::Unsatisfiable),
-            Policy::Trivial => Ok(Policy::Trivial),
-            Policy::Key(ref pk) => t.pk(pk).map(Policy::Key),
-            Policy::Sha256(ref h) => t.sha256(h).map(Policy::Sha256),
-            Policy::Hash256(ref h) => t.hash256(h).map(Policy::Hash256),
-            Policy::Ripemd160(ref h) => t.ripemd160(h).map(Policy::Ripemd160),
-            Policy::Hash160(ref h) => t.hash160(h).map(Policy::Hash160),
-            Policy::Older(n) => Ok(Policy::Older(n)),
-            Policy::After(n) => Ok(Policy::After(n)),
-            Policy::Threshold(k, ref subs) => {
-                let new_subs: Result<Vec<Policy<Q>>, _> =
-                    subs.iter().map(|sub| sub._translate_pk(t)).collect();
-                new_subs
-                    .map(|ok| Policy::Threshold(k, ok.into_iter().map(|p| Arc::new(p)).collect()))
-            }
-            Policy::And(ref subs) => {
-                let new_subs = subs
+        let mut translated = vec![];
+        for data in self.post_order_iter() {
+            let child_n = |n| Arc::clone(&translated[data.child_indices[n]]);
+
+            let new_policy = match data.node {
+                Unsatisfiable => Unsatisfiable,
+                Trivial => Trivial,
+                Key(ref pk) => t.pk(pk).map(Key)?,
+                Sha256(ref h) => t.sha256(h).map(Sha256)?,
+                Hash256(ref h) => t.hash256(h).map(Hash256)?,
+                Ripemd160(ref h) => t.ripemd160(h).map(Ripemd160)?,
+                Hash160(ref h) => t.hash160(h).map(Hash160)?,
+                Older(ref n) => Older(*n),
+                After(ref n) => After(*n),
+                Threshold(ref k, ref subs) => Threshold(*k, (0..subs.len()).map(child_n).collect()),
+                And(ref subs) => And((0..subs.len()).map(child_n).collect()),
+                Or(ref subs) => Or(subs
                     .iter()
-                    .map(|sub| sub._translate_pk(t))
-                    .collect::<Result<Vec<Policy<Q>>, E>>()?;
-                Ok(Policy::And(new_subs.into_iter().map(|p| Arc::new(p)).collect()))
-            }
-            Policy::Or(ref subs) => {
-                let new_subs = subs
-                    .iter()
-                    .map(|(prob, sub)| Ok((*prob, sub._translate_pk(t)?)))
-                    .collect::<Result<Vec<(usize, Policy<Q>)>, E>>()?;
-                Ok(Policy::Or(
-                    new_subs
-                        .into_iter()
-                        .map(|(prob, sub)| (prob, Arc::new(sub)))
-                        .collect(),
-                ))
-            }
+                    .enumerate()
+                    .map(|(i, (prob, _))| (*prob, child_n(i)))
+                    .collect()),
+            };
+            translated.push(Arc::new(new_policy));
         }
+        // Unwrap is ok because we know we processed at least one node.
+        let root_node = translated.pop().unwrap();
+        // Unwrap is ok because we know `root_node` is the only strong reference.
+        Ok(Arc::try_unwrap(root_node).unwrap())
     }
 
     /// Translates `Concrete::Key(key)` to `Concrete::Unsatisfiable` when extracting `TapKey`.

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1205,4 +1205,14 @@ mod tests {
         }));
         assert_eq!(count, 17);
     }
+
+    #[test]
+    fn translate_unsatisfiable_pk() {
+        let policy = Policy::<String>::from_str("or(and(pk(A),pk(B)),pk(C))").unwrap();
+
+        let want = Policy::<String>::from_str("or(and(pk(A),UNSATISFIABLE),pk(C))").unwrap();
+        let got = policy.translate_unsatisfiable_pk(&"B".to_string());
+
+        assert_eq!(got, want);
+    }
 }

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1222,4 +1222,14 @@ mod tests {
 
         assert_eq!(got, want);
     }
+
+    #[test]
+    fn keys() {
+        let policy = Policy::<String>::from_str("or(and(pk(A),pk(B)),pk(C))").unwrap();
+
+        let want = vec!["A", "B", "C"];
+        let got = policy.keys();
+
+        assert_eq!(got, want);
+    }
 }

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1203,7 +1203,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn for_each_key() {
+    fn for_each_key_count_keys() {
         let liquid_pol = Policy::<String>::from_str(
             "or(and(older(4096),thresh(2,pk(A),pk(B),pk(C))),thresh(11,pk(F1),pk(F2),pk(F3),pk(F4),pk(F5),pk(F6),pk(F7),pk(F8),pk(F9),pk(F10),pk(F11),pk(F12),pk(F13),pk(F14)))").unwrap();
         let mut count = 0;
@@ -1212,6 +1212,13 @@ mod tests {
             true
         }));
         assert_eq!(count, 17);
+    }
+
+    #[test]
+    fn for_each_key_fails_predicate() {
+        let policy =
+            Policy::<String>::from_str("or(and(pk(key0),pk(key1)),pk(oddnamedkey))").unwrap();
+        assert!(!policy.for_each_key(|k| k.starts_with("key")));
     }
 
     #[test]

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1225,4 +1225,11 @@ mod tests {
 
         assert_eq!(got, want);
     }
+
+    #[test]
+    #[cfg(feature = "compiler")]
+    fn num_tap_leaves() {
+        let policy = Policy::<String>::from_str("or(and(pk(A),pk(B)),pk(C))").unwrap();
+        assert_eq!(policy.num_tap_leaves(), 2);
+    }
 }

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -544,30 +544,14 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
 
 impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
     fn for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, mut pred: F) -> bool {
-        self.real_for_each_key(&mut pred)
+        self.pre_order_iter().all(|policy| match policy {
+            Policy::Key(ref pk) => pred(pk),
+            _ => true,
+        })
     }
 }
 
 impl<Pk: MiniscriptKey> Policy<Pk> {
-    fn real_for_each_key<'a, F: FnMut(&'a Pk) -> bool>(&'a self, pred: &mut F) -> bool {
-        match *self {
-            Policy::Unsatisfiable | Policy::Trivial => true,
-            Policy::Key(ref pk) => pred(pk),
-            Policy::Sha256(..)
-            | Policy::Hash256(..)
-            | Policy::Ripemd160(..)
-            | Policy::Hash160(..)
-            | Policy::After(..)
-            | Policy::Older(..) => true,
-            Policy::Threshold(_, ref subs) | Policy::And(ref subs) => {
-                subs.iter().all(|sub| sub.real_for_each_key(&mut *pred))
-            }
-            Policy::Or(ref subs) => subs
-                .iter()
-                .all(|(_, sub)| sub.real_for_each_key(&mut *pred)),
-        }
-    }
-
     /// Converts a policy using one kind of public key to another type of public key.
     ///
     /// For example usage please see [`crate::policy::semantic::Policy::translate_pk`].

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -685,17 +685,21 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// Returns an error if there is at least one satisfaction that contains
     /// a combination of heightlock and timelock.
     pub fn check_timelocks(&self) -> Result<(), PolicyError> {
-        let timelocks = self.check_timelocks_helper();
-        if timelocks.contains_combination {
+        let aggregated_timelock_info = self.timelock_info();
+        if aggregated_timelock_info.contains_combination {
             Err(PolicyError::HeightTimelockCombination)
         } else {
             Ok(())
         }
     }
 
-    // Checks whether the given concrete policy contains a combination of
-    // timelocks and heightlocks
-    fn check_timelocks_helper(&self) -> TimelockInfo {
+    /// Processes `Policy` using `post_order_iter`, creates a `TimelockInfo` for each `Nullary` node
+    /// and combines them together for `Nary` nodes.
+    ///
+    /// # Returns
+    ///
+    /// A single `TimelockInfo` that is the combination of all others after processing each node.
+    fn timelock_info(&self) -> TimelockInfo {
         use Policy::*;
 
         let mut infos = vec![];

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -656,19 +656,12 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
 
     /// Gets all keys in the policy.
     pub fn keys(&self) -> Vec<&Pk> {
-        match *self {
-            Policy::Key(ref pk) => vec![pk],
-            Policy::Threshold(_k, ref subs) => {
-                subs.iter().flat_map(|sub| sub.keys()).collect::<Vec<_>>()
-            }
-            Policy::And(ref subs) => subs.iter().flat_map(|sub| sub.keys()).collect::<Vec<_>>(),
-            Policy::Or(ref subs) => subs
-                .iter()
-                .flat_map(|(ref _k, ref sub)| sub.keys())
-                .collect::<Vec<_>>(),
-            // map all hashes and time
-            _ => vec![],
-        }
+        self.pre_order_iter()
+            .filter_map(|policy| match policy {
+                Policy::Key(ref pk) => Some(pk),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Gets the number of [TapLeaf](`TapTree::Leaf`)s considering exhaustive root-level [`Policy::Or`]

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -22,6 +22,7 @@ pub use self::concrete::Policy as Concrete;
 pub use self::semantic::Policy as Semantic;
 use crate::descriptor::Descriptor;
 use crate::miniscript::{Miniscript, ScriptContext};
+use crate::sync::Arc;
 use crate::{Error, MiniscriptKey, Terminal};
 
 /// Policy entailment algorithm maximum number of terminals allowed.
@@ -212,6 +213,9 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
         .normalized();
         Ok(ret)
     }
+}
+impl<Pk: MiniscriptKey> Liftable<Pk> for Arc<Concrete<Pk>> {
+    fn lift(&self) -> Result<Semantic<Pk>, Error> { self.as_ref().lift() }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Make a start on removing recursion in the `policy::concrete` module.

- Patch 1: Remove`PolicyArc`
- Patch2: Implement `TreeLike` for `concrete::Policy` (does not use it)
- Patch 3: Trivial code comment deletion
- Subsequent patches are pairs
   - Add a basic unit test for the function we are about to patch
   - Remove recursion from a function (the one we just tested)
- Final patch is a refactoring 

There is still some to go but this is already a pretty heavy review burden.
