### PR TITLE
CI: Pin memchr

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -29,6 +29,7 @@ if cargo --version | grep "1\.48\.0"; then
     cargo update -p serde --precise 1.0.152
     cargo update -p log --precise 0.4.18
     cargo update -p serde_test --precise 1.0.152
+    cargo update -p memchr --precise 2.5.0
 fi
 
 # Test bitcoind integration tests if told to (this only works with the stable toolchain)


### PR DESCRIPTION
Recently `memchr` broke our MSRV by updating to edition 2021 in a patch version, pin it in CI for MSRV builds.