### PR TITLE
Add a `Threshold` type

### DIFF
--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -197,7 +197,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> policy::Liftable<Pk> for SortedMultiVec<Pk, Ctx> {
     fn lift(&self) -> Result<policy::semantic::Policy<Pk>, Error> {
-        let ret = policy::semantic::Policy::Threshold(
+        let ret = policy::semantic::Policy::Thresh(
             self.k,
             self.pks
                 .iter()

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -621,7 +621,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for TapTree<Pk> {
         fn lift_helper<Pk: MiniscriptKey>(s: &TapTree<Pk>) -> Result<Policy<Pk>, Error> {
             match *s {
                 TapTree::Tree { ref left, ref right, height: _ } => {
-                    Ok(Policy::Threshold(1, vec![lift_helper(left)?, lift_helper(right)?]))
+                    Ok(Policy::Thresh(1, vec![lift_helper(left)?, lift_helper(right)?]))
                 }
                 TapTree::Leaf(ref leaf) => leaf.lift(),
             }
@@ -636,7 +636,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Tr<Pk> {
     fn lift(&self) -> Result<Policy<Pk>, Error> {
         match &self.tree {
             Some(root) => {
-                Ok(Policy::Threshold(1, vec![Policy::Key(self.internal_key.clone()), root.lift()?]))
+                Ok(Policy::Thresh(1, vec![Policy::Key(self.internal_key.clone()), root.lift()?]))
             }
             None => Ok(Policy::Key(self.internal_key.clone())),
         }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -77,7 +77,7 @@ impl<'a, Pk: MiniscriptKey> TreeLike for &'a policy::Concrete<Pk> {
             | Ripemd160(_) | Hash160(_) => Tree::Nullary,
             And(ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
             Or(ref v) => Tree::Nary(v.iter().map(|(_, p)| p.as_ref()).collect()),
-            Threshold(_, ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
+            Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
         }
     }
 }
@@ -90,7 +90,7 @@ impl<'a, Pk: MiniscriptKey> TreeLike for Arc<policy::Concrete<Pk>> {
             | Ripemd160(_) | Hash160(_) => Tree::Nullary,
             And(ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
             Or(ref v) => Tree::Nary(v.iter().map(|(_, p)| Arc::clone(p)).collect()),
-            Threshold(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
+            Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
         }
     }
 }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -77,7 +77,7 @@ impl<'a, Pk: MiniscriptKey> TreeLike for &'a policy::Concrete<Pk> {
             | Ripemd160(_) | Hash160(_) => Tree::Nullary,
             And(ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
             Or(ref v) => Tree::Nary(v.iter().map(|(_, p)| p.as_ref()).collect()),
-            Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
+            Thresh(thresh) => Tree::Nary(thresh.iter().map(Arc::as_ref).collect()),
         }
     }
 }
@@ -90,7 +90,7 @@ impl<'a, Pk: MiniscriptKey> TreeLike for Arc<policy::Concrete<Pk>> {
             | Ripemd160(_) | Hash160(_) => Tree::Nullary,
             And(ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
             Or(ref v) => Tree::Nary(v.iter().map(|(_, p)| Arc::clone(p)).collect()),
-            Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
+            Thresh(thresh) => Tree::Nary(thresh.iter().map(Arc::clone).collect()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub mod miniscript;
 pub mod plan;
 pub mod policy;
 pub mod psbt;
+pub mod threshold;
 
 #[cfg(test)]
 mod test_utils;
@@ -861,7 +862,7 @@ mod prelude {
         rc, slice,
         string::{String, ToString},
         sync,
-        vec::Vec,
+        vec::{self, Vec},
     };
     #[cfg(any(feature = "std", test))]
     pub use std::{
@@ -872,7 +873,7 @@ mod prelude {
         string::{String, ToString},
         sync,
         sync::Mutex,
-        vec::Vec,
+        vec::{self, Vec},
     };
 
     #[cfg(all(not(feature = "std"), not(test)))]

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -920,7 +920,7 @@ where
             compile_binary!(&mut l_comp[3], &mut r_comp[2], [lw, rw], Terminal::OrI);
             compile_binary!(&mut r_comp[3], &mut l_comp[2], [rw, lw], Terminal::OrI);
         }
-        Concrete::Threshold(k, ref subs) => {
+        Concrete::Thresh(k, ref subs) => {
             let n = subs.len();
             let k_over_n = k as f64 / n as f64;
 
@@ -1301,7 +1301,7 @@ mod tests {
         let policy: BPolicy = Concrete::Or(vec![
             (
                 127,
-                Arc::new(Concrete::Threshold(
+                Arc::new(Concrete::Thresh(
                     3,
                     key_pol[0..5].iter().map(|p| (p.clone()).into()).collect(),
                 )),
@@ -1310,7 +1310,7 @@ mod tests {
                 1,
                 Arc::new(Concrete::And(vec![
                     Arc::new(Concrete::Older(Sequence::from_height(10000))),
-                    Arc::new(Concrete::Threshold(
+                    Arc::new(Concrete::Thresh(
                         2,
                         key_pol[5..8].iter().map(|p| (p.clone()).into()).collect(),
                     )),
@@ -1430,7 +1430,7 @@ mod tests {
                 .iter()
                 .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
                 .collect();
-            let big_thresh = Concrete::Threshold(*k, pubkeys);
+            let big_thresh = Concrete::Thresh(*k, pubkeys);
             let big_thresh_ms: SegwitMiniScript = big_thresh.compile().unwrap();
             if *k == 21 {
                 // N * (PUSH + pubkey + CHECKSIGVERIFY)
@@ -1466,8 +1466,8 @@ mod tests {
             .collect();
 
         let thresh_res: Result<SegwitMiniScript, _> = Concrete::Or(vec![
-            (1, Arc::new(Concrete::Threshold(keys_a.len(), keys_a))),
-            (1, Arc::new(Concrete::Threshold(keys_b.len(), keys_b))),
+            (1, Arc::new(Concrete::Thresh(keys_a.len(), keys_a))),
+            (1, Arc::new(Concrete::Thresh(keys_b.len(), keys_b))),
         ])
         .compile();
         let script_size = thresh_res.clone().and_then(|m| Ok(m.script_size()));
@@ -1484,8 +1484,7 @@ mod tests {
             .iter()
             .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
             .collect();
-        let thresh_res: Result<SegwitMiniScript, _> =
-            Concrete::Threshold(keys.len(), keys).compile();
+        let thresh_res: Result<SegwitMiniScript, _> = Concrete::Thresh(keys.len(), keys).compile();
         let n_elements = thresh_res
             .clone()
             .and_then(|m| Ok(m.max_satisfaction_witness_elements()));
@@ -1506,7 +1505,7 @@ mod tests {
             .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
             .collect();
         let thresh_res: Result<SegwitMiniScript, _> =
-            Concrete::Threshold(keys.len() - 1, keys).compile();
+            Concrete::Thresh(keys.len() - 1, keys).compile();
         let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops.op_count()));
         assert_eq!(
             thresh_res,
@@ -1520,7 +1519,7 @@ mod tests {
             .iter()
             .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
             .collect();
-        let thresh_res = Concrete::Threshold(keys.len() - 1, keys).compile::<Legacy>();
+        let thresh_res = Concrete::Thresh(keys.len() - 1, keys).compile::<Legacy>();
         let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops.op_count()));
         assert_eq!(
             thresh_res,

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -136,12 +136,12 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
             | Terminal::NonZero(ref sub)
             | Terminal::ZeroNotEqual(ref sub) => sub.node.lift()?,
             Terminal::AndV(ref left, ref right) | Terminal::AndB(ref left, ref right) => {
-                Semantic::Threshold(2, vec![left.node.lift()?, right.node.lift()?])
+                Semantic::Thresh(2, vec![left.node.lift()?, right.node.lift()?])
             }
-            Terminal::AndOr(ref a, ref b, ref c) => Semantic::Threshold(
+            Terminal::AndOr(ref a, ref b, ref c) => Semantic::Thresh(
                 1,
                 vec![
-                    Semantic::Threshold(2, vec![a.node.lift()?, b.node.lift()?]),
+                    Semantic::Thresh(2, vec![a.node.lift()?, b.node.lift()?]),
                     c.node.lift()?,
                 ],
             ),
@@ -149,14 +149,14 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
             | Terminal::OrD(ref left, ref right)
             | Terminal::OrC(ref left, ref right)
             | Terminal::OrI(ref left, ref right) => {
-                Semantic::Threshold(1, vec![left.node.lift()?, right.node.lift()?])
+                Semantic::Thresh(1, vec![left.node.lift()?, right.node.lift()?])
             }
             Terminal::Thresh(k, ref subs) => {
                 let semantic_subs: Result<_, Error> = subs.iter().map(|s| s.node.lift()).collect();
-                Semantic::Threshold(k, semantic_subs?)
+                Semantic::Thresh(k, semantic_subs?)
             }
             Terminal::Multi(k, ref keys) | Terminal::MultiA(k, ref keys) => {
-                Semantic::Threshold(k, keys.iter().map(|k| Semantic::Key(k.clone())).collect())
+                Semantic::Thresh(k, keys.iter().map(|k| Semantic::Key(k.clone())).collect())
             }
         }
         .normalized();
@@ -198,16 +198,16 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
             Concrete::Hash160(ref h) => Semantic::Hash160(h.clone()),
             Concrete::And(ref subs) => {
                 let semantic_subs: Result<_, Error> = subs.iter().map(Liftable::lift).collect();
-                Semantic::Threshold(2, semantic_subs?)
+                Semantic::Thresh(2, semantic_subs?)
             }
             Concrete::Or(ref subs) => {
                 let semantic_subs: Result<_, Error> =
                     subs.iter().map(|(_p, sub)| sub.lift()).collect();
-                Semantic::Threshold(1, semantic_subs?)
+                Semantic::Thresh(1, semantic_subs?)
             }
-            Concrete::Threshold(k, ref subs) => {
+            Concrete::Thresh(k, ref subs) => {
                 let semantic_subs: Result<_, Error> = subs.iter().map(Liftable::lift).collect();
-                Semantic::Threshold(k, semantic_subs?)
+                Semantic::Thresh(k, semantic_subs?)
             }
         }
         .normalized();
@@ -345,10 +345,10 @@ mod tests {
                 .parse()
                 .unwrap();
         assert_eq!(
-            Semantic::Threshold(
+            Semantic::Thresh(
                 1,
                 vec![
-                    Semantic::Threshold(
+                    Semantic::Thresh(
                         2,
                         vec![
                             Semantic::Key(key_a),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -205,9 +205,9 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
                     subs.iter().map(|(_p, sub)| sub.lift()).collect();
                 Semantic::Thresh(1, semantic_subs?)
             }
-            Concrete::Thresh(k, ref subs) => {
-                let semantic_subs: Result<_, Error> = subs.iter().map(Liftable::lift).collect();
-                Semantic::Thresh(k, semantic_subs?)
+            Concrete::Thresh(ref thresh) => {
+                let semantic_subs: Result<_, Error> = thresh.iter().map(Liftable::lift).collect();
+                Semantic::Thresh(thresh.k(), semantic_subs?)
             }
         }
         .normalized();

--- a/src/threshold.rs
+++ b/src/threshold.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! A generic (k,n)-threshold type.
+
+use core::fmt;
+
+use crate::prelude::{vec, Vec};
+
+/// A (k, n)-threshold.
+///
+/// This type maintains the following invariants:
+/// -   n > 0
+/// -   k > 0
+/// -   k <= n
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Threshold<T> {
+    k: usize,
+    v: Vec<T>,
+}
+
+impl<T> Threshold<T> {
+    /// Creates a `Theshold<T>` after checking that invariants hold.
+    pub fn new(k: usize, v: Vec<T>) -> Result<Threshold<T>, Error> {
+        if v.len() == 0 {
+            Err(Error::ZeroN)
+        } else if k == 0 {
+            Err(Error::ZeroK)
+        } else if k > v.len() {
+            Err(Error::BigK)
+        } else {
+            Ok(Threshold { k, v })
+        }
+    }
+
+    /// Creates a `Theshold<T>` without checking that invariants hold.
+    #[cfg(test)]
+    pub fn new_unchecked(k: usize, v: Vec<T>) -> Threshold<T> { Threshold { k, v } }
+
+    /// Returns `k`, the threshold value.
+    pub fn k(&self) -> usize { self.k }
+
+    /// Returns `n`, the total number of elements in the threshold.
+    pub fn n(&self) -> usize { self.v.len() }
+
+    /// Returns a read-only iterator over the threshold elements.
+    pub fn iter(&self) -> core::slice::Iter<'_, T> { self.v.iter() }
+
+    /// Creates an iterator over the threshold elements.
+    pub fn into_iter(self) -> vec::IntoIter<T> { self.v.into_iter() }
+
+    /// Creates an iterator over the threshold elements.
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, T> { self.v.iter_mut() }
+
+    /// Returns the threshold elements, consuming self.
+    pub fn into_elements(self) -> Vec<T> { self.v }
+
+    /// Creates a new (k, n)-threshold using a newly mapped vector.
+    ///
+    /// Typically this function is called after collecting a vector that was
+    /// created by iterating this threshold. E.g.,
+    ///
+    /// `thresh.mapped((0..thresh.n()).map(|element| some_function(element)).collect())`
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new vector is not the same length as the
+    /// original i.e., `new.len() != self.n()`.
+    pub(crate) fn mapped<U>(&self, new: Vec<U>) -> Threshold<U> {
+        if self.n() != new.len() {
+            panic!("cannot map to a different length vector")
+        }
+        Threshold { k: self.k(), v: new }
+    }
+}
+
+/// An error attempting to construct a `Threshold<T>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error {
+    /// Threshold `n` value must be non-zero.
+    ZeroN,
+    /// Threshold `k` value must be non-zero.
+    ZeroK,
+    /// Threshold `k` value must be <= `n`.
+    BigK,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            ZeroN => f.write_str("threshold `n` value must be non-zero"),
+            ZeroK => f.write_str("threshold `k` value must be non-zero"),
+            BigK => f.write_str("threshold `k` value must be <= `n`"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
+        use Error::*;
+
+        match *self {
+            ZeroN | ZeroK | BigK => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn threshold_constructor_valid() {
+        let v = vec![1, 2, 3];
+        let n = 3;
+
+        for k in 1..=3 {
+            let thresh = Threshold::new(k, v.clone()).expect("failed to create threshold");
+            assert_eq!(thresh.k(), k);
+            assert_eq!(thresh.n(), n);
+        }
+    }
+
+    #[test]
+    fn threshold_constructor_invalid() {
+        let v = vec![1, 2, 3];
+        assert!(Threshold::new(0, v.clone()).is_err());
+        assert!(Threshold::new(4, v.clone()).is_err());
+    }
+}


### PR DESCRIPTION
Draft because I think we should use the new `Threshold` type in `sematic::Policy` as well before we consider this for merge, last weeks effort at that got me into a mess.

Creates the new type `crate::threshold::Threshold` that is an (k, n)-threshold and enforces the invariants 
- k != 0
- n != 0
- k < n

Use it in `policy::concrete::Policy`.
