### PR TITLE
Use `bech32` to calculate descriptor checksums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 
 [features]
 default = ["std"]
-std = ["bitcoin/std", "bitcoin/secp-recovery"]
-no-std = ["bitcoin/no-std"]
+std = ["bitcoin/std", "bitcoin/secp-recovery", "bech32/std"]
+no-std = ["bitcoin/no-std", "bech32/alloc"]
 compiler = []
 trace = []
 
@@ -22,6 +22,7 @@ rand = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
 
 [dependencies]
+bech32 = { version = "0.10.0-beta", default-features = false }
 bitcoin = { version = "0.30.0", default-features = false }
 internals = { package = "bitcoin-private", version = "0.1.0", default_features = false }
 

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -12,8 +12,8 @@ use core::fmt;
 use bitcoin::script::{self, PushBytes};
 use bitcoin::{Address, Network, ScriptBuf};
 
-use super::checksum::{self, verify_checksum};
-use crate::descriptor::DefiniteDescriptorKey;
+use super::checksum::verify_checksum;
+use crate::descriptor::{write_descriptor, DefiniteDescriptorKey};
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::{ScriptContext, ScriptContextError};
 use crate::miniscript::satisfy::{Placeholder, Satisfaction, Witness};
@@ -156,12 +156,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Bare<Pk> {
 }
 
 impl<Pk: MiniscriptKey> fmt::Display for Bare<Pk> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use fmt::Write;
-        let mut wrapped_f = checksum::Formatter::new(f);
-        write!(wrapped_f, "{}", self.ms)?;
-        wrapped_f.write_checksum_if_not_alt()
-    }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write_descriptor!(f, "{}", self.ms) }
 }
 
 impl<Pk: MiniscriptKey> Liftable<Pk> for Bare<Pk> {
@@ -354,10 +349,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Pkh<Pk> {
 
 impl<Pk: MiniscriptKey> fmt::Display for Pkh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use fmt::Write;
-        let mut wrapped_f = checksum::Formatter::new(f);
-        write!(wrapped_f, "pkh({})", self.pk)?;
-        wrapped_f.write_checksum_if_not_alt()
+        write_descriptor!(f, "pkh({})", self.pk)
     }
 }
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -978,6 +978,21 @@ impl<Pk: MiniscriptKey> fmt::Display for Descriptor<Pk> {
 
 serde_string_impl_pk!(Descriptor, "a script descriptor");
 
+macro_rules! write_descriptor {
+    ($fmt:expr, $s:literal $(, $args:expr)*) => {
+        {
+            use fmt::Write as _;
+
+            let mut wrapped_f = $crate::descriptor::checksum::Formatter::new($fmt);
+            write!(wrapped_f, $s $(, $args)*)?;
+            wrapped_f.write_checksum_if_not_alt()?;
+
+            fmt::Result::Ok(())
+        }
+    }
+}
+pub(crate) use write_descriptor;
+
 #[cfg(test)]
 mod tests {
     use core::convert::TryFrom;

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -9,9 +9,9 @@ use core::fmt;
 
 use bitcoin::{Address, Network, ScriptBuf};
 
-use super::checksum::{self, verify_checksum};
+use super::checksum::verify_checksum;
 use super::SortedMultiVec;
-use crate::descriptor::DefiniteDescriptorKey;
+use crate::descriptor::{write_descriptor, DefiniteDescriptorKey};
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::{ScriptContext, ScriptContextError};
 use crate::miniscript::satisfy::{Placeholder, Satisfaction, Witness};
@@ -260,13 +260,10 @@ impl<Pk: MiniscriptKey> fmt::Debug for Wsh<Pk> {
 
 impl<Pk: MiniscriptKey> fmt::Display for Wsh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use fmt::Write;
-        let mut wrapped_f = checksum::Formatter::new(f);
         match self.inner {
-            WshInner::SortedMulti(ref smv) => write!(wrapped_f, "wsh({})", smv)?,
-            WshInner::Ms(ref ms) => write!(wrapped_f, "wsh({})", ms)?,
+            WshInner::SortedMulti(ref smv) => write_descriptor!(f, "wsh({})", smv),
+            WshInner::Ms(ref ms) => write_descriptor!(f, "wsh({})", ms),
         }
-        wrapped_f.write_checksum_if_not_alt()
     }
 }
 
@@ -461,10 +458,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Wpkh<Pk> {
 
 impl<Pk: MiniscriptKey> fmt::Display for Wpkh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use fmt::Write;
-        let mut wrapped_f = checksum::Formatter::new(f);
-        write!(wrapped_f, "wpkh({})", self.pk)?;
-        wrapped_f.write_checksum_if_not_alt()
+        write_descriptor!(f, "wpkh({})", self.pk)
     }
 }
 

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -13,9 +13,9 @@ use core::fmt;
 use bitcoin::script::PushBytes;
 use bitcoin::{script, Address, Network, ScriptBuf};
 
-use super::checksum::{self, verify_checksum};
+use super::checksum::verify_checksum;
 use super::{SortedMultiVec, Wpkh, Wsh};
-use crate::descriptor::DefiniteDescriptorKey;
+use crate::descriptor::{write_descriptor, DefiniteDescriptorKey};
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::ScriptContext;
 use crate::miniscript::satisfy::{Placeholder, Satisfaction};
@@ -72,15 +72,12 @@ impl<Pk: MiniscriptKey> fmt::Debug for Sh<Pk> {
 
 impl<Pk: MiniscriptKey> fmt::Display for Sh<Pk> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use fmt::Write;
-        let mut wrapped_f = checksum::Formatter::new(f);
         match self.inner {
-            ShInner::Wsh(ref wsh) => write!(wrapped_f, "sh({:#})", wsh)?,
-            ShInner::Wpkh(ref pk) => write!(wrapped_f, "sh({:#})", pk)?,
-            ShInner::SortedMulti(ref smv) => write!(wrapped_f, "sh({})", smv)?,
-            ShInner::Ms(ref ms) => write!(wrapped_f, "sh({})", ms)?,
+            ShInner::Wsh(ref wsh) => write_descriptor!(f, "sh({:#})", wsh),
+            ShInner::Wpkh(ref pk) => write_descriptor!(f, "sh({:#})", pk),
+            ShInner::SortedMulti(ref smv) => write_descriptor!(f, "sh({})", smv),
+            ShInner::Ms(ref ms) => write_descriptor!(f, "sh({})", ms),
         }
-        wrapped_f.write_checksum_if_not_alt()
     }
 }
 


### PR DESCRIPTION
This is just the last patch, the rest are in #609 now.

The `checksum::poly_mod` function implements BCH codes to calculate a checksum (appended to descriptors). We recently released a version of BCH codes in `bech32`. We can implement the `bech32::Checksum` trait for BIP-380 and use the `primitives::checksum` module, removing the custom `poly_mod` function.
