### PR TITLE
Add back in helper function `semantic::Policy::_translate_pk`

### DIFF
--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -563,6 +563,14 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         T: Translator<Pk, Q, E>,
         Q: MiniscriptKey,
     {
+        self._translate_pk(t)
+    }
+
+    fn _translate_pk<Q, E, T>(&self, t: &mut T) -> Result<Policy<Q>, E>
+    where
+        T: Translator<Pk, Q, E>,
+        Q: MiniscriptKey,
+    {
         use Policy::*;
 
         let mut translated = vec![];


### PR DESCRIPTION
Recently while removing recursion I mistakenly removed the `_translate_pk` function forgetting that this was a trick to prevent compilation explosion caused by the generics.