### PR TITLE
Remove recursion in `semantic` module

### DIFF
--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -17,6 +17,7 @@ use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
 use crate::miniscript::satisfy::{Placeholder, Satisfaction};
 use crate::plan::AssetProvider;
 use crate::prelude::*;
+use crate::sync::Arc;
 use crate::{
     errstr, expression, policy, script_num_size, Error, ForEachKey, Miniscript, MiniscriptKey,
     Satisfier, ToPublicKey, TranslateErr, Translator,
@@ -201,7 +202,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> policy::Liftable<Pk> for SortedMulti
             self.k,
             self.pks
                 .iter()
-                .map(|k| policy::semantic::Policy::Key(k.clone()))
+                .map(|k| Arc::new(policy::semantic::Policy::Key(k.clone())))
                 .collect(),
         );
         Ok(ret)

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -15,7 +15,7 @@ pub use tree::{
 };
 
 use crate::sync::Arc;
-use crate::{policy, Miniscript, MiniscriptKey, ScriptContext, Terminal};
+use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal};
 
 impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> TreeLike for &'a Miniscript<Pk, Ctx> {
     fn as_node(&self) -> Tree<Self> {
@@ -65,32 +65,6 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TreeLike for Arc<Miniscript<Pk, Ctx>
                 Tree::Nary(Arc::from([Arc::clone(a), Arc::clone(b), Arc::clone(c)]))
             }
             Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
-        }
-    }
-}
-
-impl<'a, Pk: MiniscriptKey> TreeLike for &'a policy::Concrete<Pk> {
-    fn as_node(&self) -> Tree<Self> {
-        use policy::Concrete::*;
-        match *self {
-            Unsatisfiable | Trivial | Key(_) | After(_) | Older(_) | Sha256(_) | Hash256(_)
-            | Ripemd160(_) | Hash160(_) => Tree::Nullary,
-            And(ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
-            Or(ref v) => Tree::Nary(v.iter().map(|(_, p)| p.as_ref()).collect()),
-            Threshold(_, ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
-        }
-    }
-}
-
-impl<Pk: MiniscriptKey> TreeLike for Arc<policy::Concrete<Pk>> {
-    fn as_node(&self) -> Tree<Self> {
-        use policy::Concrete::*;
-        match self.as_ref() {
-            Unsatisfiable | Trivial | Key(_) | After(_) | Older(_) | Sha256(_) | Hash256(_)
-            | Ripemd160(_) | Hash160(_) => Tree::Nullary,
-            And(ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
-            Or(ref v) => Tree::Nary(v.iter().map(|(_, p)| Arc::clone(p)).collect()),
-            Threshold(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
         }
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -223,14 +223,12 @@ mod tests {
     use core::str::FromStr;
 
     use bitcoin::Sequence;
-    #[cfg(feature = "compiler")]
-    use sync::Arc;
 
-    use super::super::miniscript::context::Segwitv0;
-    use super::super::miniscript::Miniscript;
-    use super::{Concrete, Liftable, Semantic};
+    use super::*;
     #[cfg(feature = "compiler")]
     use crate::descriptor::Tr;
+    use crate::miniscript::context::Segwitv0;
+    use crate::miniscript::Miniscript;
     use crate::prelude::*;
     #[cfg(feature = "compiler")]
     use crate::{descriptor::TapTree, Descriptor, Tap};

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -596,17 +596,12 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// Counts the number of public keys and keyhashes referenced in a policy.
     /// Duplicate keys will be double-counted.
     pub fn n_keys(&self) -> usize {
-        match *self {
-            Policy::Unsatisfiable | Policy::Trivial => 0,
-            Policy::Key(..) => 1,
-            Policy::After(..)
-            | Policy::Older(..)
-            | Policy::Sha256(..)
-            | Policy::Hash256(..)
-            | Policy::Ripemd160(..)
-            | Policy::Hash160(..) => 0,
-            Policy::Threshold(_, ref subs) => subs.iter().map(|sub| sub.n_keys()).sum::<usize>(),
-        }
+        self.pre_order_iter()
+            .filter(|policy| match policy {
+                Policy::Key(..) => true,
+                _ => false,
+            })
+            .count()
     }
 
     /// Counts the minimum number of public keys for which signatures could be

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -372,7 +372,7 @@ impl_from_tree!(
                 // thresh(1) and thresh(n) are disallowed in semantic policies
                 if thresh <= 1 || thresh >= (nsubs as u32 - 1) {
                     return Err(errstr(
-                        "Semantic Policy thresh cannot have k = 1 or k =n, use `and`/`or` instead",
+                        "Semantic Policy thresh cannot have k = 1 or k = n, use `and`/`or` instead",
                     ));
                 }
                 if thresh >= (nsubs as u32) {

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -410,6 +410,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
 
                 let is_and = m == n;
                 let is_or = m == 1;
+
                 for sub in subs {
                     match sub {
                         Policy::Trivial | Policy::Unsatisfiable => {}

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -407,7 +407,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
 
                 let n = subs.len() - unsatisfied_count - trivial_count; // remove all true/false
                 let m = k.checked_sub(trivial_count).map_or(0, |x| x); // satisfy all trivial
-                                                                       // m == n denotes `and` and m == 1 denotes `or`
+
                 let is_and = m == n;
                 let is_or = m == 1;
                 for sub in subs {

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -406,7 +406,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                     .count();
 
                 let n = subs.len() - unsatisfied_count - trivial_count; // remove all true/false
-                let m = k.checked_sub(trivial_count).map_or(0, |x| x); // satisfy all trivial
+                let m = k.checked_sub(trivial_count).unwrap_or(0); // satisfy all trivial
 
                 let is_and = m == n;
                 let is_or = m == 1;


### PR DESCRIPTION
Remove most of the recursion in the `semantic` module. Does not do `normalized` and associated functions (ones that either call it or take in a normalized policy). 

Includes 4 trivial preparatory clean up patches at the front.