### PR TITLE
fuzz: Bump rustc to version1.65

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,7 +39,7 @@ compile_descriptor,
           key: cache-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: '1.65'
           override: true
           profile: minimal
       - name: fuzz

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         fuzz_target: [
-roundtrip_miniscript_str,
-roundtrip_miniscript_script,
-parse_descriptor,
 roundtrip_semantic,
+parse_descriptor,
 parse_descriptor_secret,
+roundtrip_miniscript_script,
+roundtrip_miniscript_str,
 roundtrip_descriptor,
 roundtrip_concrete,
 compile_descriptor,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,24 +15,24 @@ miniscript = { path = "..", features = [ "compiler" ] }
 regex = "1.0"
 
 [[bin]]
-name = "roundtrip_miniscript_str"
-path = "fuzz_targets/roundtrip_miniscript_str.rs"
-
-[[bin]]
-name = "roundtrip_miniscript_script"
-path = "fuzz_targets/roundtrip_miniscript_script.rs"
+name = "roundtrip_semantic"
+path = "fuzz_targets/roundtrip_semantic.rs"
 
 [[bin]]
 name = "parse_descriptor"
 path = "fuzz_targets/parse_descriptor.rs"
 
 [[bin]]
-name = "roundtrip_semantic"
-path = "fuzz_targets/roundtrip_semantic.rs"
-
-[[bin]]
 name = "parse_descriptor_secret"
 path = "fuzz_targets/parse_descriptor_secret.rs"
+
+[[bin]]
+name = "roundtrip_miniscript_script"
+path = "fuzz_targets/roundtrip_miniscript_script.rs"
+
+[[bin]]
+name = "roundtrip_miniscript_str"
+path = "fuzz_targets/roundtrip_miniscript_str.rs"
 
 [[bin]]
 name = "roundtrip_descriptor"

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -23,7 +23,7 @@ cargo-fuzz = true
 honggfuzz = { version = "0.5.55", default-features = false }
 miniscript = { path = "..", features = [ "compiler" ] }
 
-regex = "1.4"
+regex = "1.0"
 EOF
 
 for targetFile in $(listTargetFiles); do
@@ -72,7 +72,7 @@ $(for name in $(listTargetNames); do echo "$name,"; done)
           key: cache-\${{ matrix.target }}-\${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.58
+          toolchain: 1.64
           override: true
           profile: minimal
       - name: fuzz

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -72,7 +72,7 @@ $(for name in $(listTargetNames); do echo "$name,"; done)
           key: cache-\${{ matrix.target }}-\${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64
+          toolchain: '1.65'
           override: true
           profile: minimal
       - name: fuzz


### PR DESCRIPTION
CI is complaining:
    
    package `regex v1.10.0` cannot be built because it requires rustc 1.65
     or newer, while the currently active rustc version is 1.64.0
    
Bump rustc to v1.65 in the `generate_files.sh` script and run it.
