### PR TITLE
Clear trivial `clippy` warnings

### DIFF
--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -135,7 +135,7 @@ fn main() {
     println!("{:#?}", psbt);
 
     let serialized = psbt.serialize();
-    println!("{}", base64::encode(&serialized));
+    println!("{}", base64::encode(serialized));
 
     psbt.finalize_mut(&secp256k1).unwrap();
     println!("{:#?}", psbt);

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -130,7 +130,7 @@ fn main() {
 
     psbt.inputs[0]
         .partial_sigs
-        .insert(pk1, bitcoin::ecdsa::Signature { sig: sig1, hash_ty: hash_ty });
+        .insert(pk1, bitcoin::ecdsa::Signature { sig: sig1, hash_ty });
 
     println!("{:#?}", psbt);
 

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -80,10 +80,11 @@ fn main() {
 
     let (outpoint, witness_utxo) = get_vout(&depo_tx, &bridge_descriptor.script_pubkey());
 
-    let mut txin = TxIn::default();
-    txin.previous_output = outpoint;
-
-    txin.sequence = Sequence::from_height(26); //Sequence::MAX; //
+    let txin = TxIn {
+        previous_output: outpoint,
+        sequence: Sequence::from_height(26),
+        ..Default::default()
+    };
     psbt.unsigned_tx.input.push(txin);
 
     psbt.unsigned_tx

--- a/examples/taproot.rs
+++ b/examples/taproot.rs
@@ -137,8 +137,8 @@ fn hardcoded_xonlypubkeys() -> Vec<XOnlyPublicKey> {
         ],
     ];
     let mut keys: Vec<XOnlyPublicKey> = vec![];
-    for idx in 0..4 {
-        keys.push(XOnlyPublicKey::from_slice(&serialized_keys[idx][..]).unwrap());
+    for key in serialized_keys {
+        keys.push(XOnlyPublicKey::from_slice(&key[..]).unwrap());
     }
     keys
 }

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -46,15 +46,14 @@ fn main() {
 
     for elem in interpreter.iter_assume_sigs() {
         // Don't bother checking signatures.
-        match elem.expect("no evaluation error") {
-            miniscript::interpreter::SatisfiedConstraint::PublicKey { key_sig } => {
-                let (key, sig) = key_sig
-                    .as_ecdsa()
-                    .expect("expected ecdsa sig, found schnorr sig");
+        if let miniscript::interpreter::SatisfiedConstraint::PublicKey { key_sig } =
+            elem.expect("no evaluation error")
+        {
+            let (key, sig) = key_sig
+                .as_ecdsa()
+                .expect("expected ecdsa sig, found schnorr sig");
 
-                println!("Signed with:\n key: {}\n sig: {}", key, sig);
-            }
-            _ => {}
+            println!("Signed with:\n key: {}\n sig: {}", key, sig);
         }
     }
 

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -589,7 +589,7 @@ impl DescriptorPublicKey {
                 };
                 xpub.derivation_paths
                     .paths()
-                    .into_iter()
+                    .iter()
                     .map(|p| origin_path.extend(p))
                     .collect()
             }

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -943,7 +943,7 @@ impl<K: InnerXKey> DescriptorXKey<K> {
             Some((fingerprint, ref path)) => (
                 fingerprint,
                 path.into_iter()
-                    .chain(self.derivation_path.into_iter())
+                    .chain(&self.derivation_path)
                     .collect(),
             ),
             None => (

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -940,12 +940,9 @@ impl<K: InnerXKey> DescriptorXKey<K> {
         let (fingerprint, path) = keysource;
 
         let (compare_fingerprint, compare_path) = match self.origin {
-            Some((fingerprint, ref path)) => (
-                fingerprint,
-                path.into_iter()
-                    .chain(&self.derivation_path)
-                    .collect(),
-            ),
+            Some((fingerprint, ref path)) => {
+                (fingerprint, path.into_iter().chain(&self.derivation_path).collect())
+            }
             None => (
                 self.xkey.xkey_fingerprint(secp),
                 self.derivation_path.into_iter().collect::<Vec<_>>(),

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1098,7 +1098,7 @@ mod tests {
                 .push_opcode(opcodes::all::OP_DUP)
                 .push_opcode(opcodes::all::OP_HASH160)
                 .push_slice(
-                    &hash160::Hash::from_str("84e9ed95a38613f0527ff685a9928abe2d4754d4",)
+                    hash160::Hash::from_str("84e9ed95a38613f0527ff685a9928abe2d4754d4")
                         .unwrap()
                         .to_byte_array()
                 )
@@ -1122,7 +1122,7 @@ mod tests {
             script::Builder::new()
                 .push_opcode(opcodes::all::OP_PUSHBYTES_0)
                 .push_slice(
-                    &hash160::Hash::from_str("84e9ed95a38613f0527ff685a9928abe2d4754d4",)
+                    hash160::Hash::from_str("84e9ed95a38613f0527ff685a9928abe2d4754d4")
                         .unwrap()
                         .to_byte_array()
                 )
@@ -1144,7 +1144,7 @@ mod tests {
             script::Builder::new()
                 .push_opcode(opcodes::all::OP_HASH160)
                 .push_slice(
-                    &hash160::Hash::from_str("f1c3b9a431134cb90a500ec06e0067cfa9b8bba7",)
+                    hash160::Hash::from_str("f1c3b9a431134cb90a500ec06e0067cfa9b8bba7")
                         .unwrap()
                         .to_byte_array()
                 )
@@ -1167,7 +1167,7 @@ mod tests {
             script::Builder::new()
                 .push_opcode(opcodes::all::OP_HASH160)
                 .push_slice(
-                    &hash160::Hash::from_str("aa5282151694d3f2f32ace7d00ad38f927a33ac8",)
+                    hash160::Hash::from_str("aa5282151694d3f2f32ace7d00ad38f927a33ac8")
                         .unwrap()
                         .to_byte_array()
                 )
@@ -1190,11 +1190,8 @@ mod tests {
             script::Builder::new()
                 .push_opcode(opcodes::all::OP_PUSHBYTES_0)
                 .push_slice(
-                    &sha256::Hash::from_str(
-                        "\
-                         f9379edc8983152dc781747830075bd5\
-                         3896e4b0ce5bff73777fd77d124ba085\
-                         "
+                    sha256::Hash::from_str(
+                        "f9379edc8983152dc781747830075bd53896e4b0ce5bff73777fd77d124ba085"
                     )
                     .unwrap()
                     .to_byte_array()
@@ -1217,7 +1214,7 @@ mod tests {
             script::Builder::new()
                 .push_opcode(opcodes::all::OP_HASH160)
                 .push_slice(
-                    &hash160::Hash::from_str("4bec5d7feeed99e1d0a23fe32a4afe126a7ff07e",)
+                    hash160::Hash::from_str("4bec5d7feeed99e1d0a23fe32a4afe126a7ff07e")
                         .unwrap()
                         .to_byte_array()
                 )
@@ -1322,7 +1319,7 @@ mod tests {
         let redeem_script = script::Builder::new()
             .push_opcode(opcodes::all::OP_PUSHBYTES_0)
             .push_slice(
-                &hash160::Hash::from_str("d1b2a1faf62e73460af885c687dee3b7189cd8ab")
+                hash160::Hash::from_str("d1b2a1faf62e73460af885c687dee3b7189cd8ab")
                     .unwrap()
                     .to_byte_array(),
             )

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1309,7 +1309,7 @@ mod tests {
                 previous_output: bitcoin::OutPoint::default(),
                 script_sig: bitcoin::ScriptBuf::new(),
                 sequence: Sequence::from_height(100),
-                witness: Witness::from_slice(&vec![sigser.clone(), pk.to_bytes(),]),
+                witness: Witness::from_slice(&[sigser.clone(), pk.to_bytes(),]),
             }
         );
         assert_eq!(wpkh.unsigned_script_sig(), bitcoin::ScriptBuf::new());
@@ -1332,7 +1332,7 @@ mod tests {
                     .push_slice(<&PushBytes>::try_from(redeem_script.as_bytes()).unwrap())
                     .into_script(),
                 sequence: Sequence::from_height(100),
-                witness: Witness::from_slice(&vec![sigser.clone(), pk.to_bytes(),]),
+                witness: Witness::from_slice(&[sigser.clone(), pk.to_bytes(),]),
             }
         );
         assert_eq!(
@@ -1369,7 +1369,7 @@ mod tests {
                 previous_output: bitcoin::OutPoint::default(),
                 script_sig: bitcoin::ScriptBuf::new(),
                 sequence: Sequence::from_height(100),
-                witness: Witness::from_slice(&vec![sigser.clone(), ms.encode().into_bytes(),]),
+                witness: Witness::from_slice(&[sigser.clone(), ms.encode().into_bytes(),]),
             }
         );
         assert_eq!(wsh.unsigned_script_sig(), bitcoin::ScriptBuf::new());
@@ -1386,7 +1386,7 @@ mod tests {
                     )
                     .into_script(),
                 sequence: Sequence::from_height(100),
-                witness: Witness::from_slice(&vec![sigser.clone(), ms.encode().into_bytes(),]),
+                witness: Witness::from_slice(&[sigser.clone(), ms.encode().into_bytes(),]),
             }
         );
         assert_eq!(

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -737,7 +737,7 @@ where
             wit.push(Placeholder::TapScript(leaf_script.0));
             wit.push(Placeholder::TapControlBlock(control_block));
 
-            let wit_size = witness_size(&wit);
+            let wit_size = witness_size(wit);
             if min_wit_len.is_some() && Some(wit_size) > min_wit_len {
                 continue;
             } else {

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -448,14 +448,14 @@ mod tests {
                     .into_script(),
                 pkh_sig_justkey: script::Builder::new().push_key(&key).into_script(),
                 wpkh_spk: wpkh_spk.clone(),
-                wpkh_stack: Witness::from_slice(&vec![dummy_sig_vec.clone(), key.to_bytes()]),
-                wpkh_stack_justkey: Witness::from_slice(&vec![key.to_bytes()]),
+                wpkh_stack: Witness::from_slice(&[dummy_sig_vec.clone(), key.to_bytes()]),
+                wpkh_stack_justkey: Witness::from_slice(&[key.to_bytes()]),
                 sh_wpkh_spk: bitcoin::ScriptBuf::new_p2sh(&wpkh_scripthash),
                 sh_wpkh_sig: script::Builder::new()
                     .push_slice(<&PushBytes>::try_from(wpkh_spk[..].as_bytes()).unwrap())
                     .into_script(),
-                sh_wpkh_stack: Witness::from_slice(&vec![dummy_sig_vec, key.to_bytes()]),
-                sh_wpkh_stack_justkey: Witness::from_slice(&vec![key.to_bytes()]),
+                sh_wpkh_stack: Witness::from_slice(&[dummy_sig_vec, key.to_bytes()]),
+                sh_wpkh_stack_justkey: Witness::from_slice(&[key.to_bytes()]),
             }
         }
     }
@@ -534,7 +534,7 @@ mod tests {
         assert_eq!(&err.to_string()[0..12], "parse error:");
 
         // Witness is nonempty
-        let wit = Witness::from_slice(&vec![vec![]]);
+        let wit = Witness::from_slice(&[vec![]]);
         let err = from_txdata(&comp.pk_spk, &comp.pk_sig, &wit).unwrap_err();
         assert_eq!(err.to_string(), "legacy spend had nonempty witness");
     }
@@ -583,7 +583,7 @@ mod tests {
         assert_eq!(script_code, Some(uncomp.pkh_spk.clone()));
 
         // Witness is nonempty
-        let wit = Witness::from_slice(&vec![vec![]]);
+        let wit = Witness::from_slice(&[vec![]]);
         let err = from_txdata(&comp.pkh_spk, &comp.pkh_sig, &wit).unwrap_err();
         assert_eq!(err.to_string(), "legacy spend had nonempty witness");
     }
@@ -706,7 +706,7 @@ mod tests {
         assert_eq!(&err.to_string()[0..12], "parse error:");
 
         // nonempty witness
-        let wit = Witness::from_slice(&vec![vec![]]);
+        let wit = Witness::from_slice(&[vec![]]);
         let err = from_txdata(&spk, &blank_script, &wit).unwrap_err();
         assert_eq!(&err.to_string(), "legacy spend had nonempty witness");
     }
@@ -742,7 +742,7 @@ mod tests {
         assert_eq!(script_code, Some(redeem_script));
 
         // nonempty witness
-        let wit = Witness::from_slice(&vec![vec![]]);
+        let wit = Witness::from_slice(&[vec![]]);
         let err = from_txdata(&spk, &script_sig, &wit).unwrap_err();
         assert_eq!(&err.to_string(), "legacy spend had nonempty witness");
     }
@@ -753,7 +753,7 @@ mod tests {
         let hash = hash160::Hash::hash(&preimage[..]);
         let (miniscript, witness_script) = ms_inner_script(&format!("hash160({})", hash));
         let wit_hash = sha256::Hash::hash(witness_script.as_bytes()).into();
-        let wit_stack = Witness::from_slice(&vec![witness_script.to_bytes()]);
+        let wit_stack = Witness::from_slice(&[witness_script.to_bytes()]);
 
         let spk = ScriptBuf::new_v0_p2wsh(&wit_hash);
         let blank_script = bitcoin::ScriptBuf::new();
@@ -763,7 +763,7 @@ mod tests {
         assert_eq!(&err.to_string(), "unexpected end of stack");
 
         // with incorrect witness
-        let wit = Witness::from_slice(&vec![spk.to_bytes()]);
+        let wit = Witness::from_slice(&[spk.to_bytes()]);
         let err = from_txdata(&spk, &blank_script, &wit).unwrap_err();
         assert_eq!(&err.to_string()[0..12], "parse error:");
 
@@ -788,7 +788,7 @@ mod tests {
         let hash = hash160::Hash::hash(&preimage[..]);
         let (miniscript, witness_script) = ms_inner_script(&format!("hash160({})", hash));
         let wit_hash = sha256::Hash::hash(witness_script.as_bytes()).into();
-        let wit_stack = Witness::from_slice(&vec![witness_script.to_bytes()]);
+        let wit_stack = Witness::from_slice(&[witness_script.to_bytes()]);
 
         let redeem_script = ScriptBuf::new_v0_p2wsh(&wit_hash);
         let script_sig = script::Builder::new()
@@ -808,7 +808,7 @@ mod tests {
         assert_eq!(&err.to_string(), "unexpected end of stack");
 
         // with incorrect witness
-        let wit = Witness::from_slice(&vec![spk.to_bytes()]);
+        let wit = Witness::from_slice(&[spk.to_bytes()]);
         let err = from_txdata(&spk, &script_sig, &wit).unwrap_err();
         assert_eq!(&err.to_string()[0..12], "parse error:");
 

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -441,9 +441,9 @@ mod tests {
             KeyTestData {
                 pk_spk: bitcoin::ScriptBuf::new_p2pk(&key),
                 pkh_spk: bitcoin::ScriptBuf::new_p2pkh(&pkhash),
-                pk_sig: script::Builder::new().push_slice(&dummy_sig).into_script(),
+                pk_sig: script::Builder::new().push_slice(dummy_sig).into_script(),
                 pkh_sig: script::Builder::new()
-                    .push_slice(&dummy_sig)
+                    .push_slice(dummy_sig)
                     .push_key(&key)
                     .into_script(),
                 pkh_sig_justkey: script::Builder::new().push_key(&key).into_script(),

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -82,7 +82,7 @@ impl<'a, Pk: MiniscriptKey> TreeLike for &'a policy::Concrete<Pk> {
     }
 }
 
-impl<'a, Pk: MiniscriptKey> TreeLike for Arc<policy::Concrete<Pk>> {
+impl<Pk: MiniscriptKey> TreeLike for Arc<policy::Concrete<Pk>> {
     fn as_node(&self) -> Tree<Self> {
         use policy::Concrete::*;
         match self.as_ref() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -762,56 +762,6 @@ impl fmt::Display for AbsLockTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
-#[cfg(test)]
-mod tests {
-    use core::str::FromStr;
-
-    use super::*;
-
-    #[test]
-    fn regression_bitcoin_key_hash() {
-        use bitcoin::PublicKey;
-
-        // Uncompressed key.
-        let pk = PublicKey::from_str(
-            "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133"
-        ).unwrap();
-
-        let want = hash160::Hash::from_str("ac2e7daf42d2c97418fd9f78af2de552bb9c6a7a").unwrap();
-        let got = pk.to_pubkeyhash(SigType::Ecdsa);
-        assert_eq!(got, want)
-    }
-
-    #[test]
-    fn regression_secp256k1_key_hash() {
-        use bitcoin::secp256k1::PublicKey;
-
-        // Compressed key.
-        let pk = PublicKey::from_str(
-            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
-        )
-        .unwrap();
-
-        let want = hash160::Hash::from_str("9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4").unwrap();
-        let got = pk.to_pubkeyhash(SigType::Ecdsa);
-        assert_eq!(got, want)
-    }
-
-    #[test]
-    fn regression_xonly_key_hash() {
-        use bitcoin::secp256k1::XOnlyPublicKey;
-
-        let pk = XOnlyPublicKey::from_str(
-            "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115",
-        )
-        .unwrap();
-
-        let want = hash160::Hash::from_str("eb8ac65f971ae688a94aeabf223506865e7e08f2").unwrap();
-        let got = pk.to_pubkeyhash(SigType::Schnorr);
-        assert_eq!(got, want)
-    }
-}
-
 mod prelude {
     // Mutex implementation from LDK
     // https://github.com/lightningdevkit/rust-lightning/blob/9bdce47f0e0516e37c89c09f1975dfc06b5870b1/lightning-invoice/src/sync.rs
@@ -877,4 +827,54 @@ mod prelude {
 
     #[cfg(all(not(feature = "std"), not(test)))]
     pub use self::mutex::Mutex;
+}
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn regression_bitcoin_key_hash() {
+        use bitcoin::PublicKey;
+
+        // Uncompressed key.
+        let pk = PublicKey::from_str(
+            "042e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af191923a2964c177f5b5923ae500fca49e99492d534aa3759d6b25a8bc971b133"
+        ).unwrap();
+
+        let want = hash160::Hash::from_str("ac2e7daf42d2c97418fd9f78af2de552bb9c6a7a").unwrap();
+        let got = pk.to_pubkeyhash(SigType::Ecdsa);
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn regression_secp256k1_key_hash() {
+        use bitcoin::secp256k1::PublicKey;
+
+        // Compressed key.
+        let pk = PublicKey::from_str(
+            "032e58afe51f9ed8ad3cc7897f634d881fdbe49a81564629ded8156bebd2ffd1af",
+        )
+        .unwrap();
+
+        let want = hash160::Hash::from_str("9511aa27ef39bbfa4e4f3dd15f4d66ea57f475b4").unwrap();
+        let got = pk.to_pubkeyhash(SigType::Ecdsa);
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn regression_xonly_key_hash() {
+        use bitcoin::secp256k1::XOnlyPublicKey;
+
+        let pk = XOnlyPublicKey::from_str(
+            "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115",
+        )
+        .unwrap();
+
+        let want = hash160::Hash::from_str("eb8ac65f971ae688a94aeabf223506865e7e08f2").unwrap();
+        let got = pk.to_pubkeyhash(SigType::Schnorr);
+        assert_eq!(got, want)
+    }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -383,7 +383,7 @@ impl Plan {
                     .entry(pk)
                     .and_modify(|(leaf_hashes, _)| {
                         if let Some(lh) = leaf_hash {
-                            if leaf_hashes.iter().find(|&&i| i == lh).is_none() {
+                            if !leaf_hashes.iter().any(|&i| i == lh) {
                                 leaf_hashes.push(lh);
                             }
                         }
@@ -725,12 +725,9 @@ impl Assets {
     fn append(&mut self, b: Self) {
         self.keys.extend(b.keys);
         self.sha256_preimages.extend(b.sha256_preimages);
-        self.hash256_preimages
-            .extend(b.hash256_preimages);
-        self.ripemd160_preimages
-            .extend(b.ripemd160_preimages);
-        self.hash160_preimages
-            .extend(b.hash160_preimages);
+        self.hash256_preimages.extend(b.hash256_preimages);
+        self.ripemd160_preimages.extend(b.ripemd160_preimages);
+        self.hash160_preimages.extend(b.hash160_preimages);
 
         self.relative_timelock = b.relative_timelock.or(self.relative_timelock);
         self.absolute_timelock = b.absolute_timelock.or(self.absolute_timelock);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -702,6 +702,7 @@ impl Assets {
     pub fn new() -> Self { Self::default() }
 
     /// Add some assets
+    #[allow(clippy::should_implement_trait)]
     pub fn add<A: IntoAssets>(mut self, asset: A) -> Self {
         self.append(asset.into_assets());
         self

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -764,7 +764,7 @@ mod test {
                 assets = assets.add(keys[ki].clone());
             }
             for hi in hash_indexes {
-                assets = assets.add(hashes[hi].clone());
+                assets = assets.add(hashes[hi]);
             }
 
             let result = desc.clone().plan(&assets);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -397,17 +397,14 @@ impl Plan {
             }
         } else {
             for item in &self.template {
-                match item {
-                    Placeholder::EcdsaSigPk(pk) => {
-                        let public_key = pk.to_public_key().inner;
-                        let master_fingerprint = pk.master_fingerprint();
-                        for derivation_path in pk.full_derivation_paths() {
-                            input
-                                .bip32_derivation
-                                .insert(public_key, (master_fingerprint, derivation_path));
-                        }
+                if let Placeholder::EcdsaSigPk(pk) = item {
+                    let public_key = pk.to_public_key().inner;
+                    let master_fingerprint = pk.master_fingerprint();
+                    for derivation_path in pk.full_derivation_paths() {
+                        input
+                            .bip32_derivation
+                            .insert(public_key, (master_fingerprint, derivation_path));
                     }
-                    _ => {}
                 }
             }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -669,7 +669,7 @@ impl IntoAssets for DescriptorPublicKey {
 }
 
 impl IntoAssets for Vec<DescriptorPublicKey> {
-    fn into_assets(self) -> Assets { Assets::from_iter(self.into_iter()) }
+    fn into_assets(self) -> Assets { Assets::from_iter(self) }
 }
 
 impl IntoAssets for sha256::Hash {
@@ -723,14 +723,14 @@ impl Assets {
     }
 
     fn append(&mut self, b: Self) {
-        self.keys.extend(b.keys.into_iter());
-        self.sha256_preimages.extend(b.sha256_preimages.into_iter());
+        self.keys.extend(b.keys);
+        self.sha256_preimages.extend(b.sha256_preimages);
         self.hash256_preimages
-            .extend(b.hash256_preimages.into_iter());
+            .extend(b.hash256_preimages);
         self.ripemd160_preimages
-            .extend(b.ripemd160_preimages.into_iter());
+            .extend(b.ripemd160_preimages);
         self.hash160_preimages
-            .extend(b.hash160_preimages.into_iter());
+            .extend(b.hash160_preimages);
 
         self.relative_timelock = b.relative_timelock.or(self.relative_timelock);
         self.absolute_timelock = b.absolute_timelock.or(self.absolute_timelock);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -658,7 +658,7 @@ pub trait IntoAssets {
 }
 
 impl IntoAssets for KeyMap {
-    fn into_assets(self) -> Assets { Assets::from_iter(self.into_iter().map(|(k, _)| k)) }
+    fn into_assets(self) -> Assets { Assets::from_iter(self.into_keys()) }
 }
 
 impl IntoAssets for DescriptorPublicKey {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -750,7 +750,7 @@ mod test {
         // [ (key_indexes, hash_indexes, older, after, expected) ]
         tests: Vec<(Vec<usize>, Vec<usize>, Option<Sequence>, Option<LockTime>, Option<usize>)>,
     ) {
-        let desc = Descriptor::<DefiniteDescriptorKey>::from_str(&desc).unwrap();
+        let desc = Descriptor::<DefiniteDescriptorKey>::from_str(desc).unwrap();
 
         for (key_indexes, hash_indexes, older, after, expected) in tests {
             let mut assets = Assets::new();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -255,7 +255,7 @@ impl Plan {
             // scriptSig len (1) + OP_0 (1) + OP_PUSHBYTES_32 (1) + <script hash> (32)
             (_, DescriptorType::ShWsh) | (_, DescriptorType::ShWshSortedMulti) => 1 + 1 + 1 + 32,
             // Native Segwit v0 (scriptSig len (1))
-            __ => 1,
+            _ => 1,
         }
     }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -261,7 +261,7 @@ impl Plan {
 
     /// The size in bytes of the witness that satisfies this plan
     pub fn witness_size(&self) -> usize {
-        if let Some(_) = self.descriptor.desc_type().segwit_version() {
+        if self.descriptor.desc_type().segwit_version().is_some() {
             witness_size(self.template.as_ref())
         } else {
             0 // should be 1 if there's at least one segwit input in the tx, but that's out of

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1028,7 +1028,7 @@ mod test {
             "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
         )
         .unwrap()];
-        let hashes = vec![hash160::Hash::from_slice(&vec![0; 20]).unwrap()];
+        let hashes = vec![hash160::Hash::from_slice(&[0; 20]).unwrap()];
         let desc = format!("wsh(and_v(v:pk({}),hash160({})))", keys[0], hashes[0]);
 
         let tests = vec![

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1204,7 +1204,7 @@ mod tests {
             Arc::new(Concrete::Key("A".to_string())),
             Arc::new(Concrete::And(vec![
                 Arc::new(Concrete::after(9)),
-                Arc::new(Concrete::after(1000_000_000)),
+                Arc::new(Concrete::after(1_000_000_000)),
             ])),
         ]);
         assert!(pol.compile::<Segwitv0>().is_err());

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1265,7 +1265,7 @@ mod tests {
         let (keys, sig) = pubkeys_and_a_sig(10);
         let key_pol: Vec<BPolicy> = keys.iter().map(|k| Concrete::Key(*k)).collect();
 
-        let policy: BPolicy = Concrete::Key(keys[0].clone());
+        let policy: BPolicy = Concrete::Key(keys[0]);
         let ms: SegwitMiniScript = policy.compile().unwrap();
         assert_eq!(
             ms.encode(),

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1261,6 +1261,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_range_loop)] // For indexing into keys array.
     fn compile_misc() {
         let (keys, sig) = pubkeys_and_a_sig(10);
         let key_pol: Vec<BPolicy> = keys.iter().map(|k| Concrete::Key(*k)).collect();

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1127,7 +1127,7 @@ mod compiler_tests {
         let policies: Vec<Arc<Concrete<String>>> = vec!["pk(A)", "pk(B)", "pk(C)", "pk(D)"]
             .into_iter()
             .map(|st| policy_str!("{}", st))
-            .map(|p| Arc::new(p))
+            .map(Arc::new)
             .collect();
 
         let combinations = generate_combination(&policies, 1.0, 2);
@@ -1157,10 +1157,7 @@ mod compiler_tests {
             .map(|sub_pol| {
                 (
                     0.25,
-                    Arc::new(Policy::Threshold(
-                        2,
-                        sub_pol.into_iter().map(|p| Arc::new(p)).collect(),
-                    )),
+                    Arc::new(Policy::Threshold(2, sub_pol.into_iter().map(Arc::new).collect())),
                 )
             })
             .collect::<Vec<_>>();

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -440,7 +440,7 @@ mod tests {
                 .iter()
                 .zip(node_probabilities.iter())
                 .collect::<Vec<_>>();
-            sorted_policy_prob.sort_by(|a, b| (a.1).partial_cmp(&b.1).unwrap());
+            sorted_policy_prob.sort_by(|a, b| (a.1).partial_cmp(b.1).unwrap());
             let sorted_policies = sorted_policy_prob
                 .into_iter()
                 .map(|(x, _prob)| x)

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -428,7 +428,7 @@ pub(super) fn finalize_input<C: secp256k1::Verification>(
     // Now mutate the psbt input. Note that we cannot error after this point.
     // If the input is mutated, it means that the finalization succeeded.
     {
-        let original = mem::replace(&mut psbt.inputs[index], Default::default());
+        let original = mem::take(&mut psbt.inputs[index]);
         let input = &mut psbt.inputs[index];
         input.non_witness_utxo = original.non_witness_utxo;
         input.witness_utxo = original.witness_utxo;

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1589,7 +1589,7 @@ mod tests {
     #[test]
     fn test_update_input_checks() {
         let desc = "tr([73c5da0a/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ/0/0)";
-        let desc = Descriptor::<DefiniteDescriptorKey>::from_str(&desc).unwrap();
+        let desc = Descriptor::<DefiniteDescriptorKey>::from_str(desc).unwrap();
 
         let mut non_witness_utxo = bitcoin::Transaction {
             version: 1,
@@ -1651,7 +1651,7 @@ mod tests {
     #[test]
     fn test_update_output_checks() {
         let desc = "tr([73c5da0a/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ/0/0)";
-        let desc = Descriptor::<DefiniteDescriptorKey>::from_str(&desc).unwrap();
+        let desc = Descriptor::<DefiniteDescriptorKey>::from_str(desc).unwrap();
 
         let tx = bitcoin::Transaction {
             version: 1,


### PR DESCRIPTION
Hack like I'm a week one contributor again, remove a bunch of trivial lint warnings.

There are a bunch more still, draft till I get them all.
