### PR TITLE
Improve `TapTree` API

### DIFF
--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -124,7 +124,7 @@ impl<Pk: MiniscriptKey> TapTree<Pk> {
     }
 
     /// Returns the height of this tree.
-    fn height(&self) -> usize {
+    pub fn height(&self) -> usize {
         match *self {
             TapTree::Tree { left: _, right: _, height } => height,
             TapTree::Leaf(..) => 0,

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -118,7 +118,7 @@ impl<Pk: MiniscriptKey> hash::Hash for Tr<Pk> {
 
 impl<Pk: MiniscriptKey> TapTree<Pk> {
     /// Creates a `TapTree` by combining `left` and `right` tree nodes.
-    pub(crate) fn combine(left: TapTree<Pk>, right: TapTree<Pk>) -> Self {
+    pub fn combine(left: TapTree<Pk>, right: TapTree<Pk>) -> Self {
         let height = 1 + cmp::max(left.height(), right.height());
         TapTree::Tree { left: Arc::new(left), right: Arc::new(right), height }
     }


### PR DESCRIPTION
Improve the `TapTree` API by making the `height` and `combine` methods public.

Note the serendipitous finding that upgrading miniscript to use bitcoin v0.31.0-rc1 requires no changes. I found these fixes doing the `bdk` upgrade.
