### PR TITLE
fix: needless borrow (reference is immediately dereferenced by the rust-compiler)

### DIFF
--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -878,7 +878,7 @@ impl PsbtExt for Psbt {
                         .redeem_script
                         .as_ref()
                         .expect("redeem script non-empty checked earlier");
-                    cache.p2wpkh_signature_hash(idx, &script_code, amt, hash_ty)?
+                    cache.p2wpkh_signature_hash(idx, script_code, amt, hash_ty)?
                 } else {
                     let witness_script = inp
                         .witness_script


### PR DESCRIPTION
fixes:
```shell
this expression creates a reference which is immediately dereferenced by the compiler
   --> src/psbt/mod.rs:881:54
    |
881 |                     cache.p2wpkh_signature_hash(idx, &script_code, amt, hash_ty)?
    |                                                      ^^^^^^^^^^^^ 
```