### PR TITLE
Remove internals dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ base64 = ["bitcoin/base64"]
 [dependencies]
 bech32 = { version = "0.10.0-beta", default-features = false }
 bitcoin = { version = "0.31.0", default-features = false }
-internals = { package = "bitcoin-internals", version = "0.2.0", default_features = false }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", optional = true }

--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -12,4 +12,3 @@ miniscript = {path = "../"}
 bitcoind = { version = "0.34.0" }
 actual-rand = { package = "rand", version = "0.8.4"}
 secp256k1 = {version = "0.28.0", features = ["rand-std"]}
-internals = { package = "bitcoin-internals", version = "0.2.0", default_features = false }

--- a/bitcoind-tests/tests/setup/test_util.rs
+++ b/bitcoind-tests/tests/setup/test_util.rs
@@ -21,8 +21,8 @@ use std::str::FromStr;
 
 use actual_rand as rand;
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
+use bitcoin::hex::DisplayHex;
 use bitcoin::secp256k1;
-use internals::hex::exts::DisplayHex;
 use miniscript::descriptor::{SinglePub, SinglePubKey};
 use miniscript::{
     bitcoin, hash256, Descriptor, DescriptorPublicKey, Error, Miniscript, ScriptContext,

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -6,8 +6,8 @@ use core::fmt;
 use std::error;
 
 use bitcoin::hashes::hash160;
+use bitcoin::hex::DisplayHex;
 use bitcoin::{secp256k1, taproot};
-use internals::hex::display::DisplayHex;
 
 use super::BitcoinKey;
 use crate::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,6 @@ mod macros;
 #[macro_use]
 mod pub_macros;
 
-use internals::hex::exts::DisplayHex;
-
 pub mod descriptor;
 pub mod expression;
 pub mod interpreter;
@@ -137,6 +135,7 @@ use core::{cmp, fmt, hash, str};
 use std::error;
 
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
+use bitcoin::hex::DisplayHex;
 use bitcoin::locktime::absolute;
 use bitcoin::{script, Opcode};
 


### PR DESCRIPTION
We do not need to depend on `internals` anymore, this was just needed until we sorted out `DisplayHex` in `hex-conservative`. This change should have been done as part of upgrading to `rust-bitcoin v0.31`.