### PR TITLE
Use `Ordered` and remove `AbsLockTime` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,15 @@ required-features = ["std", "base64"]
 [workspace]
 members = ["bitcoind-tests", "fuzz"]
 exclude = ["embedded"]
+
+[patch.crates-io.bitcoin]
+git = "https://github.com/tcharding/rust-bitcoin.git"
+branch = "12-02-ordered"
+
+[patch.crates-io.bitcoin_hashes]
+git = "https://github.com/tcharding/rust-bitcoin.git"
+branch = "12-02-ordered"
+
+[patch.crates-io.bitcoin-io]
+git = "https://github.com/tcharding/rust-bitcoin.git"
+branch = "12-02-ordered"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ base64 = ["bitcoin/base64"]
 [dependencies]
 bech32 = { version = "0.10.0-beta", default-features = false }
 bitcoin = { version = "0.31.0", default-features = false }
-internals = { package = "bitcoin-internals", version = "0.2.0", default_features = false }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", optional = true }

--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -12,4 +12,3 @@ miniscript = {path = "../"}
 bitcoind = { version = "0.34.0" }
 actual-rand = { package = "rand", version = "0.8.4"}
 secp256k1 = {version = "0.28.0", features = ["rand-std"]}
-internals = { package = "bitcoin-internals", version = "0.2.0", default_features = false }

--- a/bitcoind-tests/tests/setup/test_util.rs
+++ b/bitcoind-tests/tests/setup/test_util.rs
@@ -21,8 +21,8 @@ use std::str::FromStr;
 
 use actual_rand as rand;
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
+use bitcoin::hex::DisplayHex;
 use bitcoin::secp256k1;
-use internals::hex::exts::DisplayHex;
 use miniscript::descriptor::{SinglePub, SinglePubKey};
 use miniscript::{
     bitcoin, hash256, Descriptor, DescriptorPublicKey, Error, Miniscript, ScriptContext,

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -508,7 +508,7 @@ impl Descriptor<DefiniteDescriptorKey> {
             Ok(Plan {
                 descriptor: self,
                 template: stack,
-                absolute_timelock: satisfaction.absolute_timelock.map(Into::into),
+                absolute_timelock: satisfaction.absolute_timelock,
                 relative_timelock: satisfaction.relative_timelock,
             })
         } else {
@@ -536,7 +536,7 @@ impl Descriptor<DefiniteDescriptorKey> {
             Ok(Plan {
                 descriptor: self,
                 template: stack,
-                absolute_timelock: satisfaction.absolute_timelock.map(Into::into),
+                absolute_timelock: satisfaction.absolute_timelock,
                 relative_timelock: satisfaction.relative_timelock,
             })
         } else {

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -6,8 +6,8 @@ use core::fmt;
 use std::error;
 
 use bitcoin::hashes::hash160;
+use bitcoin::hex::DisplayHex;
 use bitcoin::{secp256k1, taproot};
-use internals::hex::display::DisplayHex;
 
 use super::BitcoinKey;
 use crate::prelude::*;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -220,7 +220,9 @@ impl<'txin> Interpreter<'txin> {
                         Some(txout) => txout.borrow().value,
                         None => return false,
                     };
-                    let sighash = cache.segwit_signature_hash(
+                    // This is a hack, p2wsh passes through the script and since we already handled
+                    // the script_cope stuff its ok to us it.
+                    let sighash = cache.p2wsh_signature_hash(
                         input_idx,
                         script_pubkey,
                         amt,
@@ -598,9 +600,7 @@ where
                 Terminal::After(ref n) => {
                     debug_assert_eq!(node_state.n_evaluated, 0);
                     debug_assert_eq!(node_state.n_satisfied, 0);
-                    let res = self
-                        .stack
-                        .evaluate_after(&absolute::LockTime::from(*n), self.lock_time);
+                    let res = self.stack.evaluate_after(n, self.lock_time);
                     if res.is_some() {
                         return res;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,6 @@ mod macros;
 #[macro_use]
 mod pub_macros;
 
-use internals::hex::exts::DisplayHex;
-
 pub mod descriptor;
 pub mod expression;
 pub mod interpreter;
@@ -137,6 +135,7 @@ use core::{cmp, fmt, hash, str};
 use std::error;
 
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
+use bitcoin::hex::DisplayHex;
 use bitcoin::locktime::absolute;
 use bitcoin::{script, Opcode};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,13 +130,12 @@ pub mod psbt;
 mod test_utils;
 mod util;
 
-use core::{cmp, fmt, hash, str};
+use core::{fmt, hash, str};
 #[cfg(feature = "std")]
 use std::error;
 
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 use bitcoin::hex::DisplayHex;
-use bitcoin::locktime::absolute;
 use bitcoin::{script, Opcode};
 
 pub use crate::descriptor::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey};
@@ -715,51 +714,6 @@ fn push_opcode_size(script_size: usize) -> usize {
 fn hex_script(s: &str) -> bitcoin::ScriptBuf {
     let v: Vec<u8> = bitcoin::hashes::hex::FromHex::from_hex(s).unwrap();
     bitcoin::ScriptBuf::from(v)
-}
-
-/// An absolute locktime that implements `Ord`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct AbsLockTime(absolute::LockTime);
-
-impl AbsLockTime {
-    /// Constructs an `AbsLockTime` from an nLockTime value or the argument to OP_CHEKCLOCKTIMEVERIFY.
-    pub fn from_consensus(n: u32) -> Self { Self(absolute::LockTime::from_consensus(n)) }
-
-    /// Returns the inner `u32` value. This is the value used when creating this `LockTime`
-    /// i.e., `n OP_CHECKLOCKTIMEVERIFY` or nLockTime.
-    ///
-    /// This calls through to `absolute::LockTime::to_consensus_u32()` and the same usage warnings
-    /// apply.
-    pub fn to_consensus_u32(self) -> u32 { self.0.to_consensus_u32() }
-
-    /// Returns the inner `u32` value.
-    ///
-    /// Equivalent to `AbsLockTime::to_consensus_u32()`.
-    pub fn to_u32(self) -> u32 { self.to_consensus_u32() }
-}
-
-impl From<absolute::LockTime> for AbsLockTime {
-    fn from(lock_time: absolute::LockTime) -> Self { Self(lock_time) }
-}
-
-impl From<AbsLockTime> for absolute::LockTime {
-    fn from(lock_time: AbsLockTime) -> absolute::LockTime { lock_time.0 }
-}
-
-impl cmp::PartialOrd for AbsLockTime {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> { Some(self.cmp(other)) }
-}
-
-impl cmp::Ord for AbsLockTime {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        let this = self.0.to_consensus_u32();
-        let that = other.0.to_consensus_u32();
-        this.cmp(&that)
-    }
-}
-
-impl fmt::Display for AbsLockTime {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self.0, f) }
 }
 
 #[cfg(test)]

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -601,9 +601,10 @@ mod tests {
     use core::str::FromStr;
 
     use bitcoin::hashes::{hash160, sha256, Hash};
+    use bitcoin::ordered::Ordered;
     use bitcoin::secp256k1::XOnlyPublicKey;
     use bitcoin::taproot::TapLeafHash;
-    use bitcoin::{self, secp256k1, Sequence};
+    use bitcoin::{self, absolute, secp256k1, Sequence};
     use sync::Arc;
 
     use super::{Miniscript, ScriptContext, Segwitv0, Tap};
@@ -1260,7 +1261,6 @@ mod tests {
 
     #[test]
     fn template_timelocks() {
-        use crate::AbsLockTime;
         let key_present = bitcoin::PublicKey::from_str(
             "0327a6ed0e71b451c79327aa9e4a6bb26ffb1c0056abc02c25e783f6096b79bb4f",
         )
@@ -1275,7 +1275,7 @@ mod tests {
             (format!("t:or_c(pk({}),v:pkh({}))", key_present, key_missing), None, None),
             (
                 format!("thresh(2,pk({}),s:pk({}),snl:after(1))", key_present, key_missing),
-                Some(AbsLockTime::from_consensus(1)),
+                Some(Ordered(absolute::LockTime::from_consensus(1))),
                 None,
             ),
             (
@@ -1293,7 +1293,7 @@ mod tests {
                     "thresh(3,pk({}),s:pk({}),snl:older(10),snl:after(11))",
                     key_present, key_missing
                 ),
-                Some(AbsLockTime::from_consensus(11)),
+                Some(Ordered(absolute::LockTime::from_consensus(11))),
                 Some(bitcoin::Sequence(10)),
             ),
             (

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -914,7 +914,7 @@ impl Property for ExtData {
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_after(t.into()))
+                Ok(Self::from_after(*t))
             }
             Terminal::Older(t) => {
                 if t == Sequence::ZERO || !t.is_relative_lock_time() {

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -395,7 +395,7 @@ pub trait Property: Sized {
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_after(t.into()))
+                Ok(Self::from_after(*t))
             }
             Terminal::Older(t) => {
                 if t == Sequence::ZERO || !t.is_relative_lock_time() {
@@ -751,7 +751,7 @@ impl Property for Type {
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_after(t.into()))
+                Ok(Self::from_after(*t))
             }
             Terminal::Older(t) => {
                 if t == Sequence::ZERO || !t.is_relative_lock_time() {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -20,6 +20,7 @@ use core::iter::FromIterator;
 use bitcoin::absolute::LockTime;
 use bitcoin::hashes::{hash160, ripemd160, sha256};
 use bitcoin::key::XOnlyPublicKey;
+use bitcoin::ordered::Ordered;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::taproot::{ControlBlock, LeafVersion, TapLeafHash};
 use bitcoin::{bip32, psbt, ScriptBuf, Sequence, WitnessVersion};
@@ -222,7 +223,7 @@ pub struct Plan {
     /// This plan's witness template
     pub(crate) template: Vec<Placeholder<DefiniteDescriptorKey>>,
     /// The absolute timelock this plan uses
-    pub absolute_timelock: Option<LockTime>,
+    pub absolute_timelock: Option<Ordered<LockTime>>,
     /// The relative timelock this plan uses
     pub relative_timelock: Option<Sequence>,
 


### PR DESCRIPTION
This is not a merge candidate, its a demo, together with https://github.com/rust-bitcoin/rust-bitcoin/pull/2248

The sole purpose of the `AbsLockTime` type is to implement `PartialOrd` and `Ord`. We can use the `Ordered` type to wrap `absolute::LockTime` to achieve this purpose.
