### PR TITLE
Update MSRV to 1.56.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
           - rust: stable
           - rust: beta
           - rust: nightly
-          - rust: 1.48
+          - rust: "1.56.1"
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build](https://github.com/rust-bitcoin/rust-miniscript/workflows/Continuous%20integration/badge.svg)
 
-**Minimum Supported Rust Version:** 1.48.0
+**Minimum Supported Rust Version:** 1.56.1
 
 # Miniscript
 
@@ -40,7 +40,8 @@ The cargo feature `std` is enabled by default. At least one of the features `std
 Enabling the `no-std` feature does not disable `std`. To disable the `std` feature you must disable default features. The `no-std` feature only enables additional features required for this crate to be usable without `std`. Both can be enabled without conflict.
 
 ## Minimum Supported Rust Version (MSRV)
-This library should always compile with any combination of features on **Rust 1.48.0**.
+
+This library should always compile with any combination of features on **Rust 1.56.1**.
 
 Some dependencies do not play nicely with our MSRV, if you are running the tests
 you may need to pin some dependencies. See `./contrib/test.sh` for current pinning.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,3 @@
-msrv = "1.48.0"
+msrv = "1.56.1"
 # plan API returns Self as an error type for an large-ish enum
 large-error-threshold = 256

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -20,19 +20,6 @@ then
     cargo fmt -- --check
 fi
 
-# Pin dependencies required to build with Rust 1.48.0
-if cargo --version | grep "1\.48\.0"; then
-    cargo update -p once_cell --precise 1.13.1
-    cargo update -p quote --precise 1.0.28
-    cargo update -p syn --precise 2.0.32
-    cargo update -p proc-macro2 --precise 1.0.63
-    cargo update -p serde_json --precise 1.0.99
-    cargo update -p serde --precise 1.0.152
-    cargo update -p log --precise 0.4.18
-    cargo update -p serde_test --precise 1.0.152
-    cargo update -p memchr --precise 2.5.0
-fi
-
 # Test bitcoind integration tests if told to (this only works with the stable toolchain)
 if [ "$DO_BITCOIND_TESTS" = true ]; then
     cd bitcoind-tests


### PR DESCRIPTION
Following `rust-bitcoin` MSRV of 1.56.1, this pins MSRV to 1.56.1.

Quoting a recent merge in `rust-bitcoin`

> Rust version 1.56.0 introduced edition 2021. Shortly afterwards, on
> October 21 2021 Rust version 1.56.1 was released.
>
> Debian stable is currently shipping `rustc 1.63.0`.
>
> Our stated MSRV policy is: In Debian stable and at least 2 years old.
>
> Therefore our MSRV policy is met by Rust version 1.56.1 and we can strat
> to bump our MSRV org wide.
>
> Links:
> - https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html
> - https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
> - https://packages.debian.org/stable/rust/rustc

Removing the pins in `contrib/test.sh` since they are not necessary
in 1.56.1.


EDIT: CI fails because of the `#[allow(dead_code)]` implemented in #638 on some Psbt traits.
Do I port these to here? Conceptually they belong to #638 and not here.