### PR TITLE
remove sketchy `LikelyFalse` error

### DIFF
--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -8,7 +8,7 @@ use miniscript::bitcoin::hashes::hex::FromHex;
 use miniscript::bitcoin::psbt::{self, Psbt};
 use miniscript::bitcoin::sighash::SighashCache;
 use miniscript::bitcoin::{
-    self, secp256k1, transaction, Address, Amount, Network, OutPoint, PrivateKey, Script, Sequence,
+    secp256k1, transaction, Address, Amount, Network, OutPoint, PrivateKey, Script, Sequence,
     Transaction, TxIn, TxOut,
 };
 use miniscript::psbt::{PsbtExt, PsbtInputExt};

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -9,8 +9,8 @@ use miniscript::bitcoin::psbt::{self, Psbt};
 use miniscript::bitcoin::sighash::SighashCache;
 //use miniscript::bitcoin::secp256k1; // https://github.com/rust-lang/rust/issues/121684
 use miniscript::bitcoin::{
-    transaction, Address, Amount, Network, OutPoint, PrivateKey, Script, Sequence,
-    Transaction, TxIn, TxOut,
+    transaction, Address, Amount, Network, OutPoint, PrivateKey, Script, Sequence, Transaction,
+    TxIn, TxOut,
 };
 use miniscript::psbt::{PsbtExt, PsbtInputExt};
 use miniscript::Descriptor;

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -7,8 +7,9 @@ use miniscript::bitcoin::consensus::encode::deserialize;
 use miniscript::bitcoin::hashes::hex::FromHex;
 use miniscript::bitcoin::psbt::{self, Psbt};
 use miniscript::bitcoin::sighash::SighashCache;
+//use miniscript::bitcoin::secp256k1; // https://github.com/rust-lang/rust/issues/121684
 use miniscript::bitcoin::{
-    secp256k1, transaction, Address, Amount, Network, OutPoint, PrivateKey, Script, Sequence,
+    transaction, Address, Amount, Network, OutPoint, PrivateKey, Script, Sequence,
     Transaction, TxIn, TxOut,
 };
 use miniscript::psbt::{PsbtExt, PsbtInputExt};

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use bitcoin::blockdata::witness::Witness;
-use bitcoin::{absolute, ecdsa, secp256k1, transaction, Amount, Sequence};
+use bitcoin::{absolute, ecdsa, transaction, Amount, Sequence};
 
 fn main() {
     let mut tx = spending_transaction();

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -5,7 +5,7 @@
 use std::str::FromStr;
 
 use miniscript::bitcoin::consensus::Decodable;
-use miniscript::bitcoin::secp256k1::{self, Secp256k1};
+use miniscript::bitcoin::secp256k1::Secp256k1;
 use miniscript::bitcoin::{absolute, sighash, Sequence};
 use miniscript::interpreter::KeySigPair;
 

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -1142,7 +1142,7 @@ impl Serialize for DescriptorPublicKey {
 mod test {
     use core::str::FromStr;
 
-    use bitcoin::{bip32, secp256k1};
+    use bitcoin::bip32;
     #[cfg(feature = "serde")]
     use serde_test::{assert_tokens, Token};
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1009,9 +1009,9 @@ mod tests {
 
     use super::checksum::desc_checksum;
     use super::*;
+    use crate::hex_script;
     #[cfg(feature = "compiler")]
     use crate::policy;
-    use crate::hex_script;
 
     type StdDescriptor = Descriptor<PublicKey>;
     const TEST_PK: &str = "pk(020000000000000000000000000000000000000000000000000000000000000002)";

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -997,25 +997,21 @@ pub(crate) use write_descriptor;
 #[cfg(test)]
 mod tests {
     use core::convert::TryFrom;
-    use core::str::FromStr;
 
     use bitcoin::blockdata::opcodes::all::{OP_CLTV, OP_CSV};
     use bitcoin::blockdata::script::Instruction;
     use bitcoin::blockdata::{opcodes, script};
     use bitcoin::hashes::hex::FromHex;
-    use bitcoin::hashes::{hash160, sha256, Hash};
+    use bitcoin::hashes::Hash;
     use bitcoin::script::PushBytes;
     use bitcoin::sighash::EcdsaSighashType;
-    use bitcoin::{self, bip32, secp256k1, PublicKey, Sequence};
+    use bitcoin::{bip32, PublicKey, Sequence};
 
     use super::checksum::desc_checksum;
-    use super::tr::Tr;
     use super::*;
-    use crate::descriptor::key::Wildcard;
-    use crate::descriptor::{DescriptorPublicKey, DescriptorXKey, SinglePub};
     #[cfg(feature = "compiler")]
     use crate::policy;
-    use crate::{hex_script, Descriptor, Error, Miniscript, Satisfier};
+    use crate::hex_script;
 
     type StdDescriptor = Descriptor<PublicKey>;
     const TEST_PK: &str = "pk(020000000000000000000000000000000000000000000000000000000000000002)";

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -3,12 +3,12 @@
 use core::str::FromStr;
 use core::{cmp, fmt, hash};
 
+#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
+use bitcoin::secp256k1;
 use bitcoin::taproot::{
     LeafVersion, TaprootBuilder, TaprootSpendInfo, TAPROOT_CONTROL_BASE_SIZE,
     TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_NODE_SIZE,
 };
-#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
-use bitcoin::secp256k1;
 use bitcoin::{opcodes, Address, Network, ScriptBuf};
 use sync::Arc;
 

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -7,7 +7,9 @@ use bitcoin::taproot::{
     LeafVersion, TaprootBuilder, TaprootSpendInfo, TAPROOT_CONTROL_BASE_SIZE,
     TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_NODE_SIZE,
 };
-use bitcoin::{opcodes, secp256k1, Address, Network, ScriptBuf};
+#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
+use bitcoin::secp256k1;
+use bitcoin::{opcodes, Address, Network, ScriptBuf};
 use sync::Arc;
 
 use super::checksum::{self, verify_checksum};

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -7,7 +7,9 @@ use std::error;
 
 use bitcoin::hashes::hash160;
 use bitcoin::hex::DisplayHex;
-use bitcoin::{secp256k1, taproot};
+#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
+use bitcoin::secp256k1;
+use bitcoin::taproot;
 
 use super::BitcoinKey;
 use crate::prelude::*;

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -399,7 +399,7 @@ mod tests {
     use bitcoin::blockdata::script;
     use bitcoin::hashes::hex::FromHex;
     use bitcoin::script::PushBytes;
-    use bitcoin::{self, ScriptBuf};
+    use bitcoin::ScriptBuf;
 
     use super::*;
 

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -398,12 +398,10 @@ mod tests {
 
     use bitcoin::blockdata::script;
     use bitcoin::hashes::hex::FromHex;
-    use bitcoin::hashes::{hash160, sha256, Hash};
     use bitcoin::script::PushBytes;
     use bitcoin::{self, ScriptBuf};
 
     use super::*;
-    use crate::miniscript::analyzable::ExtParams;
 
     struct KeyTestData {
         pk_spk: bitcoin::ScriptBuf,

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1023,7 +1023,6 @@ fn verify_sersig<'txin>(
 #[cfg(test)]
 mod tests {
 
-    use bitcoin;
     use bitcoin::secp256k1::Secp256k1;
 
     use super::inner::ToNoChecks;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1024,14 +1024,11 @@ fn verify_sersig<'txin>(
 mod tests {
 
     use bitcoin;
-    use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
-    use bitcoin::secp256k1::{self, Secp256k1};
+    use bitcoin::secp256k1::Secp256k1;
 
     use super::inner::ToNoChecks;
     use super::*;
     use crate::miniscript::analyzable::ExtParams;
-    use crate::miniscript::context::NoChecks;
-    use crate::{Miniscript, ToPublicKey};
 
     #[allow(clippy::type_complexity)]
     fn setup_keys_sigs(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,8 +442,6 @@ pub enum Error {
     MultiAt(String),
     /// Name of a fragment contained `@` but we were not parsing an OR
     AtOutsideOr(String),
-    /// Encountered a `l:0` which is syntactically equal to `u:0` except stupid
-    LikelyFalse,
     /// Encountered a wrapping character that we don't recognize
     UnknownWrapper(char),
     /// Parsed a miniscript and the result was not of type T
@@ -526,7 +524,6 @@ impl fmt::Display for Error {
             Error::MultiColon(ref s) => write!(f, "«{}» has multiple instances of «:»", s),
             Error::MultiAt(ref s) => write!(f, "«{}» has multiple instances of «@»", s),
             Error::AtOutsideOr(ref s) => write!(f, "«{}» contains «@» in non-or() context", s),
-            Error::LikelyFalse => write!(f, "0 is not very likely (use «u:0»)"),
             Error::UnknownWrapper(ch) => write!(f, "unknown wrapper «{}:»", ch),
             Error::NonTopLevel(ref s) => write!(f, "non-T miniscript: {}", s),
             Error::Trailing(ref s) => write!(f, "trailing tokens: {}", s),
@@ -599,7 +596,6 @@ impl error::Error for Error {
             | MultiColon(_)
             | MultiAt(_)
             | AtOutsideOr(_)
-            | LikelyFalse
             | UnknownWrapper(_)
             | NonTopLevel(_)
             | Trailing(_)

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -412,9 +412,6 @@ impl_from_tree!(
                     )
                 }
                 'l' => {
-                    if ms.node == Terminal::False {
-                        return Err(Error::LikelyFalse);
-                    }
                     unwrapped = Terminal::OrI(
                         Arc::new(Miniscript::from_ast(Terminal::False)?),
                         Arc::new(ms),

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -205,7 +205,6 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkIter<'a, Pk, Ctx>
 #[cfg(test)]
 pub mod test {
     use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
-    use bitcoin::secp256k1;
 
     use super::Miniscript;
     use crate::miniscript::context::Segwitv0;

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -204,7 +204,6 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> Iterator for PkIter<'a, Pk, Ctx>
 // dependent libraries for their own tasts based on Miniscript AST
 #[cfg(test)]
 pub mod test {
-    use bitcoin;
     use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d, Hash};
     use bitcoin::secp256k1;
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -603,7 +603,7 @@ mod tests {
     use bitcoin::hashes::{hash160, sha256, Hash};
     use bitcoin::secp256k1::XOnlyPublicKey;
     use bitcoin::taproot::TapLeafHash;
-    use bitcoin::{self, secp256k1, Sequence};
+    use bitcoin::{secp256k1, Sequence};
     use sync::Arc;
 
     use super::{Miniscript, ScriptContext, Segwitv0, Tap};

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -603,7 +603,7 @@ mod tests {
     use bitcoin::hashes::{hash160, sha256, Hash};
     use bitcoin::secp256k1::XOnlyPublicKey;
     use bitcoin::taproot::TapLeafHash;
-    use bitcoin::{secp256k1, Sequence};
+    use bitcoin::Sequence;
     use sync::Arc;
 
     use super::{Miniscript, ScriptContext, Segwitv0, Tap};

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -735,9 +735,7 @@ impl Assets {
 mod test {
     use std::str::FromStr;
 
-    use bitcoin::absolute::LockTime;
     use bitcoin::bip32::Xpub;
-    use bitcoin::Sequence;
 
     use super::*;
     use crate::*;

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -5,7 +5,6 @@
 //! Optimizing compiler from concrete policies to Miniscript
 //!
 
-use core::convert::From;
 use core::{cmp, f64, fmt, hash, mem};
 #[cfg(feature = "std")]
 use std::error;
@@ -1152,7 +1151,7 @@ mod tests {
     use core::str::FromStr;
 
     use bitcoin::blockdata::{opcodes, script};
-    use bitcoin::{hashes, secp256k1, Sequence};
+    use bitcoin::{hashes, Sequence};
 
     use super::*;
     use crate::miniscript::{Legacy, Segwitv0, Tap};

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1152,7 +1152,7 @@ mod tests {
     use core::str::FromStr;
 
     use bitcoin::blockdata::{opcodes, script};
-    use bitcoin::{self, hashes, secp256k1, Sequence};
+    use bitcoin::{hashes, secp256k1, Sequence};
 
     use super::*;
     use crate::miniscript::{Legacy, Segwitv0, Tap};

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1146,8 +1146,6 @@ impl<Pk: MiniscriptKey> TreeLike for Arc<Policy<Pk>> {
 mod compiler_tests {
     use core::str::FromStr;
 
-    use sync::Arc;
-
     use super::*;
 
     #[test]

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -23,9 +23,9 @@ pub use self::semantic::Policy as Semantic;
 use crate::descriptor::Descriptor;
 use crate::miniscript::{Miniscript, ScriptContext};
 use crate::sync::Arc;
-use crate::{Error, MiniscriptKey, Terminal};
 #[cfg(all(not(feature = "std"), not(test)))]
 use crate::Vec;
+use crate::{Error, MiniscriptKey, Terminal};
 
 /// Policy entailment algorithm maximum number of terminals allowed.
 const ENTAILMENT_MAX_TERMINALS: usize = 20;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -245,10 +245,9 @@ mod tests {
     #[cfg(feature = "compiler")]
     use crate::descriptor::Tr;
     use crate::miniscript::context::Segwitv0;
-    use crate::miniscript::Miniscript;
     use crate::prelude::*;
     #[cfg(feature = "compiler")]
-    use crate::{descriptor::TapTree, Descriptor, Tap};
+    use crate::{descriptor::TapTree, Tap};
 
     type ConcretePol = Concrete<String>;
     type SemanticPol = Semantic<String>;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -23,7 +23,9 @@ pub use self::semantic::Policy as Semantic;
 use crate::descriptor::Descriptor;
 use crate::miniscript::{Miniscript, ScriptContext};
 use crate::sync::Arc;
-use crate::{Error, MiniscriptKey, Terminal, Vec};
+use crate::{Error, MiniscriptKey, Terminal};
+#[cfg(all(not(feature = "std"), not(test)))]
+use crate::Vec;
 
 /// Policy entailment algorithm maximum number of terminals allowed.
 const ENTAILMENT_MAX_TERMINALS: usize = 20;

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -698,8 +698,6 @@ impl<Pk: MiniscriptKey> TreeLike for Arc<Policy<Pk>> {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
     use bitcoin::PublicKey;
 
     use super::*;

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -12,7 +12,9 @@ use core::mem;
 
 use bitcoin::hashes::hash160;
 use bitcoin::key::XOnlyPublicKey;
-use bitcoin::secp256k1::{self, Secp256k1};
+#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
+use bitcoin::secp256k1;
+use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::Prevouts;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::{PublicKey, Script, ScriptBuf, TxOut, Witness};

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -14,7 +14,9 @@ use std::error;
 
 use bitcoin::hashes::{hash160, sha256d, Hash};
 use bitcoin::psbt::{self, Psbt};
-use bitcoin::secp256k1::{self, Secp256k1, VerifyOnly};
+#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
+use bitcoin::secp256k1;
+use bitcoin::secp256k1::{Secp256k1, VerifyOnly};
 use bitcoin::sighash::{self, SighashCache};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapLeafHash};
 use bitcoin::{absolute, bip32, transaction, Script, ScriptBuf, Sequence};

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1403,7 +1403,7 @@ mod tests {
     use bitcoin::hashes::hex::FromHex;
     use bitcoin::key::XOnlyPublicKey;
     use bitcoin::secp256k1::PublicKey;
-    use bitcoin::{absolute, Amount, OutPoint, TxIn, TxOut};
+    use bitcoin::{Amount, OutPoint, TxIn, TxOut};
 
     use super::*;
     use crate::Miniscript;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 use bitcoin::hashes::{hash160, ripemd160, sha256};
 use bitcoin::key::XOnlyPublicKey;
+#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
 use bitcoin::secp256k1;
 
 use crate::miniscript::context::SigType;


### PR DESCRIPTION
This error would trigger on `l:0` on the basis that this is equivalent to `u:0` but always less efficient. There are no other "linting" errors like this in this library, and the C++ implementation doesn't have it, so we should drop it.

Fixes #633 