### PR TITLE
Introduce an example binary useful for profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ required-features = ["compiler","std"]
 name = "psbt_sign_finalize"
 required-features = ["std", "base64"]
 
+[[example]]
+name = "big"
+required-features = ["std", "base64", "compiler"]
+
 [workspace]
 members = ["bitcoind-tests", "fuzz"]
 exclude = ["embedded"]

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-//! This is not an example and will surely panic if executed, the purpose of this is using the 
+//! This is not an example and will surely panic if executed, the purpose of this is using the
 //! compiled binary with tools like `cargo bloat` that cannot work with libraries.
 //!
 //! Ideal properties:
@@ -9,9 +9,17 @@
 //! * Use results so that calls are not stripped out.
 //!
 
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
+use std::str::FromStr;
+
 use bitcoin::{ecdsa, XOnlyPublicKey};
-use miniscript::{descriptor::Wsh, policy::{Concrete, Liftable}, psbt::PsbtExt, translate_hash_fail, DefiniteDescriptorKey, Descriptor, DescriptorPublicKey, MiniscriptKey, TranslatePk, Translator};
+use miniscript::descriptor::Wsh;
+use miniscript::policy::{Concrete, Liftable};
+use miniscript::psbt::PsbtExt;
+use miniscript::{
+    translate_hash_fail, DefiniteDescriptorKey, Descriptor, DescriptorPublicKey, MiniscriptKey,
+    TranslatePk, Translator,
+};
 use secp256k1::Secp256k1;
 fn main() {
     let empty = "".to_string();
@@ -24,7 +32,11 @@ fn main() {
     use_descriptor(Descriptor::<bitcoin::PublicKey>::from_str(&i).unwrap());
     use_descriptor(Descriptor::<String>::from_str(&i).unwrap());
 
-    let a = d.at_derivation_index(0).unwrap().address(bitcoin::Network::Bitcoin).unwrap();
+    let a = d
+        .at_derivation_index(0)
+        .unwrap()
+        .address(bitcoin::Network::Bitcoin)
+        .unwrap();
     println!("{}", a);
 
     let secp = Secp256k1::new();
@@ -51,7 +63,7 @@ fn main() {
     let pol = Concrete::<String>::from_str(&i).unwrap();
     let desc = pol.compile_tr(Some("UNSPENDABLE_KEY".to_string())).unwrap();
     println!("{}", desc);
-    let pk_map =HashMap::new();
+    let pk_map = HashMap::new();
     let mut t = StrPkTranslator { pk_map };
     let real_desc = desc.translate_pk(&mut t).unwrap();
     println!("{}", real_desc);
@@ -65,7 +77,6 @@ fn use_descriptor<K: MiniscriptKey>(d: Descriptor<K>) {
     println!("{:?}", d.desc_type());
     println!("{:?}", d.sanity_check());
 }
-
 
 struct StrPkTranslator {
     pk_map: HashMap<String, XOnlyPublicKey>,

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -10,7 +10,7 @@
 //!
 
 use std::str::FromStr;
-use miniscript::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey, MiniscriptKey};
+use miniscript::{descriptor::Wsh, policy::{Concrete, Liftable}, psbt::PsbtExt, DefiniteDescriptorKey, Descriptor, DescriptorPublicKey, MiniscriptKey};
 use secp256k1::Secp256k1;
 fn main() {
     let empty = "".to_string();
@@ -30,6 +30,13 @@ fn main() {
     let (d, m) = Descriptor::parse_descriptor(&secp, &i).unwrap();
     use_descriptor(d);
     println!("{:?}", m);
+
+    let p = Concrete::<bitcoin::PublicKey>::from_str(&i).unwrap();
+    let h = Wsh::new(p.compile().unwrap()).unwrap();
+    println!("{}", h);
+    println!("{:?}", h.lift());
+    println!("{:?}", h.script_pubkey());
+    println!("{:?}", h.address(bitcoin::Network::Bitcoin));
 }
 
 fn use_descriptor<K: MiniscriptKey>(d: Descriptor<K>) {

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -37,6 +37,11 @@ fn main() {
     println!("{:?}", h.lift());
     println!("{:?}", h.script_pubkey());
     println!("{:?}", h.address(bitcoin::Network::Bitcoin));
+
+    let psbt: bitcoin::Psbt = i.parse().unwrap();
+    let psbt = psbt.finalize(&secp).unwrap();
+    let tx = psbt.extract_tx().unwrap();
+    println!("{:?}", tx);
 }
 
 fn use_descriptor<K: MiniscriptKey>(d: Descriptor<K>) {

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -9,7 +9,8 @@
 //! * Use results so that calls are not stripped out.
 //!
 
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
+use bitcoin::ecdsa;
 use miniscript::{descriptor::Wsh, policy::{Concrete, Liftable}, psbt::PsbtExt, DefiniteDescriptorKey, Descriptor, DescriptorPublicKey, MiniscriptKey};
 use secp256k1::Secp256k1;
 fn main() {
@@ -40,8 +41,12 @@ fn main() {
 
     let psbt: bitcoin::Psbt = i.parse().unwrap();
     let psbt = psbt.finalize(&secp).unwrap();
-    let tx = psbt.extract_tx().unwrap();
+    let mut tx = psbt.extract_tx().unwrap();
     println!("{:?}", tx);
+
+    let d = miniscript::Descriptor::<bitcoin::PublicKey>::from_str(&i).unwrap();
+    let sigs = HashMap::<bitcoin::PublicKey, ecdsa::Signature>::new();
+    d.satisfy(&mut tx.input[0], &sigs).unwrap();
 }
 
 fn use_descriptor<K: MiniscriptKey>(d: Descriptor<K>) {

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: CC0-1.0
+//! This is not an example and will surely panic if executed, the purpose of this is using the 
+//! compiled binary with tools like `cargo bloat` that cannot work with libraries.
+//!
+//! Ideal properties:
+//!
+//! * Call all the library API surface.
+//! * Depend on user input so that functions are not stripped out on the base of static input.
+//! * Use results so that calls are not stripped out.
+//!
+
+use std::str::FromStr;
+use miniscript::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey, MiniscriptKey};
+use secp256k1::Secp256k1;
+fn main() {
+    let empty = "".to_string();
+    let mut args = std::env::args().collect::<Vec<_>>();
+    let i = args.pop().unwrap_or(empty);
+
+    let d = Descriptor::<DescriptorPublicKey>::from_str(&i).unwrap();
+    use_descriptor(d.clone());
+    use_descriptor(Descriptor::<DefiniteDescriptorKey>::from_str(&i).unwrap());
+    use_descriptor(Descriptor::<bitcoin::PublicKey>::from_str(&i).unwrap());
+    use_descriptor(Descriptor::<String>::from_str(&i).unwrap());
+
+    let a = d.at_derivation_index(0).unwrap().address(bitcoin::Network::Bitcoin).unwrap();
+    println!("{}", a);
+
+    let secp = Secp256k1::new();
+    let (d, m) = Descriptor::parse_descriptor(&secp, &i).unwrap();
+    use_descriptor(d);
+    println!("{:?}", m);
+}
+
+fn use_descriptor<K: MiniscriptKey>(d: Descriptor<K>) {
+    println!("{}", d);
+    println!("{:?}", d);
+    println!("{:?}", d.desc_type());
+    println!("{:?}", d.sanity_check());
+}


### PR DESCRIPTION
Tools like `cargo bloat` don't work on libraries but on final executable.

As seen in https://github.com/rust-bitcoin/rust-miniscript/issues/585 and https://github.com/rust-bitcoin/rust-miniscript/pull/584 the parse example is used as a base to profile binary bloat.

However, since the parse example is not using all the API surface, we may have good optimization that are not recognized as such because the optimized function are not in the tree of the functions used.

For benchmarking size optimization a specific binary that ideally touch all the API surface is needed and this MR introduce it.

More coverage will be added if this seem a good idea for reviewers.