### PR TITLE
use max_weight_to_satisfy instead of deprecated max_satisfaction_weight

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -347,12 +347,12 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
     )]
     pub fn max_satisfaction_weight(&self) -> Result<usize, Error> {
         let weight = match *self {
-            Descriptor::Bare(ref bare) => bare.max_satisfaction_weight()?,
-            Descriptor::Pkh(ref pkh) => pkh.max_satisfaction_weight(),
-            Descriptor::Wpkh(ref wpkh) => wpkh.max_satisfaction_weight(),
-            Descriptor::Wsh(ref wsh) => wsh.max_satisfaction_weight()?,
-            Descriptor::Sh(ref sh) => sh.max_satisfaction_weight()?,
-            Descriptor::Tr(ref tr) => tr.max_satisfaction_weight()?,
+            Descriptor::Bare(ref bare) => bare.max_weight_to_satisfy()?,
+            Descriptor::Pkh(ref pkh) => pkh.max_weight_to_satisfy(),
+            Descriptor::Wpkh(ref wpkh) => wpkh.max_weight_to_satisfy(),
+            Descriptor::Wsh(ref wsh) => wsh.max_weight_to_satisfy()?,
+            Descriptor::Sh(ref sh) => sh.max_weight_to_satisfy()?,
+            Descriptor::Tr(ref tr) => tr.max_weight_to_satisfy()?,
         };
         Ok(weight)
     }

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -239,7 +239,7 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
     pub fn max_satisfaction_weight(&self) -> Result<usize, Error> {
         Ok(match self.inner {
             // add weighted script sig, len byte stays the same
-            ShInner::Wsh(ref wsh) => 4 * 35 + wsh.max_satisfaction_weight()?,
+            ShInner::Wsh(ref wsh) => 4 * 35 + wsh.max_weight_to_satisfy()?,
             ShInner::SortedMulti(ref smv) => {
                 let ss = smv.script_size();
                 let ps = push_opcode_size(ss);
@@ -247,7 +247,7 @@ impl<Pk: MiniscriptKey> Sh<Pk> {
                 4 * (varint_len(scriptsig_len) + scriptsig_len)
             }
             // add weighted script sig, len byte stays the same
-            ShInner::Wpkh(ref wpkh) => 4 * 23 + wpkh.max_satisfaction_weight(),
+            ShInner::Wpkh(ref wpkh) => 4 * 23 + wpkh.max_weight_to_satisfy(),
             ShInner::Ms(ref ms) => {
                 let ss = ms.script_size();
                 let ps = push_opcode_size(ss);


### PR DESCRIPTION
This was simply meant to get rid of the warnings but I put in draft because it seems clear the two method are not equivalent for wpkh, with the new method computing always 5 less than the old one. Maybe it was simply wrong before but I can't explain this line:

```
        let stack_varint_diff = varint_len(2) - varint_len(0);
```

Which is always zero

Disclosure: I didn't read all https://github.com/rust-bitcoin/rust-miniscript/pull/476