### PR TITLE
add conditional formatting for Terminal

### DIFF
--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -180,15 +180,15 @@ fn conditional_fmt<D: fmt::Debug + fmt::Display>(
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("[")?;
-        if let Ok(type_map) = types::Type::type_check(self) {
+
+        fn fmt_type_map(f: &mut fmt::Formatter<'_>, type_map: types::Type) -> fmt::Result {
             f.write_str(match type_map.corr.base {
                 types::Base::B => "B",
                 types::Base::K => "K",
                 types::Base::V => "V",
                 types::Base::W => "W",
             })?;
-            fmt::Write::write_char(f, '/')?;
+            f.write_str("/")?;
             f.write_str(match type_map.corr.input {
                 types::Input::Zero => "z",
                 types::Input::One => "o",
@@ -197,10 +197,10 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
                 types::Input::AnyNonZero => "n",
             })?;
             if type_map.corr.dissatisfiable {
-                fmt::Write::write_char(f, 'd')?;
+                f.write_str("d")?;
             }
             if type_map.corr.unit {
-                fmt::Write::write_char(f, 'u')?;
+                f.write_str("u")?;
             }
             f.write_str(match type_map.mall.dissat {
                 types::Dissat::None => "f",
@@ -208,11 +208,17 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
                 types::Dissat::Unknown => "",
             })?;
             if type_map.mall.safe {
-                fmt::Write::write_char(f, 's')?;
+                f.write_str("s")?;
             }
             if type_map.mall.non_malleable {
-                fmt::Write::write_char(f, 'm')?;
+                f.write_str("m")?;
             }
+            Ok(())
+        }
+
+        f.write_str("[")?;
+        if let Ok(type_map) = types::Type::type_check(self) {
+            fmt_type_map(f, type_map)?;
         } else {
             f.write_str("TYPECHECK FAILED")?;
         }
@@ -220,7 +226,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
         if let Some((ch, sub)) = self.wrap_char() {
             fmt::Write::write_char(f, ch)?;
             if sub.node.wrap_char().is_none() {
-                fmt::Write::write_char(f, ':')?;
+                f.write_str(":")?;
             }
             write!(f, "{:?}", sub)
         } else {

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -41,6 +41,141 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             _ => None,
         }
     }
+
+    fn conditional_fmt(&self, f: &mut fmt::Formatter, is_debug: bool) -> fmt::Result {
+        match *self {
+            Terminal::PkK(ref pk) => fmt_1(f, "pk_k(", pk, is_debug),
+            Terminal::PkH(ref pk) => fmt_1(f, "pk_h(", pk, is_debug),
+            Terminal::RawPkH(ref pkh) => fmt_1(f, "expr_raw_pk_h(", pkh, is_debug),
+            Terminal::After(ref t) => fmt_1(f, "after(", t, is_debug),
+            Terminal::Older(ref t) => fmt_1(f, "older(", t, is_debug),
+            Terminal::Sha256(ref h) => fmt_1(f, "sha256(", h, is_debug),
+            Terminal::Hash256(ref h) => fmt_1(f, "hash256(", h, is_debug),
+            Terminal::Ripemd160(ref h) => fmt_1(f, "ripemd160(", h, is_debug),
+            Terminal::Hash160(ref h) => fmt_1(f, "hash160(", h, is_debug),
+            Terminal::True => f.write_str("1"),
+            Terminal::False => f.write_str("0"),
+            Terminal::AndV(ref l, ref r) if r.node != Terminal::True => {
+                fmt_2(f, "and_v(", l, r, is_debug)
+            }
+            Terminal::AndB(ref l, ref r) => fmt_2(f, "and_b(", l, r, is_debug),
+            Terminal::AndOr(ref a, ref b, ref c) => {
+                if c.node == Terminal::False {
+                    fmt_2(f, "and_b(", a, b, is_debug)
+                } else {
+                    f.write_str("andor(")?;
+                    conditional_fmt(f, a, is_debug)?;
+                    f.write_str(",")?;
+                    conditional_fmt(f, b, is_debug)?;
+                    f.write_str(",")?;
+                    conditional_fmt(f, c, is_debug)?;
+                    f.write_str(")")
+                }
+            }
+            Terminal::OrB(ref l, ref r) => fmt_2(f, "or_b(", l, r, is_debug),
+            Terminal::OrD(ref l, ref r) => fmt_2(f, "or_d(", l, r, is_debug),
+            Terminal::OrC(ref l, ref r) => fmt_2(f, "or_c(", l, r, is_debug),
+            Terminal::OrI(ref l, ref r)
+                if l.node != Terminal::False && r.node != Terminal::False =>
+            {
+                fmt_2(f, "or_i(", l, r, is_debug)
+            }
+            Terminal::Thresh(k, ref subs) => fmt_n(f, "thresh(", k, subs, is_debug),
+            Terminal::Multi(k, ref keys) => fmt_n(f, "multi(", k, keys, is_debug),
+            Terminal::MultiA(k, ref keys) => fmt_n(f, "multi_a(", k, keys, is_debug),
+            // wrappers
+            _ => {
+                if let Some((ch, sub)) = self.wrap_char() {
+                    if ch == 'c' {
+                        if let Terminal::PkK(ref pk) = sub.node {
+                            // alias: pk(K) = c:pk_k(K)
+                            return write!(f, "pk({})", pk);
+                        } else if let Terminal::RawPkH(ref pkh) = sub.node {
+                            // `RawPkH` is currently unsupported in the descriptor spec
+                            // alias: pkh(K) = c:pk_h(K)
+                            // We temporarily display there using raw_pkh, but these descriptors
+                            // are not defined in the spec yet. These are prefixed with `expr`
+                            // in the descriptor string.
+                            // We do not support parsing these descriptors yet.
+                            return write!(f, "expr_raw_pkh({})", pkh);
+                        } else if let Terminal::PkH(ref pk) = sub.node {
+                            // alias: pkh(K) = c:pk_h(K)
+                            return write!(f, "pkh({})", pk);
+                        }
+                    }
+
+                    fmt::Write::write_char(f, ch)?;
+                    match sub.node.wrap_char() {
+                        None => {
+                            f.write_str(":")?;
+                        }
+                        // Add a ':' wrapper if there are other wrappers apart from c:pk_k()
+                        // tvc:pk_k() -> tv:pk()
+                        Some(('c', ms)) => match ms.node {
+                            Terminal::PkK(_) | Terminal::PkH(_) | Terminal::RawPkH(_) => {
+                                f.write_str(":")?;
+                            }
+                            _ => {}
+                        },
+                        _ => {}
+                    };
+                    write!(f, "{}", sub)
+                } else {
+                    unreachable!();
+                }
+            }
+        }
+    }
+}
+
+fn fmt_1<D: fmt::Debug + fmt::Display>(
+    f: &mut fmt::Formatter,
+    name: &str,
+    a: &D,
+    is_debug: bool,
+) -> fmt::Result {
+    f.write_str(&name)?;
+    conditional_fmt(f, a, is_debug)?;
+    f.write_str(")")
+}
+fn fmt_2<D: fmt::Debug + fmt::Display>(
+    f: &mut fmt::Formatter,
+    name: &str,
+    a: &D,
+    b: &D,
+    is_debug: bool,
+) -> fmt::Result {
+    f.write_str(&name)?;
+    conditional_fmt(f, a, is_debug)?;
+    f.write_str(",")?;
+    conditional_fmt(f, b, is_debug)?;
+    f.write_str(")")
+}
+fn fmt_n<D: fmt::Debug + fmt::Display>(
+    f: &mut fmt::Formatter,
+    name: &str,
+    first: usize,
+    list: &[D],
+    is_debug: bool,
+) -> fmt::Result {
+    f.write_str(&name)?;
+    write!(f, "{}", first)?;
+    for el in list {
+        f.write_str(",")?;
+        conditional_fmt(f, el, is_debug)?;
+    }
+    f.write_str(")")
+}
+fn conditional_fmt<D: fmt::Debug + fmt::Display>(
+    f: &mut fmt::Formatter,
+    data: &D,
+    is_debug: bool,
+) -> fmt::Result {
+    if is_debug {
+        fmt::Debug::fmt(data, f)
+    } else {
+        fmt::Display::fmt(data, f)
+    }
 }
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
@@ -89,155 +224,13 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
             }
             write!(f, "{:?}", sub)
         } else {
-            match *self {
-                Terminal::PkK(ref pk) => write!(f, "pk_k({:?})", pk),
-                Terminal::PkH(ref pk) => write!(f, "pk_h({:?})", pk),
-                Terminal::RawPkH(ref pkh) => write!(f, "expr_raw_pk_h({:?})", pkh),
-                Terminal::After(t) => write!(f, "after({})", t),
-                Terminal::Older(t) => write!(f, "older({})", t),
-                Terminal::Sha256(ref h) => write!(f, "sha256({})", h),
-                Terminal::Hash256(ref h) => write!(f, "hash256({})", h),
-                Terminal::Ripemd160(ref h) => write!(f, "ripemd160({})", h),
-                Terminal::Hash160(ref h) => write!(f, "hash160({})", h),
-                Terminal::True => f.write_str("1"),
-                Terminal::False => f.write_str("0"),
-                Terminal::AndV(ref l, ref r) => write!(f, "and_v({:?},{:?})", l, r),
-                Terminal::AndB(ref l, ref r) => write!(f, "and_b({:?},{:?})", l, r),
-                Terminal::AndOr(ref a, ref b, ref c) => {
-                    if c.node == Terminal::False {
-                        write!(f, "and_n({:?},{:?})", a, b)
-                    } else {
-                        write!(f, "andor({:?},{:?},{:?})", a, b, c)
-                    }
-                }
-                Terminal::OrB(ref l, ref r) => write!(f, "or_b({:?},{:?})", l, r),
-                Terminal::OrD(ref l, ref r) => write!(f, "or_d({:?},{:?})", l, r),
-                Terminal::OrC(ref l, ref r) => write!(f, "or_c({:?},{:?})", l, r),
-                Terminal::OrI(ref l, ref r) => write!(f, "or_i({:?},{:?})", l, r),
-                Terminal::Thresh(k, ref subs) => {
-                    write!(f, "thresh({}", k)?;
-                    for s in subs {
-                        write!(f, ",{:?}", s)?;
-                    }
-                    f.write_str(")")
-                }
-                Terminal::Multi(k, ref keys) => {
-                    write!(f, "multi({}", k)?;
-                    for k in keys {
-                        write!(f, ",{:?}", k)?;
-                    }
-                    f.write_str(")")
-                }
-                Terminal::MultiA(k, ref keys) => {
-                    write!(f, "multi_a({}", k)?;
-                    for k in keys {
-                        write!(f, ",{}", k)?;
-                    }
-                    f.write_str(")")
-                }
-                _ => unreachable!(),
-            }
+            self.conditional_fmt(f, true)
         }
     }
 }
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Terminal<Pk, Ctx> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Terminal::PkK(ref pk) => write!(f, "pk_k({})", pk),
-            Terminal::PkH(ref pk) => write!(f, "pk_h({})", pk),
-            Terminal::RawPkH(ref pkh) => write!(f, "expr_raw_pk_h({})", pkh),
-            Terminal::After(t) => write!(f, "after({})", t),
-            Terminal::Older(t) => write!(f, "older({})", t),
-            Terminal::Sha256(ref h) => write!(f, "sha256({})", h),
-            Terminal::Hash256(ref h) => write!(f, "hash256({})", h),
-            Terminal::Ripemd160(ref h) => write!(f, "ripemd160({})", h),
-            Terminal::Hash160(ref h) => write!(f, "hash160({})", h),
-            Terminal::True => f.write_str("1"),
-            Terminal::False => f.write_str("0"),
-            Terminal::AndV(ref l, ref r) if r.node != Terminal::True => {
-                write!(f, "and_v({},{})", l, r)
-            }
-            Terminal::AndB(ref l, ref r) => write!(f, "and_b({},{})", l, r),
-            Terminal::AndOr(ref a, ref b, ref c) => {
-                if c.node == Terminal::False {
-                    write!(f, "and_n({},{})", a, b)
-                } else {
-                    write!(f, "andor({},{},{})", a, b, c)
-                }
-            }
-            Terminal::OrB(ref l, ref r) => write!(f, "or_b({},{})", l, r),
-            Terminal::OrD(ref l, ref r) => write!(f, "or_d({},{})", l, r),
-            Terminal::OrC(ref l, ref r) => write!(f, "or_c({},{})", l, r),
-            Terminal::OrI(ref l, ref r)
-                if l.node != Terminal::False && r.node != Terminal::False =>
-            {
-                write!(f, "or_i({},{})", l, r)
-            }
-            Terminal::Thresh(k, ref subs) => {
-                write!(f, "thresh({}", k)?;
-                for s in subs {
-                    write!(f, ",{}", s)?;
-                }
-                f.write_str(")")
-            }
-            Terminal::Multi(k, ref keys) => {
-                write!(f, "multi({}", k)?;
-                for k in keys {
-                    write!(f, ",{}", k)?;
-                }
-                f.write_str(")")
-            }
-            Terminal::MultiA(k, ref keys) => {
-                write!(f, "multi_a({}", k)?;
-                for k in keys {
-                    write!(f, ",{}", k)?;
-                }
-                f.write_str(")")
-            }
-            // wrappers
-            _ => {
-                if let Some((ch, sub)) = self.wrap_char() {
-                    if ch == 'c' {
-                        if let Terminal::PkK(ref pk) = sub.node {
-                            // alias: pk(K) = c:pk_k(K)
-                            return write!(f, "pk({})", pk);
-                        } else if let Terminal::RawPkH(ref pkh) = sub.node {
-                            // `RawPkH` is currently unsupported in the descriptor spec
-                            // alias: pkh(K) = c:pk_h(K)
-                            // We temporarily display there using raw_pkh, but these descriptors
-                            // are not defined in the spec yet. These are prefixed with `expr`
-                            // in the descriptor string.
-                            // We do not support parsing these descriptors yet.
-                            return write!(f, "expr_raw_pkh({})", pkh);
-                        } else if let Terminal::PkH(ref pk) = sub.node {
-                            // alias: pkh(K) = c:pk_h(K)
-                            return write!(f, "pkh({})", pk);
-                        }
-                    }
-
-                    fmt::Write::write_char(f, ch)?;
-                    match sub.node.wrap_char() {
-                        None => {
-                            fmt::Write::write_char(f, ':')?;
-                        }
-                        // Add a ':' wrapper if there are other wrappers apart from c:pk_k()
-                        // tvc:pk_k() -> tv:pk()
-                        Some(('c', ms)) => match ms.node {
-                            Terminal::PkK(_) | Terminal::PkH(_) | Terminal::RawPkH(_) => {
-                                fmt::Write::write_char(f, ':')?
-                            }
-                            _ => {}
-                        },
-                        _ => {}
-                    };
-                    write!(f, "{}", sub)
-                } else {
-                    unreachable!();
-                }
-            }
-        }
-    }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.conditional_fmt(f, false) }
 }
 
 impl<Pk: crate::FromStrKey, Ctx: ScriptContext> crate::expression::FromTree

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -89,7 +89,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
                     if ch == 'c' {
                         if let Terminal::PkK(ref pk) = sub.node {
                             // alias: pk(K) = c:pk_k(K)
-                            return write!(f, "pk({})", pk);
+                            return fmt_1(f, "pk(", pk, is_debug);
                         } else if let Terminal::RawPkH(ref pkh) = sub.node {
                             // `RawPkH` is currently unsupported in the descriptor spec
                             // alias: pkh(K) = c:pk_h(K)
@@ -97,10 +97,10 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
                             // are not defined in the spec yet. These are prefixed with `expr`
                             // in the descriptor string.
                             // We do not support parsing these descriptors yet.
-                            return write!(f, "expr_raw_pkh({})", pkh);
+                            return fmt_1(f, "expr_raw_pkh(", pkh, is_debug);
                         } else if let Terminal::PkH(ref pk) = sub.node {
                             // alias: pkh(K) = c:pk_h(K)
-                            return write!(f, "pkh({})", pk);
+                            return fmt_1(f, "pkh(", pk, is_debug);
                         }
                     }
 
@@ -119,7 +119,11 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
                         },
                         _ => {}
                     };
-                    write!(f, "{}", sub)
+                    if is_debug {
+                        write!(f, "{:?}", sub)
+                    } else {
+                        write!(f, "{}", sub)
+                    }
                 } else {
                     unreachable!();
                 }
@@ -180,7 +184,6 @@ fn conditional_fmt<D: fmt::Debug + fmt::Display>(
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-
         fn fmt_type_map(f: &mut fmt::Formatter<'_>, type_map: types::Type) -> fmt::Result {
             f.write_str(match type_map.corr.base {
                 types::Base::B => "B",
@@ -223,15 +226,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Debug for Terminal<Pk, Ctx> {
             f.write_str("TYPECHECK FAILED")?;
         }
         f.write_str("]")?;
-        if let Some((ch, sub)) = self.wrap_char() {
-            fmt::Write::write_char(f, ch)?;
-            if sub.node.wrap_char().is_none() {
-                f.write_str(":")?;
-            }
-            write!(f, "{:?}", sub)
-        } else {
-            self.conditional_fmt(f, true)
-        }
+
+        self.conditional_fmt(f, true)
     }
 }
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -898,7 +898,7 @@ mod tests {
             phantom: PhantomData,
         }));
         let pkk_ms: Miniscript<String, Segwitv0> = Miniscript::from_ast(pk_node).unwrap();
-        dummy_string_rtt(pkk_ms, "[B/onduesm]c:[K/onduesm]pk_k(\"\")", "pk()");
+        dummy_string_rtt(pkk_ms, "[B/onduesm]pk(\"\")", "pk()");
 
         let pkh_node = Terminal::Check(Arc::new(Miniscript {
             node: Terminal::PkH(String::from("")),
@@ -908,7 +908,7 @@ mod tests {
         }));
         let pkh_ms: Miniscript<String, Segwitv0> = Miniscript::from_ast(pkh_node).unwrap();
 
-        let expected_debug = "[B/nduesm]c:[K/nduesm]pk_h(\"\")";
+        let expected_debug = "[B/nduesm]pkh(\"\")";
         let expected_display = "pkh()";
 
         assert_eq!(pkh_ms.ty.corr.base, types::Base::B);
@@ -988,7 +988,7 @@ mod tests {
 
         string_rtt(
             script,
-            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/onduesm]pk(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "pk(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)"
         );
 
@@ -996,7 +996,7 @@ mod tests {
 
         string_rtt(
             script,
-            "[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/onduesm]pk(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "pk(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)"
         );
 
@@ -1004,7 +1004,7 @@ mod tests {
 
         string_rtt(
             script,
-            "[B/onufsm]t[V/onfsm]v[B/onduesm]c:[K/onduesm]pk_k(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/onufsm]t[V/onfsm]v:[B/onduesm]pk(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "tv:pk(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)"
         );
 
@@ -1012,7 +1012,7 @@ mod tests {
 
         string_display_debug_test(
             script,
-            "[B/nduesm]c:[K/nduesm]pk_h(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/nduesm]pkh(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "pkh(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)",
         );
 
@@ -1020,7 +1020,7 @@ mod tests {
 
         string_display_debug_test(
             script,
-            "[B/nduesm]c:[K/nduesm]pk_h(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/nduesm]pkh(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "pkh(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)",
         );
 
@@ -1028,7 +1028,7 @@ mod tests {
 
         string_display_debug_test(
             script,
-            "[B/nufsm]t[V/nfsm]v[B/nduesm]c:[K/nduesm]pk_h(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
+            "[B/nufsm]t[V/nfsm]v:[B/nduesm]pkh(PublicKey { compressed: true, inner: PublicKey(aa4c32e50fb34a95a372940ae3654b692ea35294748c3dd2c08b29f87ba9288c8294efcb73dc719e45b91c45f084e77aebc07c1ff3ed8f37935130a36304a340) })",
             "tv:pkh(028c28a97bf8298bc0d23d8c749452a32e694b65e30a9472a3954ab30fe5324caa)",
         );
     }


### PR DESCRIPTION
fmt functions produce big binaries.

<details>
  <summary>cargo bloat --release --example big --all-features -n 1000000 --full-fn | grep astelem | grep fmt</summary>
   0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h75ba3ce6da61d374
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h6786aa26184b9ff6
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h03f9c2155559a440
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h00e63af9b88389b4
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hb60190c99fd48d17
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::ha9001c527b4cc4d6
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::ha726829fe4f3bf2b
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h95a7eadaa261d645
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h819e09dcb99bbc52
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h6ef89d30f9f4cb57
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h693edb5e35f9fc08
 0.0%   0.1%  2.8KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h27891ccf9609c782
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::he0a63893fe76f527
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h86eba44cb7298c4f
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h37a4628264df8c3b
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h2f3a9d297ec35dea
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h879ad74922a70f16
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h7dc2d9bc27c88fab
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h7578352fd420fc88
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h1809b9931776159e
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hf7760e0f27d70db4
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h9adfe0d7e2bfdd42
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h61cdb06e2a061932
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h44e1ab5daacde0df
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h2646ddd57694241b
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::he31fd2e9b12960f9
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hbefb77c4050bd5c9
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hb4deb7ef951af7af
 0.0%   0.1%  2.7KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Debug for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h80ee1108b955f2b4
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hc779f37cb81f761a
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hc4ac4a9b598fbdfb
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h5cca31d73f30c3c7
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h4588410e445d16c6
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::heb60f683c9e55e36
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hbe7939a797fcce35
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::ha536af3ff4313ed1
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h8969ddab726dea7f
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h7fca0d80a428dd24
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h6b4909db760a4721
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h5ed643a399966d49
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h1ed7d512c859a5a9
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hfd9775e798913648
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hf87563509ea7253d
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hb8b75c9c988d95c3
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h87b650968eb119ba
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h9986ae4314d85479
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h74343d637646e38a
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h680da8fa0ec0142c
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h6197658ba03f1fdf
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h961e1a4b75732a11
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h57b3cd148371177a
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h13d43f019a96d314
 0.0%   0.1%  2.6KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h008ca416c1ebc0d7
 0.0%   0.1%  2.5KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h82a27926db80dc37
 0.0%   0.1%  2.5KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::hc12b3098c3979175
 0.0%   0.1%  2.5KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h76e624d7abc545ba
 0.0%   0.1%  2.5KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h24511846d004e114
 0.0%   0.1%  2.5KiB       miniscript miniscript::miniscript::astelem::<impl core::fmt::Display for miniscript::miniscript::decode::Terminal<Pk,Ctx>>::fmt::h0d96e9d943f04d7d

</details>

Since Debug and Display implementations are ~equal except the Debug or Display representation of its child, this introduce conditional fmt trading performance for code size. Since performance shouldn't be that important in string conversion seems an interesting trade-off.

This is a PoC since the final impl of `conditional_fmt` is a little tedious, would like a concept ack before proceding