### PR TITLE
Drop the `Property` trait entirely

### DIFF
--- a/src/blanket_traits.rs
+++ b/src/blanket_traits.rs
@@ -12,8 +12,8 @@
 //! automatically implemented if you satisfy all the bounds.
 //!
 
-use core::fmt;
 use core::str::FromStr;
+use core::{fmt, hash};
 
 use crate::MiniscriptKey;
 
@@ -28,19 +28,43 @@ pub trait FromStrKey:
     > + FromStr<Err = Self::_FromStrErr>
 {
     /// Dummy type. Do not use.
-    type _Sha256: FromStr<Err = Self::_Sha256FromStrErr>;
+    type _Sha256: FromStr<Err = Self::_Sha256FromStrErr>
+        + Clone
+        + Eq
+        + Ord
+        + fmt::Display
+        + fmt::Debug
+        + hash::Hash;
     /// Dummy type. Do not use.
     type _Sha256FromStrErr: fmt::Debug + fmt::Display;
     /// Dummy type. Do not use.
-    type _Hash256: FromStr<Err = Self::_Hash256FromStrErr>;
+    type _Hash256: FromStr<Err = Self::_Hash256FromStrErr>
+        + Clone
+        + Eq
+        + Ord
+        + fmt::Display
+        + fmt::Debug
+        + hash::Hash;
     /// Dummy type. Do not use.
     type _Hash256FromStrErr: fmt::Debug + fmt::Display;
     /// Dummy type. Do not use.
-    type _Ripemd160: FromStr<Err = Self::_Ripemd160FromStrErr>;
+    type _Ripemd160: FromStr<Err = Self::_Ripemd160FromStrErr>
+        + Clone
+        + Eq
+        + Ord
+        + fmt::Display
+        + fmt::Debug
+        + hash::Hash;
     /// Dummy type. Do not use.
     type _Ripemd160FromStrErr: fmt::Debug + fmt::Display;
     /// Dummy type. Do not use.
-    type _Hash160: FromStr<Err = Self::_Hash160FromStrErr>;
+    type _Hash160: FromStr<Err = Self::_Hash160FromStrErr>
+        + Clone
+        + Eq
+        + Ord
+        + fmt::Display
+        + fmt::Debug
+        + hash::Hash;
     /// Dummy type. Do not use.
     type _Hash160FromStrErr: fmt::Debug + fmt::Display;
     /// Dummy type. Do not use.

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -22,8 +22,8 @@ use crate::policy::{semantic, Liftable};
 use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
-    BareCtx, Error, ForEachKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey, TranslateErr,
-    TranslatePk, Translator,
+    BareCtx, Error, ForEachKey, FromStrKey, Miniscript, MiniscriptKey, Satisfier, ToPublicKey,
+    TranslateErr, TranslatePk, Translator,
 };
 
 /// Create a Bare Descriptor. That is descriptor that is
@@ -166,7 +166,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Bare<Pk> {
     fn lift(&self) -> Result<semantic::Policy<Pk>, Error> { self.ms.lift() }
 }
 
-impl<Pk: crate::FromStrKey> FromTree for Bare<Pk> {
+impl<Pk: FromStrKey> FromTree for Bare<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         let sub = Miniscript::<Pk, BareCtx>::from_tree(top)?;
         BareCtx::top_level_checks(&sub)?;
@@ -174,7 +174,7 @@ impl<Pk: crate::FromStrKey> FromTree for Bare<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> core::str::FromStr for Bare<Pk> {
+impl<Pk: FromStrKey> core::str::FromStr for Bare<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let desc_str = verify_checksum(s)?;
@@ -364,7 +364,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Pkh<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> FromTree for Pkh<Pk> {
+impl<Pk: FromStrKey> FromTree for Pkh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         if top.name == "pkh" && top.args.len() == 1 {
             Ok(Pkh::new(expression::terminal(&top.args[0], |pk| Pk::from_str(pk))?)?)
@@ -378,7 +378,7 @@ impl<Pk: crate::FromStrKey> FromTree for Pkh<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> core::str::FromStr for Pkh<Pk> {
+impl<Pk: FromStrKey> core::str::FromStr for Pkh<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let desc_str = verify_checksum(s)?;

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -25,8 +25,8 @@ use crate::miniscript::{satisfy, Legacy, Miniscript, Segwitv0};
 use crate::plan::{AssetProvider, Plan};
 use crate::prelude::*;
 use crate::{
-    expression, hash256, BareCtx, Error, ForEachKey, MiniscriptKey, Satisfier, ToPublicKey,
-    TranslateErr, TranslatePk, Translator,
+    expression, hash256, BareCtx, Error, ForEachKey, FromStrKey, MiniscriptKey, Satisfier,
+    ToPublicKey, TranslateErr, TranslatePk, Translator,
 };
 
 mod bare;
@@ -918,7 +918,7 @@ impl Descriptor<DefiniteDescriptorKey> {
     }
 }
 
-impl<Pk: crate::FromStrKey> crate::expression::FromTree for Descriptor<Pk> {
+impl<Pk: FromStrKey> crate::expression::FromTree for Descriptor<Pk> {
     /// Parse an expression tree into a descriptor.
     fn from_tree(top: &expression::Tree) -> Result<Descriptor<Pk>, Error> {
         Ok(match (top.name, top.args.len() as u32) {
@@ -932,7 +932,7 @@ impl<Pk: crate::FromStrKey> crate::expression::FromTree for Descriptor<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> FromStr for Descriptor<Pk> {
+impl<Pk: FromStrKey> FromStr for Descriptor<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Descriptor<Pk>, Error> {
         // tr tree parsing has special code

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -20,8 +20,8 @@ use crate::policy::{semantic, Liftable};
 use crate::prelude::*;
 use crate::util::varint_len;
 use crate::{
-    Error, ForEachKey, Miniscript, MiniscriptKey, Satisfier, Segwitv0, ToPublicKey, TranslateErr,
-    TranslatePk, Translator,
+    Error, ForEachKey, FromStrKey, Miniscript, MiniscriptKey, Satisfier, Segwitv0, ToPublicKey,
+    TranslateErr, TranslatePk, Translator,
 };
 /// A Segwitv0 wsh descriptor
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -231,7 +231,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Wsh<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> crate::expression::FromTree for Wsh<Pk> {
+impl<Pk: FromStrKey> crate::expression::FromTree for Wsh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         if top.name == "wsh" && top.args.len() == 1 {
             let top = &top.args[0];
@@ -269,7 +269,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Wsh<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> core::str::FromStr for Wsh<Pk> {
+impl<Pk: FromStrKey> core::str::FromStr for Wsh<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let desc_str = verify_checksum(s)?;
@@ -473,7 +473,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Wpkh<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> crate::expression::FromTree for Wpkh<Pk> {
+impl<Pk: FromStrKey> crate::expression::FromTree for Wpkh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         if top.name == "wpkh" && top.args.len() == 1 {
             Ok(Wpkh::new(expression::terminal(&top.args[0], |pk| Pk::from_str(pk))?)?)
@@ -487,7 +487,7 @@ impl<Pk: crate::FromStrKey> crate::expression::FromTree for Wpkh<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> core::str::FromStr for Wpkh<Pk> {
+impl<Pk: FromStrKey> core::str::FromStr for Wpkh<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let desc_str = verify_checksum(s)?;

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -24,8 +24,8 @@ use crate::policy::{semantic, Liftable};
 use crate::prelude::*;
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
-    push_opcode_size, Error, ForEachKey, Legacy, Miniscript, MiniscriptKey, Satisfier, Segwitv0,
-    ToPublicKey, TranslateErr, TranslatePk, Translator,
+    push_opcode_size, Error, ForEachKey, FromStrKey, Legacy, Miniscript, MiniscriptKey, Satisfier,
+    Segwitv0, ToPublicKey, TranslateErr, TranslatePk, Translator,
 };
 
 /// A Legacy p2sh Descriptor
@@ -81,7 +81,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Sh<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> crate::expression::FromTree for Sh<Pk> {
+impl<Pk: FromStrKey> crate::expression::FromTree for Sh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         if top.name == "sh" && top.args.len() == 1 {
             let top = &top.args[0];
@@ -106,7 +106,7 @@ impl<Pk: crate::FromStrKey> crate::expression::FromTree for Sh<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> core::str::FromStr for Sh<Pk> {
+impl<Pk: FromStrKey> core::str::FromStr for Sh<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let desc_str = verify_checksum(s)?;

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -23,8 +23,8 @@ use crate::policy::Liftable;
 use crate::prelude::*;
 use crate::util::{varint_len, witness_size};
 use crate::{
-    errstr, Error, ForEachKey, MiniscriptKey, Satisfier, ScriptContext, Tap, ToPublicKey,
-    TranslateErr, TranslatePk, Translator,
+    errstr, Error, ForEachKey, FromStrKey, MiniscriptKey, Satisfier, ScriptContext, Tap,
+    ToPublicKey, TranslateErr, TranslatePk, Translator,
 };
 
 /// A Taproot Tree representation.
@@ -467,7 +467,7 @@ where
 }
 
 #[rustfmt::skip]
-impl<Pk: crate::FromStrKey> Tr<Pk> {
+impl<Pk: FromStrKey> Tr<Pk> {
     // Helper function to parse taproot script path
     fn parse_tr_script_spend(tree: &expression::Tree,) -> Result<TapTree<Pk>, Error> {
         match tree {
@@ -488,7 +488,7 @@ impl<Pk: crate::FromStrKey> Tr<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> crate::expression::FromTree for Tr<Pk> {
+impl<Pk: FromStrKey> crate::expression::FromTree for Tr<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         if top.name == "tr" {
             match top.args.len() {
@@ -530,7 +530,7 @@ impl<Pk: crate::FromStrKey> crate::expression::FromTree for Tr<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> core::str::FromStr for Tr<Pk> {
+impl<Pk: FromStrKey> core::str::FromStr for Tr<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let desc_str = verify_checksum(s)?;

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -19,7 +19,8 @@ use crate::miniscript::{types, ScriptContext};
 use crate::prelude::*;
 use crate::util::MsKeyBuilder;
 use crate::{
-    errstr, expression, AbsLockTime, Error, Miniscript, MiniscriptKey, Terminal, ToPublicKey,
+    errstr, expression, AbsLockTime, Error, FromStrKey, Miniscript, MiniscriptKey, Terminal,
+    ToPublicKey,
 };
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
@@ -240,15 +241,13 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> fmt::Display for Terminal<Pk, Ctx> {
     }
 }
 
-impl<Pk: crate::FromStrKey, Ctx: ScriptContext> crate::expression::FromTree
-    for Arc<Terminal<Pk, Ctx>>
-{
+impl<Pk: FromStrKey, Ctx: ScriptContext> crate::expression::FromTree for Arc<Terminal<Pk, Ctx>> {
     fn from_tree(top: &expression::Tree) -> Result<Arc<Terminal<Pk, Ctx>>, Error> {
         Ok(Arc::new(expression::FromTree::from_tree(top)?))
     }
 }
 
-impl<Pk: crate::FromStrKey, Ctx: ScriptContext> crate::expression::FromTree for Terminal<Pk, Ctx> {
+impl<Pk: FromStrKey, Ctx: ScriptContext> crate::expression::FromTree for Terminal<Pk, Ctx> {
     fn from_tree(top: &expression::Tree) -> Result<Terminal<Pk, Ctx>, Error> {
         let (frag_name, frag_wrap) = super::split_expression_name(top.name)?;
         let unwrapped = match (frag_name, top.args.len()) {

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -702,7 +702,7 @@ mod tests {
     use sync::Arc;
 
     use super::{Miniscript, ScriptContext, Segwitv0, Tap};
-    use crate::miniscript::types::{self, ExtData, Property, Type};
+    use crate::miniscript::types::{self, ExtData, Type};
     use crate::miniscript::Terminal;
     use crate::policy::Liftable;
     use crate::prelude::*;
@@ -890,7 +890,7 @@ mod tests {
 
         let pk_node = Terminal::Check(Arc::new(Miniscript {
             node: Terminal::PkK(String::from("")),
-            ty: Type::from_pk_k::<Segwitv0>(),
+            ty: Type::pk_k(),
             ext: types::extra_props::ExtData::pk_k::<Segwitv0>(),
             phantom: PhantomData,
         }));
@@ -899,7 +899,7 @@ mod tests {
 
         let pkh_node = Terminal::Check(Arc::new(Miniscript {
             node: Terminal::PkH(String::from("")),
-            ty: Type::from_pk_h::<Segwitv0>(),
+            ty: Type::pk_h(),
             ext: types::extra_props::ExtData::pk_h::<Segwitv0>(),
             phantom: PhantomData,
         }));
@@ -920,7 +920,7 @@ mod tests {
 
         let pkk_node = Terminal::Check(Arc::new(Miniscript {
             node: Terminal::PkK(pk),
-            ty: Type::from_pk_k::<Segwitv0>(),
+            ty: Type::pk_k(),
             ext: types::extra_props::ExtData::pk_k::<Segwitv0>(),
             phantom: PhantomData,
         }));
@@ -935,11 +935,11 @@ mod tests {
         let pkh_ms: Segwitv0Script = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
                 node: Terminal::RawPkH(hash),
-                ty: Type::from_pk_h::<Segwitv0>(),
+                ty: Type::pk_h(),
                 ext: types::extra_props::ExtData::pk_h::<Segwitv0>(),
                 phantom: PhantomData,
             })),
-            ty: Type::cast_check(Type::from_pk_h::<Segwitv0>()).unwrap(),
+            ty: Type::cast_check(Type::pk_h()).unwrap(),
             ext: ExtData::cast_check(ExtData::pk_h::<Segwitv0>()),
             phantom: PhantomData,
         };

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -45,7 +45,8 @@ use crate::miniscript::decode::Terminal;
 use crate::miniscript::types::extra_props::ExtData;
 use crate::miniscript::types::Type;
 use crate::{
-    expression, plan, Error, ForEachKey, MiniscriptKey, ToPublicKey, TranslatePk, Translator,
+    expression, plan, Error, ForEachKey, FromStrKey, MiniscriptKey, ToPublicKey, TranslatePk,
+    Translator,
 };
 #[cfg(test)]
 mod ms_tests;
@@ -617,7 +618,7 @@ where
     Ok(ms)
 }
 
-impl<Pk: crate::FromStrKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
+impl<Pk: FromStrKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Attempt to parse an insane(scripts don't clear sanity checks)
     /// from string into a Miniscript representation.
     /// Use this to parse scripts with repeated pubkeys, timelock mixing, malleable
@@ -648,17 +649,13 @@ impl<Pk: crate::FromStrKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     }
 }
 
-impl<Pk: crate::FromStrKey, Ctx: ScriptContext> crate::expression::FromTree
-    for Arc<Miniscript<Pk, Ctx>>
-{
+impl<Pk: FromStrKey, Ctx: ScriptContext> crate::expression::FromTree for Arc<Miniscript<Pk, Ctx>> {
     fn from_tree(top: &expression::Tree) -> Result<Arc<Miniscript<Pk, Ctx>>, Error> {
         Ok(Arc::new(expression::FromTree::from_tree(top)?))
     }
 }
 
-impl<Pk: crate::FromStrKey, Ctx: ScriptContext> crate::expression::FromTree
-    for Miniscript<Pk, Ctx>
-{
+impl<Pk: FromStrKey, Ctx: ScriptContext> crate::expression::FromTree for Miniscript<Pk, Ctx> {
     /// Parse an expression tree into a Miniscript. As a general rule, this
     /// should not be called directly; rather go through the descriptor API.
     fn from_tree(top: &expression::Tree) -> Result<Miniscript<Pk, Ctx>, Error> {
@@ -667,7 +664,7 @@ impl<Pk: crate::FromStrKey, Ctx: ScriptContext> crate::expression::FromTree
     }
 }
 
-impl<Pk: crate::FromStrKey, Ctx: ScriptContext> str::FromStr for Miniscript<Pk, Ctx> {
+impl<Pk: FromStrKey, Ctx: ScriptContext> str::FromStr for Miniscript<Pk, Ctx> {
     type Err = Error;
     /// Parse a Miniscript from string and perform sanity checks
     /// See [Miniscript::from_str_insane] to parse scripts from string that

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -891,7 +891,7 @@ mod tests {
         let pk_node = Terminal::Check(Arc::new(Miniscript {
             node: Terminal::PkK(String::from("")),
             ty: Type::from_pk_k::<Segwitv0>(),
-            ext: types::extra_props::ExtData::from_pk_k::<Segwitv0>(),
+            ext: types::extra_props::ExtData::pk_k::<Segwitv0>(),
             phantom: PhantomData,
         }));
         let pkk_ms: Miniscript<String, Segwitv0> = Miniscript::from_ast(pk_node).unwrap();
@@ -900,7 +900,7 @@ mod tests {
         let pkh_node = Terminal::Check(Arc::new(Miniscript {
             node: Terminal::PkH(String::from("")),
             ty: Type::from_pk_h::<Segwitv0>(),
-            ext: types::extra_props::ExtData::from_pk_h::<Segwitv0>(),
+            ext: types::extra_props::ExtData::pk_h::<Segwitv0>(),
             phantom: PhantomData,
         }));
         let pkh_ms: Miniscript<String, Segwitv0> = Miniscript::from_ast(pkh_node).unwrap();
@@ -921,7 +921,7 @@ mod tests {
         let pkk_node = Terminal::Check(Arc::new(Miniscript {
             node: Terminal::PkK(pk),
             ty: Type::from_pk_k::<Segwitv0>(),
-            ext: types::extra_props::ExtData::from_pk_k::<Segwitv0>(),
+            ext: types::extra_props::ExtData::pk_k::<Segwitv0>(),
             phantom: PhantomData,
         }));
         let pkk_ms: Segwitv0Script = Miniscript::from_ast(pkk_node).unwrap();
@@ -936,11 +936,11 @@ mod tests {
             node: Terminal::Check(Arc::new(Miniscript {
                 node: Terminal::RawPkH(hash),
                 ty: Type::from_pk_h::<Segwitv0>(),
-                ext: types::extra_props::ExtData::from_pk_h::<Segwitv0>(),
+                ext: types::extra_props::ExtData::pk_h::<Segwitv0>(),
                 phantom: PhantomData,
             })),
             ty: Type::cast_check(Type::from_pk_h::<Segwitv0>()).unwrap(),
-            ext: ExtData::cast_check(ExtData::from_pk_h::<Segwitv0>()).unwrap(),
+            ext: ExtData::cast_check(ExtData::pk_h::<Segwitv0>()).unwrap(),
             phantom: PhantomData,
         };
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -940,7 +940,7 @@ mod tests {
                 phantom: PhantomData,
             })),
             ty: Type::cast_check(Type::from_pk_h::<Segwitv0>()).unwrap(),
-            ext: ExtData::cast_check(ExtData::pk_h::<Segwitv0>()).unwrap(),
+            ext: ExtData::cast_check(ExtData::pk_h::<Segwitv0>()),
             phantom: PhantomData,
         };
 

--- a/src/miniscript/types/correctness.rs
+++ b/src/miniscript/types/correctness.rs
@@ -469,11 +469,11 @@ impl Correctness {
     // Cannot be constfn because it takes a closure.
     pub fn threshold<S>(_k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
     where
-        S: FnMut(usize) -> Result<Self, ErrorKind>,
+        S: FnMut(usize) -> Self,
     {
         let mut num_args = 0;
         for i in 0..n {
-            let subtype = sub_ck(i)?;
+            let subtype = sub_ck(i);
             num_args += match subtype.input {
                 Input::Zero => 0,
                 Input::One | Input::OneNonZero => 1,

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -387,8 +387,8 @@ impl ExtData {
     }
 
     /// Extra properties for the `a:` fragment.
-    pub const fn cast_alt(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub const fn cast_alt(self) -> Self {
+        ExtData {
             pk_cost: self.pk_cost + 2,
             has_free_verify: false,
             ops: OpLimits::new(2 + self.ops.count, self.ops.sat, self.ops.nsat),
@@ -399,12 +399,12 @@ impl ExtData {
             timelock_info: self.timelock_info,
             exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
             exec_stack_elem_count_dissat: self.exec_stack_elem_count_dissat,
-        })
+        }
     }
 
     /// Extra properties for the `s:` fragment.
-    pub const fn cast_swap(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub const fn cast_swap(self) -> Self {
+        ExtData {
             pk_cost: self.pk_cost + 1,
             has_free_verify: self.has_free_verify,
             ops: OpLimits::new(1 + self.ops.count, self.ops.sat, self.ops.nsat),
@@ -415,12 +415,12 @@ impl ExtData {
             timelock_info: self.timelock_info,
             exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
             exec_stack_elem_count_dissat: self.exec_stack_elem_count_dissat,
-        })
+        }
     }
 
     /// Extra properties for the `c:` fragment.
-    pub const fn cast_check(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub const fn cast_check(self) -> Self {
+        ExtData {
             pk_cost: self.pk_cost + 1,
             has_free_verify: true,
             ops: OpLimits::new(1 + self.ops.count, self.ops.sat, self.ops.nsat),
@@ -431,12 +431,12 @@ impl ExtData {
             timelock_info: self.timelock_info,
             exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
             exec_stack_elem_count_dissat: self.exec_stack_elem_count_dissat,
-        })
+        }
     }
 
     /// Extra properties for the `d:` fragment.
-    pub fn cast_dupif(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub fn cast_dupif(self) -> Self {
+        ExtData {
             pk_cost: self.pk_cost + 3,
             has_free_verify: false,
             ops: OpLimits::new(3 + self.ops.count, self.ops.sat, Some(0)),
@@ -450,13 +450,13 @@ impl ExtData {
             // Even all V types push something onto the stack and then remove them
             exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
             exec_stack_elem_count_dissat: Some(1),
-        })
+        }
     }
 
     /// Extra properties for the `v:` fragment.
-    pub fn cast_verify(self) -> Result<Self, ErrorKind> {
+    pub fn cast_verify(self) -> Self {
         let verify_cost = usize::from(!self.has_free_verify);
-        Ok(ExtData {
+        ExtData {
             pk_cost: self.pk_cost + usize::from(!self.has_free_verify),
             has_free_verify: false,
             ops: OpLimits::new(verify_cost + self.ops.count, self.ops.sat, None),
@@ -467,12 +467,12 @@ impl ExtData {
             timelock_info: self.timelock_info,
             exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
             exec_stack_elem_count_dissat: None,
-        })
+        }
     }
 
     /// Extra properties for the `j:` fragment.
-    pub const fn cast_nonzero(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub const fn cast_nonzero(self) -> Self {
+        ExtData {
             pk_cost: self.pk_cost + 4,
             has_free_verify: false,
             ops: OpLimits::new(4 + self.ops.count, self.ops.sat, Some(0)),
@@ -483,12 +483,12 @@ impl ExtData {
             timelock_info: self.timelock_info,
             exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
             exec_stack_elem_count_dissat: Some(1),
-        })
+        }
     }
 
     /// Extra properties for the `n:` fragment.
-    pub const fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub const fn cast_zeronotequal(self) -> Self {
+        ExtData {
             pk_cost: self.pk_cost + 1,
             has_free_verify: false,
             ops: OpLimits::new(1 + self.ops.count, self.ops.sat, self.ops.nsat),
@@ -500,23 +500,23 @@ impl ExtData {
             // Technically max(1, self.exec_stack_elem_count_sat), same rationale as cast_dupif
             exec_stack_elem_count_sat: self.exec_stack_elem_count_sat,
             exec_stack_elem_count_dissat: self.exec_stack_elem_count_dissat,
-        })
+        }
     }
 
     /// Cast by changing `[X]` to `AndV([X], True)`
-    pub fn cast_true(self) -> Result<Self, ErrorKind> { Self::and_v(self, Self::TRUE) }
+    pub fn cast_true(self) -> Self { Self::and_v(self, Self::TRUE) }
 
     /// Cast by changing `[X]` to `or_i([X], 0)`. Default implementation
     /// simply passes through to `cast_or_i_false`
-    pub fn cast_unlikely(self) -> Result<Self, ErrorKind> { Self::or_i(self, Self::FALSE) }
+    pub fn cast_unlikely(self) -> Self { Self::or_i(self, Self::FALSE) }
 
     /// Cast by changing `[X]` to `or_i(0, [X])`. Default implementation
     /// simply passes through to `cast_or_i_false`
-    pub fn cast_likely(self) -> Result<Self, ErrorKind> { Self::or_i(Self::FALSE, self) }
+    pub fn cast_likely(self) -> Self { Self::or_i(Self::FALSE, self) }
 
     /// Extra properties for the `and_b` fragment.
-    pub fn and_b(l: Self, r: Self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub fn and_b(l: Self, r: Self) -> Self {
+        ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 1,
             has_free_verify: false,
             ops: OpLimits::new(
@@ -547,12 +547,12 @@ impl ExtData {
                 l.exec_stack_elem_count_dissat,
                 r.exec_stack_elem_count_dissat.map(|x| x + 1),
             ),
-        })
+        }
     }
 
     /// Extra properties for the `and_v` fragment.
-    pub fn and_v(l: Self, r: Self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub fn and_v(l: Self, r: Self) -> Self {
+        ExtData {
             pk_cost: l.pk_cost + r.pk_cost,
             has_free_verify: r.has_free_verify,
             ops: OpLimits::new(l.ops.count + r.ops.count, opt_add(l.ops.sat, r.ops.sat), None),
@@ -571,12 +571,12 @@ impl ExtData {
                 r.exec_stack_elem_count_sat,
             ),
             exec_stack_elem_count_dissat: None,
-        })
+        }
     }
 
     /// Extra properties for the `or_b` fragment.
-    pub fn or_b(l: Self, r: Self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub fn or_b(l: Self, r: Self) -> Self {
+        ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 1,
             has_free_verify: false,
             ops: OpLimits::new(
@@ -611,12 +611,12 @@ impl ExtData {
                 l.exec_stack_elem_count_dissat,
                 r.exec_stack_elem_count_dissat.map(|x| x + 1),
             ),
-        })
+        }
     }
 
     /// Extra properties for the `or_d` fragment.
-    pub fn or_d(l: Self, r: Self) -> Result<Self, ErrorKind> {
-        let res = ExtData {
+    pub fn or_d(l: Self, r: Self) -> Self {
+        ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 3,
             has_free_verify: false,
             ops: OpLimits::new(
@@ -649,13 +649,12 @@ impl ExtData {
                 l.exec_stack_elem_count_dissat,
                 r.exec_stack_elem_count_dissat.map(|x| x + 1),
             ),
-        };
-        Ok(res)
+        }
     }
 
     /// Extra properties for the `or_c` fragment.
-    pub fn or_c(l: Self, r: Self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub fn or_c(l: Self, r: Self) -> Self {
+        ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 2,
             has_free_verify: false,
             ops: OpLimits::new(
@@ -681,12 +680,12 @@ impl ExtData {
                 opt_max(r.exec_stack_elem_count_sat, l.exec_stack_elem_count_dissat),
             ),
             exec_stack_elem_count_dissat: None,
-        })
+        }
     }
 
     /// Extra properties for the `or_i` fragment.
-    pub fn or_i(l: Self, r: Self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub fn or_i(l: Self, r: Self) -> Self {
+        ExtData {
             pk_cost: l.pk_cost + r.pk_cost + 3,
             has_free_verify: false,
             ops: OpLimits::new(
@@ -728,12 +727,12 @@ impl ExtData {
                 l.exec_stack_elem_count_dissat,
                 r.exec_stack_elem_count_dissat,
             ),
-        })
+        }
     }
 
     /// Extra properties for the `andor` fragment.
-    pub fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
-        Ok(ExtData {
+    pub fn and_or(a: Self, b: Self, c: Self) -> Self {
+        ExtData {
             pk_cost: a.pk_cost + b.pk_cost + c.pk_cost + 3,
             has_free_verify: false,
             ops: OpLimits::new(
@@ -771,13 +770,13 @@ impl ExtData {
                 a.exec_stack_elem_count_dissat,
                 c.exec_stack_elem_count_dissat,
             ),
-        })
+        }
     }
 
     /// Extra properties for the `thresh` fragment.
-    pub fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
+    pub fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Self
     where
-        S: FnMut(usize) -> Result<Self, ErrorKind>,
+        S: FnMut(usize) -> Self,
     {
         let mut pk_cost = 1 + script_num_size(k); //Equal and k
         let mut ops_count = 0;
@@ -793,7 +792,7 @@ impl ExtData {
         let mut exec_stack_elem_count_dissat = Some(0);
 
         for i in 0..n {
-            let sub = sub_ck(i)?;
+            let sub = sub_ck(i);
 
             pk_cost += sub.pk_cost;
             ops_count += sub.ops.count;
@@ -875,7 +874,7 @@ impl ExtData {
                 }
             });
 
-        Ok(ExtData {
+        ExtData {
             pk_cost: pk_cost + n - 1, //all pk cost + (n-1)*ADD
             has_free_verify: true,
             ops: OpLimits::new(
@@ -890,7 +889,7 @@ impl ExtData {
             timelock_info: TimelockInfo::combine_threshold(k, timelocks),
             exec_stack_elem_count_sat,
             exec_stack_elem_count_dissat,
-        })
+        }
     }
 
     /// Compute the type of a fragment assuming all the children of
@@ -900,15 +899,11 @@ impl ExtData {
         Ctx: ScriptContext,
         Pk: MiniscriptKey,
     {
-        let wrap_err = |result: Result<Self, ErrorKind>| {
-            result.map_err(|kind| Error { fragment_string: fragment.to_string(), error: kind })
-        };
-
         let ret = match *fragment {
-            Terminal::True => Ok(Self::TRUE),
-            Terminal::False => Ok(Self::FALSE),
-            Terminal::PkK(..) => Ok(Self::pk_k::<Ctx>()),
-            Terminal::PkH(..) | Terminal::RawPkH(..) => Ok(Self::pk_h::<Ctx>()),
+            Terminal::True => Self::TRUE,
+            Terminal::False => Self::FALSE,
+            Terminal::PkK(..) => Self::pk_k::<Ctx>(),
+            Terminal::PkH(..) | Terminal::RawPkH(..) => Self::pk_h::<Ctx>(),
             Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
@@ -923,8 +918,8 @@ impl ExtData {
                     });
                 }
                 match *fragment {
-                    Terminal::Multi(..) => Ok(Self::multi(k, pks.len())),
-                    Terminal::MultiA(..) => Ok(Self::multi_a(k, pks.len())),
+                    Terminal::Multi(..) => Self::multi(k, pks.len()),
+                    Terminal::MultiA(..) => Self::multi_a(k, pks.len()),
                     _ => unreachable!(),
                 }
             }
@@ -938,7 +933,7 @@ impl ExtData {
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::after(t.into()))
+                Self::after(t.into())
             }
             Terminal::Older(t) => {
                 if t == Sequence::ZERO || !t.is_relative_lock_time() {
@@ -947,54 +942,54 @@ impl ExtData {
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::older(t))
+                Self::older(t)
             }
-            Terminal::Sha256(..) => Ok(Self::sha256()),
-            Terminal::Hash256(..) => Ok(Self::hash256()),
-            Terminal::Ripemd160(..) => Ok(Self::ripemd160()),
-            Terminal::Hash160(..) => Ok(Self::hash160()),
-            Terminal::Alt(ref sub) => wrap_err(Self::cast_alt(sub.ext)),
-            Terminal::Swap(ref sub) => wrap_err(Self::cast_swap(sub.ext)),
-            Terminal::Check(ref sub) => wrap_err(Self::cast_check(sub.ext)),
-            Terminal::DupIf(ref sub) => wrap_err(Self::cast_dupif(sub.ext)),
-            Terminal::Verify(ref sub) => wrap_err(Self::cast_verify(sub.ext)),
-            Terminal::NonZero(ref sub) => wrap_err(Self::cast_nonzero(sub.ext)),
-            Terminal::ZeroNotEqual(ref sub) => wrap_err(Self::cast_zeronotequal(sub.ext)),
+            Terminal::Sha256(..) => Self::sha256(),
+            Terminal::Hash256(..) => Self::hash256(),
+            Terminal::Ripemd160(..) => Self::ripemd160(),
+            Terminal::Hash160(..) => Self::hash160(),
+            Terminal::Alt(ref sub) => Self::cast_alt(sub.ext),
+            Terminal::Swap(ref sub) => Self::cast_swap(sub.ext),
+            Terminal::Check(ref sub) => Self::cast_check(sub.ext),
+            Terminal::DupIf(ref sub) => Self::cast_dupif(sub.ext),
+            Terminal::Verify(ref sub) => Self::cast_verify(sub.ext),
+            Terminal::NonZero(ref sub) => Self::cast_nonzero(sub.ext),
+            Terminal::ZeroNotEqual(ref sub) => Self::cast_zeronotequal(sub.ext),
             Terminal::AndB(ref l, ref r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
-                wrap_err(Self::and_b(ltype, rtype))
+                Self::and_b(ltype, rtype)
             }
             Terminal::AndV(ref l, ref r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
-                wrap_err(Self::and_v(ltype, rtype))
+                Self::and_v(ltype, rtype)
             }
             Terminal::OrB(ref l, ref r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
-                wrap_err(Self::or_b(ltype, rtype))
+                Self::or_b(ltype, rtype)
             }
             Terminal::OrD(ref l, ref r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
-                wrap_err(Self::or_d(ltype, rtype))
+                Self::or_d(ltype, rtype)
             }
             Terminal::OrC(ref l, ref r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
-                wrap_err(Self::or_c(ltype, rtype))
+                Self::or_c(ltype, rtype)
             }
             Terminal::OrI(ref l, ref r) => {
                 let ltype = l.ext;
                 let rtype = r.ext;
-                wrap_err(Self::or_i(ltype, rtype))
+                Self::or_i(ltype, rtype)
             }
             Terminal::AndOr(ref a, ref b, ref c) => {
                 let atype = a.ext;
                 let btype = b.ext;
                 let ctype = c.ext;
-                wrap_err(Self::and_or(atype, btype, ctype))
+                Self::and_or(atype, btype, ctype)
             }
             Terminal::Thresh(k, ref subs) => {
                 if k == 0 {
@@ -1010,15 +1005,11 @@ impl ExtData {
                     });
                 }
 
-                let res = Self::threshold(k, subs.len(), |n| Ok(subs[n].ext));
-
-                res.map_err(|kind| Error { fragment_string: fragment.to_string(), error: kind })
+                Self::threshold(k, subs.len(), |n| subs[n].ext)
             }
         };
-        if let Ok(ref ret) = ret {
-            ret.sanity_checks()
-        }
-        ret
+        ret.sanity_checks();
+        Ok(ret)
     }
 }
 

--- a/src/miniscript/types/malleability.rs
+++ b/src/miniscript/types/malleability.rs
@@ -75,7 +75,7 @@ impl Malleability {
     /// This checks whether the argument `other` has attributes which are present
     /// in the given `Type`. This returns `true` on same arguments
     /// `a.is_subtype(a)` is `true`.
-    pub fn is_subtype(&self, other: Self) -> bool {
+    pub const fn is_subtype(&self, other: Self) -> bool {
         self.dissat.is_subtype(other.dissat)
             && self.safe >= other.safe
             && self.non_malleable >= other.non_malleable

--- a/src/miniscript/types/malleability.rs
+++ b/src/miniscript/types/malleability.rs
@@ -2,8 +2,6 @@
 
 //! Malleability-related Type properties
 
-use super::ErrorKind;
-
 /// Whether the fragment has a dissatisfaction, and if so, whether
 /// it is unique. Affects both correctness and malleability-freeness,
 /// since we assume 3rd parties are able to produce dissatisfactions
@@ -280,20 +278,20 @@ impl Malleability {
 
     /// Constructor for the malleabilitiy properties of the `thresh` fragment.
     // Cannot be constfn because it takes a closure.
-    pub fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
+    pub fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Self
     where
-        S: FnMut(usize) -> Result<Self, ErrorKind>,
+        S: FnMut(usize) -> Self,
     {
         let mut safe_count = 0;
         let mut all_are_dissat_unique = true;
         let mut all_are_non_malleable = true;
         for i in 0..n {
-            let subtype = sub_ck(i)?;
+            let subtype = sub_ck(i);
             safe_count += usize::from(subtype.safe);
             all_are_dissat_unique &= subtype.dissat == Dissat::Unique;
             all_are_non_malleable &= subtype.non_malleable;
         }
-        Ok(Malleability {
+        Malleability {
             dissat: if all_are_dissat_unique && safe_count == n {
                 Dissat::Unique
             } else {
@@ -301,6 +299,6 @@ impl Malleability {
             },
             safe: safe_count > n - k,
             non_malleable: all_are_non_malleable && safe_count >= n - k && all_are_dissat_unique,
-        })
+        }
     }
 }

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -466,11 +466,11 @@ impl Type {
     // Cannot be a constfn because it takes a closure.
     pub fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
     where
-        S: FnMut(usize) -> Result<Self, ErrorKind>,
+        S: FnMut(usize) -> Self,
     {
         Ok(Type {
-            corr: Correctness::threshold(k, n, |n| Ok(sub_ck(n)?.corr))?,
-            mall: Malleability::threshold(k, n, |n| Ok(sub_ck(n)?.mall))?,
+            corr: Correctness::threshold(k, n, |n| sub_ck(n).corr)?,
+            mall: Malleability::threshold(k, n, |n| sub_ck(n).mall),
         })
     }
 }
@@ -593,7 +593,7 @@ impl Type {
                     });
                 }
 
-                let res = Self::threshold(k, subs.len(), |n| Ok(subs[n].ty));
+                let res = Self::threshold(k, subs.len(), |n| subs[n].ty);
 
                 res.map_err(|kind| Error { fragment_string: fragment.to_string(), error: kind })
             }

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -362,163 +362,173 @@ impl Property for Type {
         debug_assert!(self.mall.non_malleable || self.corr.input != Input::Zero);
     }
 
-    fn from_true() -> Self { Type { corr: Property::from_true(), mall: Property::from_true() } }
+    fn from_true() -> Self { Type { corr: Correctness::TRUE, mall: Malleability::TRUE } }
 
-    fn from_false() -> Self { Type { corr: Property::from_false(), mall: Property::from_false() } }
+    fn from_false() -> Self { Type { corr: Correctness::FALSE, mall: Malleability::FALSE } }
 
     fn from_pk_k<Ctx: ScriptContext>() -> Self {
-        Type { corr: Property::from_pk_k::<Ctx>(), mall: Property::from_pk_k::<Ctx>() }
+        Type { corr: Correctness::pk_k(), mall: Property::from_pk_k::<Ctx>() }
     }
 
     fn from_pk_h<Ctx: ScriptContext>() -> Self {
-        Type { corr: Property::from_pk_h::<Ctx>(), mall: Property::from_pk_h::<Ctx>() }
+        Type { corr: Correctness::pk_h(), mall: Property::from_pk_h::<Ctx>() }
     }
 
     fn from_multi(k: usize, n: usize) -> Self {
-        Type { corr: Property::from_multi(k, n), mall: Property::from_multi(k, n) }
+        Type { corr: Correctness::multi(), mall: Property::from_multi(k, n) }
     }
 
     fn from_multi_a(k: usize, n: usize) -> Self {
-        Type { corr: Property::from_multi_a(k, n), mall: Property::from_multi_a(k, n) }
+        Type { corr: Correctness::multi_a(), mall: Property::from_multi_a(k, n) }
     }
 
-    fn from_hash() -> Self { Type { corr: Property::from_hash(), mall: Property::from_hash() } }
+    fn from_hash() -> Self { Type { corr: Correctness::hash(), mall: Property::from_hash() } }
 
-    fn from_sha256() -> Self {
-        Type { corr: Property::from_sha256(), mall: Property::from_sha256() }
-    }
+    fn from_sha256() -> Self { Type { corr: Correctness::hash(), mall: Property::from_sha256() } }
 
-    fn from_hash256() -> Self {
-        Type { corr: Property::from_hash256(), mall: Property::from_hash256() }
-    }
+    fn from_hash256() -> Self { Type { corr: Correctness::hash(), mall: Property::from_hash256() } }
 
     fn from_ripemd160() -> Self {
-        Type { corr: Property::from_ripemd160(), mall: Property::from_ripemd160() }
+        Type { corr: Correctness::hash(), mall: Property::from_ripemd160() }
     }
 
-    fn from_hash160() -> Self {
-        Type { corr: Property::from_hash160(), mall: Property::from_hash160() }
-    }
+    fn from_hash160() -> Self { Type { corr: Correctness::hash(), mall: Property::from_hash160() } }
 
     fn from_time(t: u32) -> Self {
-        Type { corr: Property::from_time(t), mall: Property::from_time(t) }
+        Type { corr: Correctness::time(), mall: Property::from_time(t) }
     }
 
     fn from_after(t: absolute::LockTime) -> Self {
-        Type { corr: Property::from_after(t), mall: Property::from_after(t) }
+        Type { corr: Correctness::time(), mall: Property::from_after(t) }
     }
 
     fn from_older(t: Sequence) -> Self {
-        Type { corr: Property::from_older(t), mall: Property::from_older(t) }
+        Type { corr: Correctness::time(), mall: Property::from_older(t) }
     }
 
     fn cast_alt(self) -> Result<Self, ErrorKind> {
-        Ok(Type { corr: Property::cast_alt(self.corr)?, mall: Property::cast_alt(self.mall)? })
+        Ok(Type { corr: Correctness::cast_alt(self.corr)?, mall: Property::cast_alt(self.mall)? })
     }
 
     fn cast_swap(self) -> Result<Self, ErrorKind> {
-        Ok(Type { corr: Property::cast_swap(self.corr)?, mall: Property::cast_swap(self.mall)? })
+        Ok(
+            Type {
+                corr: Correctness::cast_swap(self.corr)?,
+                mall: Property::cast_swap(self.mall)?,
+            },
+        )
     }
 
     fn cast_check(self) -> Result<Self, ErrorKind> {
-        Ok(Type { corr: Property::cast_check(self.corr)?, mall: Property::cast_check(self.mall)? })
+        Ok(Type {
+            corr: Correctness::cast_check(self.corr)?,
+            mall: Property::cast_check(self.mall)?,
+        })
     }
 
     fn cast_dupif(self) -> Result<Self, ErrorKind> {
-        Ok(Type { corr: Property::cast_dupif(self.corr)?, mall: Property::cast_dupif(self.mall)? })
+        Ok(Type {
+            corr: Correctness::cast_dupif(self.corr)?,
+            mall: Property::cast_dupif(self.mall)?,
+        })
     }
 
     fn cast_verify(self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::cast_verify(self.corr)?,
+            corr: Correctness::cast_verify(self.corr)?,
             mall: Property::cast_verify(self.mall)?,
         })
     }
 
     fn cast_nonzero(self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::cast_nonzero(self.corr)?,
+            corr: Correctness::cast_nonzero(self.corr)?,
             mall: Property::cast_nonzero(self.mall)?,
         })
     }
 
     fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::cast_zeronotequal(self.corr)?,
+            corr: Correctness::cast_zeronotequal(self.corr)?,
             mall: Property::cast_zeronotequal(self.mall)?,
         })
     }
 
-    fn cast_true(self) -> Result<Self, ErrorKind> {
-        Ok(Type { corr: Property::cast_true(self.corr)?, mall: Property::cast_true(self.mall)? })
-    }
-
     fn cast_or_i_false(self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::cast_or_i_false(self.corr)?,
+            corr: Correctness::cast_or_i_false(self.corr)?,
             mall: Property::cast_or_i_false(self.mall)?,
         })
     }
 
+    fn cast_true(self) -> Result<Self, ErrorKind> {
+        Ok(
+            Type {
+                corr: Correctness::cast_true(self.corr)?,
+                mall: Property::cast_true(self.mall)?,
+            },
+        )
+    }
+
     fn cast_unlikely(self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::cast_unlikely(self.corr)?,
+            corr: Correctness::cast_or_i_false(self.corr)?,
             mall: Property::cast_unlikely(self.mall)?,
         })
     }
 
     fn cast_likely(self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::cast_likely(self.corr)?,
+            corr: Correctness::cast_or_i_false(self.corr)?,
             mall: Property::cast_likely(self.mall)?,
         })
     }
 
     fn and_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::and_b(left.corr, right.corr)?,
+            corr: Correctness::and_b(left.corr, right.corr)?,
             mall: Property::and_b(left.mall, right.mall)?,
         })
     }
 
     fn and_v(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::and_v(left.corr, right.corr)?,
+            corr: Correctness::and_v(left.corr, right.corr)?,
             mall: Property::and_v(left.mall, right.mall)?,
         })
     }
 
     fn or_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::or_b(left.corr, right.corr)?,
+            corr: Correctness::or_b(left.corr, right.corr)?,
             mall: Property::or_b(left.mall, right.mall)?,
         })
     }
 
     fn or_d(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::or_d(left.corr, right.corr)?,
+            corr: Correctness::or_d(left.corr, right.corr)?,
             mall: Property::or_d(left.mall, right.mall)?,
         })
     }
 
     fn or_c(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::or_c(left.corr, right.corr)?,
+            corr: Correctness::or_c(left.corr, right.corr)?,
             mall: Property::or_c(left.mall, right.mall)?,
         })
     }
 
     fn or_i(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::or_i(left.corr, right.corr)?,
+            corr: Correctness::or_i(left.corr, right.corr)?,
             mall: Property::or_i(left.mall, right.mall)?,
         })
     }
 
     fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Property::and_or(a.corr, b.corr, c.corr)?,
+            corr: Correctness::and_or(a.corr, b.corr, c.corr)?,
             mall: Property::and_or(a.mall, b.mall, c.mall)?,
         })
     }
@@ -528,7 +538,7 @@ impl Property for Type {
         S: FnMut(usize) -> Result<Self, ErrorKind>,
     {
         Ok(Type {
-            corr: Property::threshold(k, n, |n| Ok(sub_ck(n)?.corr))?,
+            corr: Correctness::threshold(k, n, |n| Ok(sub_ck(n)?.corr))?,
             mall: Property::threshold(k, n, |n| Ok(sub_ck(n)?.mall))?,
         })
     }

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -367,169 +367,164 @@ impl Property for Type {
     fn from_false() -> Self { Type { corr: Correctness::FALSE, mall: Malleability::FALSE } }
 
     fn from_pk_k<Ctx: ScriptContext>() -> Self {
-        Type { corr: Correctness::pk_k(), mall: Property::from_pk_k::<Ctx>() }
+        Type { corr: Correctness::pk_k(), mall: Malleability::pk_k() }
     }
 
     fn from_pk_h<Ctx: ScriptContext>() -> Self {
-        Type { corr: Correctness::pk_h(), mall: Property::from_pk_h::<Ctx>() }
+        Type { corr: Correctness::pk_h(), mall: Malleability::pk_h() }
     }
 
-    fn from_multi(k: usize, n: usize) -> Self {
-        Type { corr: Correctness::multi(), mall: Property::from_multi(k, n) }
+    fn from_multi(_: usize, _: usize) -> Self {
+        Type { corr: Correctness::multi(), mall: Malleability::multi() }
     }
 
-    fn from_multi_a(k: usize, n: usize) -> Self {
-        Type { corr: Correctness::multi_a(), mall: Property::from_multi_a(k, n) }
+    fn from_multi_a(_: usize, _: usize) -> Self {
+        Type { corr: Correctness::multi_a(), mall: Malleability::multi_a() }
     }
 
-    fn from_hash() -> Self { Type { corr: Correctness::hash(), mall: Property::from_hash() } }
+    fn from_hash() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
 
-    fn from_sha256() -> Self { Type { corr: Correctness::hash(), mall: Property::from_sha256() } }
+    fn from_sha256() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
 
-    fn from_hash256() -> Self { Type { corr: Correctness::hash(), mall: Property::from_hash256() } }
+    fn from_hash256() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
 
-    fn from_ripemd160() -> Self {
-        Type { corr: Correctness::hash(), mall: Property::from_ripemd160() }
+    fn from_ripemd160() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
+
+    fn from_hash160() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
+
+    fn from_time(_: u32) -> Self { Type { corr: Correctness::time(), mall: Malleability::time() } }
+
+    fn from_after(_: absolute::LockTime) -> Self {
+        Type { corr: Correctness::time(), mall: Malleability::time() }
     }
 
-    fn from_hash160() -> Self { Type { corr: Correctness::hash(), mall: Property::from_hash160() } }
-
-    fn from_time(t: u32) -> Self {
-        Type { corr: Correctness::time(), mall: Property::from_time(t) }
-    }
-
-    fn from_after(t: absolute::LockTime) -> Self {
-        Type { corr: Correctness::time(), mall: Property::from_after(t) }
-    }
-
-    fn from_older(t: Sequence) -> Self {
-        Type { corr: Correctness::time(), mall: Property::from_older(t) }
+    fn from_older(_: Sequence) -> Self {
+        Type { corr: Correctness::time(), mall: Malleability::time() }
     }
 
     fn cast_alt(self) -> Result<Self, ErrorKind> {
-        Ok(Type { corr: Correctness::cast_alt(self.corr)?, mall: Property::cast_alt(self.mall)? })
+        Ok(Type {
+            corr: Correctness::cast_alt(self.corr)?,
+            mall: Malleability::cast_alt(self.mall),
+        })
     }
 
     fn cast_swap(self) -> Result<Self, ErrorKind> {
-        Ok(
-            Type {
-                corr: Correctness::cast_swap(self.corr)?,
-                mall: Property::cast_swap(self.mall)?,
-            },
-        )
+        Ok(Type {
+            corr: Correctness::cast_swap(self.corr)?,
+            mall: Malleability::cast_swap(self.mall),
+        })
     }
 
     fn cast_check(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_check(self.corr)?,
-            mall: Property::cast_check(self.mall)?,
+            mall: Malleability::cast_check(self.mall),
         })
     }
 
     fn cast_dupif(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_dupif(self.corr)?,
-            mall: Property::cast_dupif(self.mall)?,
+            mall: Malleability::cast_dupif(self.mall),
         })
     }
 
     fn cast_verify(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_verify(self.corr)?,
-            mall: Property::cast_verify(self.mall)?,
+            mall: Malleability::cast_verify(self.mall),
         })
     }
 
     fn cast_nonzero(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_nonzero(self.corr)?,
-            mall: Property::cast_nonzero(self.mall)?,
+            mall: Malleability::cast_nonzero(self.mall),
         })
     }
 
     fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_zeronotequal(self.corr)?,
-            mall: Property::cast_zeronotequal(self.mall)?,
+            mall: Malleability::cast_zeronotequal(self.mall),
         })
     }
 
     fn cast_or_i_false(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_or_i_false(self.corr)?,
-            mall: Property::cast_or_i_false(self.mall)?,
+            mall: Malleability::cast_or_i_false(self.mall),
         })
     }
 
     fn cast_true(self) -> Result<Self, ErrorKind> {
-        Ok(
-            Type {
-                corr: Correctness::cast_true(self.corr)?,
-                mall: Property::cast_true(self.mall)?,
-            },
-        )
+        Ok(Type {
+            corr: Correctness::cast_true(self.corr)?,
+            mall: Malleability::cast_true(self.mall),
+        })
     }
 
     fn cast_unlikely(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_or_i_false(self.corr)?,
-            mall: Property::cast_unlikely(self.mall)?,
+            mall: Malleability::cast_or_i_false(self.mall),
         })
     }
 
     fn cast_likely(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_or_i_false(self.corr)?,
-            mall: Property::cast_likely(self.mall)?,
+            mall: Malleability::cast_or_i_false(self.mall),
         })
     }
 
     fn and_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::and_b(left.corr, right.corr)?,
-            mall: Property::and_b(left.mall, right.mall)?,
+            mall: Malleability::and_b(left.mall, right.mall),
         })
     }
 
     fn and_v(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::and_v(left.corr, right.corr)?,
-            mall: Property::and_v(left.mall, right.mall)?,
+            mall: Malleability::and_v(left.mall, right.mall),
         })
     }
 
     fn or_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::or_b(left.corr, right.corr)?,
-            mall: Property::or_b(left.mall, right.mall)?,
+            mall: Malleability::or_b(left.mall, right.mall),
         })
     }
 
     fn or_d(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::or_d(left.corr, right.corr)?,
-            mall: Property::or_d(left.mall, right.mall)?,
+            mall: Malleability::or_d(left.mall, right.mall),
         })
     }
 
     fn or_c(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::or_c(left.corr, right.corr)?,
-            mall: Property::or_c(left.mall, right.mall)?,
+            mall: Malleability::or_c(left.mall, right.mall),
         })
     }
 
     fn or_i(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::or_i(left.corr, right.corr)?,
-            mall: Property::or_i(left.mall, right.mall)?,
+            mall: Malleability::or_i(left.mall, right.mall),
         })
     }
 
     fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::and_or(a.corr, b.corr, c.corr)?,
-            mall: Property::and_or(a.mall, b.mall, c.mall)?,
+            mall: Malleability::and_or(a.mall, b.mall, c.mall),
         })
     }
 
@@ -539,7 +534,7 @@ impl Property for Type {
     {
         Ok(Type {
             corr: Correctness::threshold(k, n, |n| Ok(sub_ck(n)?.corr))?,
-            mall: Property::threshold(k, n, |n| Ok(sub_ck(n)?.mall))?,
+            mall: Malleability::threshold(k, n, |n| Ok(sub_ck(n)?.mall))?,
         })
     }
 }

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -229,306 +229,175 @@ impl Type {
     pub fn is_subtype(&self, other: Self) -> bool {
         self.corr.is_subtype(other.corr) && self.mall.is_subtype(other.mall)
     }
-}
-/// Trait representing a type property, which defines how the property
-/// propagates from terminals to the root of a Miniscript
-pub trait Property: Sized {
-    /// Any extra sanity checks/assertions that should be applied after
-    /// typechecking
-    fn sanity_checks(&self) {
-        // no checks by default
-    }
 
-    /// Type property of the `True` fragment
-    fn from_true() -> Self;
-
-    /// Type property of the `False` fragment
-    fn from_false() -> Self;
-
-    /// Type property of the `PkK` fragment
-    fn from_pk_k<Ctx: ScriptContext>() -> Self;
-
-    /// Type property of the `PkH` fragment
-    fn from_pk_h<Ctx: ScriptContext>() -> Self;
-
-    /// Type property of a `Multi` fragment
-    fn from_multi(k: usize, n: usize) -> Self;
-
-    /// Type property of a `MultiA` fragment
-    fn from_multi_a(k: usize, n: usize) -> Self;
-
-    /// Type property of a hash fragment
-    fn from_hash() -> Self;
-
-    /// Type property of a `Sha256` hash. Default implementation simply
-    /// passes through to `from_hash`
-    fn from_sha256() -> Self { Self::from_hash() }
-
-    /// Type property of a `Hash256` hash. Default implementation simply
-    /// passes through to `from_hash`
-    fn from_hash256() -> Self { Self::from_hash() }
-
-    /// Type property of a `Ripemd160` hash. Default implementation simply
-    /// passes through to `from_hash`
-    fn from_ripemd160() -> Self { Self::from_hash() }
-
-    /// Type property of a `Hash160` hash. Default implementation simply
-    /// passes through to `from_hash`
-    fn from_hash160() -> Self { Self::from_hash() }
-
-    /// Type property of a timelock
-    fn from_time(t: u32) -> Self;
-
-    /// Type property of an absolute timelock. Default implementation simply
-    /// passes through to `from_time`
-    fn from_after(t: absolute::LockTime) -> Self { Self::from_time(t.to_consensus_u32()) }
-
-    /// Type property of a relative timelock. Default implementation simply
-    /// passes through to `from_time`
-    fn from_older(t: Sequence) -> Self { Self::from_time(t.to_consensus_u32()) }
-
-    /// Cast using the `Alt` wrapper
-    fn cast_alt(self) -> Result<Self, ErrorKind>;
-
-    /// Cast using the `Swap` wrapper
-    fn cast_swap(self) -> Result<Self, ErrorKind>;
-
-    /// Cast using the `Check` wrapper
-    fn cast_check(self) -> Result<Self, ErrorKind>;
-
-    /// Cast using the `DupIf` wrapper
-    fn cast_dupif(self) -> Result<Self, ErrorKind>;
-
-    /// Cast using the `Verify` wrapper
-    fn cast_verify(self) -> Result<Self, ErrorKind>;
-
-    /// Cast using the `NonZero` wrapper
-    fn cast_nonzero(self) -> Result<Self, ErrorKind>;
-
-    /// Cast using the `ZeroNotEqual` wrapper
-    fn cast_zeronotequal(self) -> Result<Self, ErrorKind>;
-
-    /// Cast by changing `[X]` to `AndV([X], True)`
-    fn cast_true(self) -> Result<Self, ErrorKind> { Self::and_v(self, Self::from_true()) }
-
-    /// Cast by changing `[X]` to `or_i([X], 0)` or `or_i(0, [X])`
-    fn cast_or_i_false(self) -> Result<Self, ErrorKind>;
-
-    /// Cast by changing `[X]` to `or_i([X], 0)`. Default implementation
-    /// simply passes through to `cast_or_i_false`
-    fn cast_unlikely(self) -> Result<Self, ErrorKind> { Self::or_i(self, Self::from_false()) }
-
-    /// Cast by changing `[X]` to `or_i(0, [X])`. Default implementation
-    /// simply passes through to `cast_or_i_false`
-    fn cast_likely(self) -> Result<Self, ErrorKind> { Self::or_i(Self::from_false(), self) }
-
-    /// Computes the type of an `AndB` fragment
-    fn and_b(left: Self, right: Self) -> Result<Self, ErrorKind>;
-
-    /// Computes the type of an `AndV` fragment
-    fn and_v(left: Self, right: Self) -> Result<Self, ErrorKind>;
-
-    /// Computes the type of an `AndN` fragment
-    fn and_n(left: Self, right: Self) -> Result<Self, ErrorKind> {
-        Self::and_or(left, right, Self::from_false())
-    }
-
-    /// Computes the type of an `OrB` fragment
-    fn or_b(left: Self, right: Self) -> Result<Self, ErrorKind>;
-
-    /// Computes the type of an `OrD` fragment
-    fn or_d(left: Self, right: Self) -> Result<Self, ErrorKind>;
-
-    /// Computes the type of an `OrC` fragment
-    fn or_c(left: Self, right: Self) -> Result<Self, ErrorKind>;
-
-    /// Computes the type of an `OrI` fragment
-    fn or_i(left: Self, right: Self) -> Result<Self, ErrorKind>;
-
-    /// Computes the type of an `AndOr` fragment
-    fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind>;
-
-    /// Computes the type of an `Thresh` fragment
-    fn threshold<S>(k: usize, n: usize, sub_ck: S) -> Result<Self, ErrorKind>
-    where
-        S: FnMut(usize) -> Result<Self, ErrorKind>;
-}
-
-impl Property for Type {
-    fn sanity_checks(&self) {
+    /// Confirm invariants of the type checker.
+    pub fn sanity_checks(&self) {
         debug_assert!(!self.corr.dissatisfiable || self.mall.dissat != Dissat::None);
         debug_assert!(self.mall.dissat == Dissat::None || self.corr.base != Base::V);
         debug_assert!(self.mall.safe || self.corr.base != Base::K);
         debug_assert!(self.mall.non_malleable || self.corr.input != Input::Zero);
     }
 
-    fn from_true() -> Self { Type { corr: Correctness::TRUE, mall: Malleability::TRUE } }
+    /// Constructor for the type of the `pk_k` fragment.
+    pub const fn pk_k() -> Self { Type { corr: Correctness::pk_k(), mall: Malleability::pk_k() } }
 
-    fn from_false() -> Self { Type { corr: Correctness::FALSE, mall: Malleability::FALSE } }
+    /// Constructor for the type of the `pk_h` fragment.
+    pub const fn pk_h() -> Self { Type { corr: Correctness::pk_h(), mall: Malleability::pk_h() } }
 
-    fn from_pk_k<Ctx: ScriptContext>() -> Self {
-        Type { corr: Correctness::pk_k(), mall: Malleability::pk_k() }
-    }
-
-    fn from_pk_h<Ctx: ScriptContext>() -> Self {
-        Type { corr: Correctness::pk_h(), mall: Malleability::pk_h() }
-    }
-
-    fn from_multi(_: usize, _: usize) -> Self {
+    /// Constructor for the type of the `multi` fragment.
+    pub const fn multi() -> Self {
         Type { corr: Correctness::multi(), mall: Malleability::multi() }
     }
 
-    fn from_multi_a(_: usize, _: usize) -> Self {
+    /// Constructor for the type of the `multi_a` fragment.
+    pub const fn multi_a() -> Self {
         Type { corr: Correctness::multi_a(), mall: Malleability::multi_a() }
     }
 
-    fn from_hash() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
+    /// Constructor for the type of all the hash fragments.
+    pub const fn hash() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
 
-    fn from_sha256() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
+    /// Constructor for the type of the `after` and `older` fragments.
+    pub const fn time() -> Self { Type { corr: Correctness::time(), mall: Malleability::time() } }
 
-    fn from_hash256() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
-
-    fn from_ripemd160() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
-
-    fn from_hash160() -> Self { Type { corr: Correctness::hash(), mall: Malleability::hash() } }
-
-    fn from_time(_: u32) -> Self { Type { corr: Correctness::time(), mall: Malleability::time() } }
-
-    fn from_after(_: absolute::LockTime) -> Self {
-        Type { corr: Correctness::time(), mall: Malleability::time() }
-    }
-
-    fn from_older(_: Sequence) -> Self {
-        Type { corr: Correctness::time(), mall: Malleability::time() }
-    }
-
-    fn cast_alt(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `a:` fragment.
+    pub fn cast_alt(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_alt(self.corr)?,
             mall: Malleability::cast_alt(self.mall),
         })
     }
 
-    fn cast_swap(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `s:` fragment.
+    pub fn cast_swap(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_swap(self.corr)?,
             mall: Malleability::cast_swap(self.mall),
         })
     }
 
-    fn cast_check(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `c:` fragment.
+    pub fn cast_check(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_check(self.corr)?,
             mall: Malleability::cast_check(self.mall),
         })
     }
 
-    fn cast_dupif(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `d:` fragment.
+    pub fn cast_dupif(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_dupif(self.corr)?,
             mall: Malleability::cast_dupif(self.mall),
         })
     }
 
-    fn cast_verify(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `v:` fragment.
+    pub fn cast_verify(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_verify(self.corr)?,
             mall: Malleability::cast_verify(self.mall),
         })
     }
 
-    fn cast_nonzero(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `j:` fragment.
+    pub fn cast_nonzero(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_nonzero(self.corr)?,
             mall: Malleability::cast_nonzero(self.mall),
         })
     }
 
-    fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `n:` fragment.
+    pub fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_zeronotequal(self.corr)?,
             mall: Malleability::cast_zeronotequal(self.mall),
         })
     }
 
-    fn cast_or_i_false(self) -> Result<Self, ErrorKind> {
-        Ok(Type {
-            corr: Correctness::cast_or_i_false(self.corr)?,
-            mall: Malleability::cast_or_i_false(self.mall),
-        })
-    }
-
-    fn cast_true(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `t:` fragment.
+    pub fn cast_true(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_true(self.corr)?,
             mall: Malleability::cast_true(self.mall),
         })
     }
 
-    fn cast_unlikely(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `u:` fragment.
+    pub fn cast_unlikely(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_or_i_false(self.corr)?,
             mall: Malleability::cast_or_i_false(self.mall),
         })
     }
 
-    fn cast_likely(self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `l:` fragment.
+    pub fn cast_likely(self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::cast_or_i_false(self.corr)?,
             mall: Malleability::cast_or_i_false(self.mall),
         })
     }
 
-    fn and_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `and_b` fragment.
+    pub fn and_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::and_b(left.corr, right.corr)?,
             mall: Malleability::and_b(left.mall, right.mall),
         })
     }
 
-    fn and_v(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `and_v` fragment.
+    pub fn and_v(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::and_v(left.corr, right.corr)?,
             mall: Malleability::and_v(left.mall, right.mall),
         })
     }
 
-    fn or_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `or_b` fragment.
+    pub fn or_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::or_b(left.corr, right.corr)?,
             mall: Malleability::or_b(left.mall, right.mall),
         })
     }
 
-    fn or_d(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `or_b` fragment.
+    pub fn or_d(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::or_d(left.corr, right.corr)?,
             mall: Malleability::or_d(left.mall, right.mall),
         })
     }
 
-    fn or_c(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `or_c` fragment.
+    pub fn or_c(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::or_c(left.corr, right.corr)?,
             mall: Malleability::or_c(left.mall, right.mall),
         })
     }
 
-    fn or_i(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `or_i` fragment.
+    pub fn or_i(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::or_i(left.corr, right.corr)?,
             mall: Malleability::or_i(left.mall, right.mall),
         })
     }
 
-    fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
+    /// Constructor for the type of the `and_or` fragment.
+    pub fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
             corr: Correctness::and_or(a.corr, b.corr, c.corr)?,
             mall: Malleability::and_or(a.mall, b.mall, c.mall),
         })
     }
 
-    fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
+    /// Constructor for the type of the `thresh` fragment.
+    pub fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
     where
         S: FnMut(usize) -> Result<Self, ErrorKind>,
     {
@@ -552,10 +421,10 @@ impl Type {
         };
 
         let ret = match *fragment {
-            Terminal::True => Ok(Self::from_true()),
-            Terminal::False => Ok(Self::from_false()),
-            Terminal::PkK(..) => Ok(Self::from_pk_k::<Ctx>()),
-            Terminal::PkH(..) | Terminal::RawPkH(..) => Ok(Self::from_pk_h::<Ctx>()),
+            Terminal::True => Ok(Self::TRUE),
+            Terminal::False => Ok(Self::FALSE),
+            Terminal::PkK(..) => Ok(Self::pk_k()),
+            Terminal::PkH(..) | Terminal::RawPkH(..) => Ok(Self::pk_h()),
             Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
                 if k == 0 {
                     return Err(Error {
@@ -570,8 +439,8 @@ impl Type {
                     });
                 }
                 match *fragment {
-                    Terminal::Multi(..) => Ok(Self::from_multi(k, pks.len())),
-                    Terminal::MultiA(..) => Ok(Self::from_multi_a(k, pks.len())),
+                    Terminal::Multi(..) => Ok(Self::multi()),
+                    Terminal::MultiA(..) => Ok(Self::multi_a()),
                     _ => unreachable!(),
                 }
             }
@@ -585,7 +454,7 @@ impl Type {
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_after(t.into()))
+                Ok(Self::time())
             }
             Terminal::Older(t) => {
                 if t == Sequence::ZERO || !t.is_relative_lock_time() {
@@ -594,12 +463,12 @@ impl Type {
                         error: ErrorKind::InvalidTime,
                     });
                 }
-                Ok(Self::from_older(t))
+                Ok(Self::time())
             }
-            Terminal::Sha256(..) => Ok(Self::from_sha256()),
-            Terminal::Hash256(..) => Ok(Self::from_hash256()),
-            Terminal::Ripemd160(..) => Ok(Self::from_ripemd160()),
-            Terminal::Hash160(..) => Ok(Self::from_hash160()),
+            Terminal::Sha256(..) => Ok(Self::hash()),
+            Terminal::Hash256(..) => Ok(Self::hash()),
+            Terminal::Ripemd160(..) => Ok(Self::hash()),
+            Terminal::Hash160(..) => Ok(Self::hash()),
             Terminal::Alt(ref sub) => wrap_err(Self::cast_alt(sub.ty)),
             Terminal::Swap(ref sub) => wrap_err(Self::cast_swap(sub.ty)),
             Terminal::Check(ref sub) => wrap_err(Self::cast_check(sub.ty)),

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -226,7 +226,7 @@ impl Type {
     /// This checks whether the argument `other` has attributes which are present
     /// in the given `Type`. This returns `true` on same arguments
     /// `a.is_subtype(a)` is `true`.
-    pub fn is_subtype(&self, other: Self) -> bool {
+    pub const fn is_subtype(&self, other: Self) -> bool {
         self.corr.is_subtype(other.corr) && self.mall.is_subtype(other.mall)
     }
 
@@ -261,142 +261,209 @@ impl Type {
     pub const fn time() -> Self { Type { corr: Correctness::time(), mall: Malleability::time() } }
 
     /// Constructor for the type of the `a:` fragment.
-    pub fn cast_alt(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_alt(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_alt(self.corr)?,
+            corr: match Correctness::cast_alt(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_alt(self.mall),
         })
     }
 
     /// Constructor for the type of the `s:` fragment.
-    pub fn cast_swap(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_swap(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_swap(self.corr)?,
+            corr: match Correctness::cast_swap(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_swap(self.mall),
         })
     }
 
     /// Constructor for the type of the `c:` fragment.
-    pub fn cast_check(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_check(self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Correctness::cast_check(self.corr)?,
+            corr: match Correctness::cast_check(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_check(self.mall),
         })
     }
 
     /// Constructor for the type of the `d:` fragment.
-    pub fn cast_dupif(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_dupif(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_dupif(self.corr)?,
+            corr: match Correctness::cast_dupif(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_dupif(self.mall),
         })
     }
 
     /// Constructor for the type of the `v:` fragment.
-    pub fn cast_verify(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_verify(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_verify(self.corr)?,
+            corr: match Correctness::cast_verify(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_verify(self.mall),
         })
     }
 
     /// Constructor for the type of the `j:` fragment.
-    pub fn cast_nonzero(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_nonzero(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_nonzero(self.corr)?,
+            corr: match Correctness::cast_nonzero(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_nonzero(self.mall),
         })
     }
 
     /// Constructor for the type of the `n:` fragment.
-    pub fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_zeronotequal(self.corr)?,
+            corr: match Correctness::cast_zeronotequal(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_zeronotequal(self.mall),
         })
     }
 
     /// Constructor for the type of the `t:` fragment.
-    pub fn cast_true(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_true(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_true(self.corr)?,
+            corr: match Correctness::cast_true(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_true(self.mall),
         })
     }
 
     /// Constructor for the type of the `u:` fragment.
-    pub fn cast_unlikely(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_unlikely(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_or_i_false(self.corr)?,
+            corr: match Correctness::cast_or_i_false(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_or_i_false(self.mall),
         })
     }
 
     /// Constructor for the type of the `l:` fragment.
-    pub fn cast_likely(self) -> Result<Self, ErrorKind> {
+    pub const fn cast_likely(self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::cast_or_i_false(self.corr)?,
+            corr: match Correctness::cast_or_i_false(self.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::cast_or_i_false(self.mall),
         })
     }
 
     /// Constructor for the type of the `and_b` fragment.
-    pub fn and_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    pub const fn and_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::and_b(left.corr, right.corr)?,
+            corr: match Correctness::and_b(left.corr, right.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::and_b(left.mall, right.mall),
         })
     }
 
     /// Constructor for the type of the `and_v` fragment.
-    pub fn and_v(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    pub const fn and_v(left: Self, right: Self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::and_v(left.corr, right.corr)?,
+            corr: match Correctness::and_v(left.corr, right.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::and_v(left.mall, right.mall),
         })
     }
 
     /// Constructor for the type of the `or_b` fragment.
-    pub fn or_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    pub const fn or_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::or_b(left.corr, right.corr)?,
+            corr: match Correctness::or_b(left.corr, right.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::or_b(left.mall, right.mall),
         })
     }
 
     /// Constructor for the type of the `or_b` fragment.
-    pub fn or_d(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    pub const fn or_d(left: Self, right: Self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::or_d(left.corr, right.corr)?,
+            corr: match Correctness::or_d(left.corr, right.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::or_d(left.mall, right.mall),
         })
     }
 
     /// Constructor for the type of the `or_c` fragment.
-    pub fn or_c(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    pub const fn or_c(left: Self, right: Self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::or_c(left.corr, right.corr)?,
+            corr: match Correctness::or_c(left.corr, right.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::or_c(left.mall, right.mall),
         })
     }
 
     /// Constructor for the type of the `or_i` fragment.
-    pub fn or_i(left: Self, right: Self) -> Result<Self, ErrorKind> {
+    pub const fn or_i(left: Self, right: Self) -> Result<Self, ErrorKind> {
         Ok(Type {
-            corr: Correctness::or_i(left.corr, right.corr)?,
+            corr: match Correctness::or_i(left.corr, right.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::or_i(left.mall, right.mall),
         })
     }
 
     /// Constructor for the type of the `and_or` fragment.
-    pub fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
+    pub const fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
+        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
-            corr: Correctness::and_or(a.corr, b.corr, c.corr)?,
+            corr: match Correctness::and_or(a.corr, b.corr, c.corr) {
+                Ok(x) => x,
+                Err(e) => return Err(e),
+            },
             mall: Malleability::and_or(a.mall, b.mall, c.mall),
         })
     }
 
     /// Constructor for the type of the `thresh` fragment.
+    // Cannot be a constfn because it takes a closure.
     pub fn threshold<S>(k: usize, n: usize, mut sub_ck: S) -> Result<Self, ErrorKind>
     where
         S: FnMut(usize) -> Result<Self, ErrorKind>,

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -200,145 +200,133 @@ impl CompilerExtData {
 
     fn time() -> Self { CompilerExtData { branch_prob: None, sat_cost: 0.0, dissat_cost: None } }
 
-    fn cast_alt(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
+    fn cast_alt(self) -> Self {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: self.sat_cost,
             dissat_cost: self.dissat_cost,
-        })
+        }
     }
 
-    fn cast_swap(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
+    fn cast_swap(self) -> Self {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: self.sat_cost,
             dissat_cost: self.dissat_cost,
-        })
+        }
     }
 
-    fn cast_check(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
+    fn cast_check(self) -> Self {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: self.sat_cost,
             dissat_cost: self.dissat_cost,
-        })
+        }
     }
 
-    fn cast_dupif(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
-            branch_prob: None,
-            sat_cost: 2.0 + self.sat_cost,
-            dissat_cost: Some(1.0),
-        })
+    fn cast_dupif(self) -> Self {
+        CompilerExtData { branch_prob: None, sat_cost: 2.0 + self.sat_cost, dissat_cost: Some(1.0) }
     }
 
-    fn cast_verify(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData { branch_prob: None, sat_cost: self.sat_cost, dissat_cost: None })
+    fn cast_verify(self) -> Self {
+        CompilerExtData { branch_prob: None, sat_cost: self.sat_cost, dissat_cost: None }
     }
 
-    fn cast_nonzero(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData { branch_prob: None, sat_cost: self.sat_cost, dissat_cost: Some(1.0) })
+    fn cast_nonzero(self) -> Self {
+        CompilerExtData { branch_prob: None, sat_cost: self.sat_cost, dissat_cost: Some(1.0) }
     }
 
-    fn cast_zeronotequal(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
+    fn cast_zeronotequal(self) -> Self {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: self.sat_cost,
             dissat_cost: self.dissat_cost,
-        })
+        }
     }
 
-    fn cast_true(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData { branch_prob: None, sat_cost: self.sat_cost, dissat_cost: None })
+    fn cast_true(self) -> Self {
+        CompilerExtData { branch_prob: None, sat_cost: self.sat_cost, dissat_cost: None }
     }
 
-    fn cast_unlikely(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
-            branch_prob: None,
-            sat_cost: 2.0 + self.sat_cost,
-            dissat_cost: Some(1.0),
-        })
+    fn cast_unlikely(self) -> Self {
+        CompilerExtData { branch_prob: None, sat_cost: 2.0 + self.sat_cost, dissat_cost: Some(1.0) }
     }
 
-    fn cast_likely(self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
-            branch_prob: None,
-            sat_cost: 1.0 + self.sat_cost,
-            dissat_cost: Some(2.0),
-        })
+    fn cast_likely(self) -> Self {
+        CompilerExtData { branch_prob: None, sat_cost: 1.0 + self.sat_cost, dissat_cost: Some(2.0) }
     }
 
-    fn and_b(left: Self, right: Self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
+    fn and_b(left: Self, right: Self) -> Self {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: left.sat_cost + right.sat_cost,
             dissat_cost: match (left.dissat_cost, right.dissat_cost) {
                 (Some(l), Some(r)) => Some(l + r),
                 _ => None,
             },
-        })
+        }
     }
 
-    fn and_v(left: Self, right: Self) -> Result<Self, types::ErrorKind> {
-        Ok(CompilerExtData {
+    fn and_v(left: Self, right: Self) -> Self {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: left.sat_cost + right.sat_cost,
             dissat_cost: None,
-        })
+        }
     }
 
-    fn or_b(l: Self, r: Self) -> Result<Self, types::ErrorKind> {
+    fn or_b(l: Self, r: Self) -> Self {
         let lprob = l
             .branch_prob
             .expect("BUG: left branch prob must be set for disjunctions");
         let rprob = r
             .branch_prob
             .expect("BUG: right branch prob must be set for disjunctions");
-        Ok(CompilerExtData {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: lprob * (l.sat_cost + r.dissat_cost.unwrap())
                 + rprob * (r.sat_cost + l.dissat_cost.unwrap()),
             dissat_cost: Some(l.dissat_cost.unwrap() + r.dissat_cost.unwrap()),
-        })
+        }
     }
 
-    fn or_d(l: Self, r: Self) -> Result<Self, types::ErrorKind> {
+    fn or_d(l: Self, r: Self) -> Self {
         let lprob = l
             .branch_prob
             .expect("BUG: left branch prob must be set for disjunctions");
         let rprob = r
             .branch_prob
             .expect("BUG: right branch prob must be set for disjunctions");
-        Ok(CompilerExtData {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: lprob * l.sat_cost + rprob * (r.sat_cost + l.dissat_cost.unwrap()),
             dissat_cost: r.dissat_cost.map(|rd| l.dissat_cost.unwrap() + rd),
-        })
+        }
     }
 
-    fn or_c(l: Self, r: Self) -> Result<Self, types::ErrorKind> {
+    fn or_c(l: Self, r: Self) -> Self {
         let lprob = l
             .branch_prob
             .expect("BUG: left branch prob must be set for disjunctions");
         let rprob = r
             .branch_prob
             .expect("BUG: right branch prob must be set for disjunctions");
-        Ok(CompilerExtData {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: lprob * l.sat_cost + rprob * (r.sat_cost + l.dissat_cost.unwrap()),
             dissat_cost: None,
-        })
+        }
     }
 
     #[allow(clippy::manual_map)] // Complex if/let is better as is.
-    fn or_i(l: Self, r: Self) -> Result<Self, types::ErrorKind> {
+    fn or_i(l: Self, r: Self) -> Self {
         let lprob = l
             .branch_prob
             .expect("BUG: left branch prob must be set for disjunctions");
         let rprob = r
             .branch_prob
             .expect("BUG: right branch prob must be set for disjunctions");
-        Ok(CompilerExtData {
+        CompilerExtData {
             branch_prob: None,
             sat_cost: lprob * (2.0 + l.sat_cost) + rprob * (1.0 + r.sat_cost),
             dissat_cost: if let (Some(ldis), Some(rdis)) = (l.dissat_cost, r.dissat_cost) {
@@ -354,7 +342,7 @@ impl CompilerExtData {
             } else {
                 None
             },
-        })
+        }
     }
 
     fn and_or(a: Self, b: Self, c: Self) -> Result<Self, types::ErrorKind> {
@@ -434,11 +422,6 @@ impl CompilerExtData {
         Pk: MiniscriptKey,
         Ctx: ScriptContext,
     {
-        let wrap_err = |result: Result<Self, ErrorKind>| {
-            result
-                .map_err(|kind| types::Error { fragment_string: fragment.to_string(), error: kind })
-        };
-
         match *fragment {
             Terminal::True => Ok(Self::TRUE),
             Terminal::False => Ok(Self::FALSE),
@@ -488,50 +471,53 @@ impl CompilerExtData {
             Terminal::Hash256(..) => Ok(Self::hash()),
             Terminal::Ripemd160(..) => Ok(Self::hash()),
             Terminal::Hash160(..) => Ok(Self::hash()),
-            Terminal::Alt(ref sub) => wrap_err(Self::cast_alt(get_child(&sub.node, 0)?)),
-            Terminal::Swap(ref sub) => wrap_err(Self::cast_swap(get_child(&sub.node, 0)?)),
-            Terminal::Check(ref sub) => wrap_err(Self::cast_check(get_child(&sub.node, 0)?)),
-            Terminal::DupIf(ref sub) => wrap_err(Self::cast_dupif(get_child(&sub.node, 0)?)),
-            Terminal::Verify(ref sub) => wrap_err(Self::cast_verify(get_child(&sub.node, 0)?)),
-            Terminal::NonZero(ref sub) => wrap_err(Self::cast_nonzero(get_child(&sub.node, 0)?)),
+            Terminal::Alt(ref sub) => Ok(Self::cast_alt(get_child(&sub.node, 0)?)),
+            Terminal::Swap(ref sub) => Ok(Self::cast_swap(get_child(&sub.node, 0)?)),
+            Terminal::Check(ref sub) => Ok(Self::cast_check(get_child(&sub.node, 0)?)),
+            Terminal::DupIf(ref sub) => Ok(Self::cast_dupif(get_child(&sub.node, 0)?)),
+            Terminal::Verify(ref sub) => Ok(Self::cast_verify(get_child(&sub.node, 0)?)),
+            Terminal::NonZero(ref sub) => Ok(Self::cast_nonzero(get_child(&sub.node, 0)?)),
             Terminal::ZeroNotEqual(ref sub) => {
-                wrap_err(Self::cast_zeronotequal(get_child(&sub.node, 0)?))
+                Ok(Self::cast_zeronotequal(get_child(&sub.node, 0)?))
             }
             Terminal::AndB(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
-                wrap_err(Self::and_b(ltype, rtype))
+                Ok(Self::and_b(ltype, rtype))
             }
             Terminal::AndV(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
-                wrap_err(Self::and_v(ltype, rtype))
+                Ok(Self::and_v(ltype, rtype))
             }
             Terminal::OrB(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
-                wrap_err(Self::or_b(ltype, rtype))
+                Ok(Self::or_b(ltype, rtype))
             }
             Terminal::OrD(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
-                wrap_err(Self::or_d(ltype, rtype))
+                Ok(Self::or_d(ltype, rtype))
             }
             Terminal::OrC(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
-                wrap_err(Self::or_c(ltype, rtype))
+                Ok(Self::or_c(ltype, rtype))
             }
             Terminal::OrI(ref l, ref r) => {
                 let ltype = get_child(&l.node, 0)?;
                 let rtype = get_child(&r.node, 1)?;
-                wrap_err(Self::or_i(ltype, rtype))
+                Ok(Self::or_i(ltype, rtype))
             }
             Terminal::AndOr(ref a, ref b, ref c) => {
                 let atype = get_child(&a.node, 0)?;
                 let btype = get_child(&b.node, 1)?;
                 let ctype = get_child(&c.node, 2)?;
-                wrap_err(Self::and_or(atype, btype, ctype))
+                Self::and_or(atype, btype, ctype).map_err(|kind| types::Error {
+                    fragment_string: fragment.to_string(),
+                    error: kind,
+                })
             }
             Terminal::Thresh(k, ref subs) => {
                 if k == 0 {
@@ -548,18 +534,14 @@ impl CompilerExtData {
                 }
 
                 let mut last_err_frag = None;
-                let res = Self::threshold(k, subs.len(), |n| match get_child(&subs[n].node, n) {
+                Self::threshold(k, subs.len(), |n| match get_child(&subs[n].node, n) {
                     Ok(x) => Ok(x),
                     Err(e) => {
                         last_err_frag = Some(e.fragment_string);
                         Err(e.error)
                     }
-                });
-
-                res.map_err(|kind| types::Error {
-                    fragment_string: last_err_frag.unwrap_or_else(|| fragment.to_string()),
-                    error: kind,
                 })
+                .map_err(|kind| types::Error { fragment_string: fragment.to_string(), error: kind })
             }
         }
     }
@@ -650,7 +632,7 @@ struct Cast<Pk: MiniscriptKey, Ctx: ScriptContext> {
     node: fn(Arc<Miniscript<Pk, Ctx>>) -> Terminal<Pk, Ctx>,
     ast_type: fn(types::Type) -> Result<types::Type, ErrorKind>,
     ext_data: fn(types::ExtData) -> types::ExtData,
-    comp_ext_data: fn(CompilerExtData) -> Result<CompilerExtData, types::ErrorKind>,
+    comp_ext_data: fn(CompilerExtData) -> CompilerExtData,
 }
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Cast<Pk, Ctx> {
@@ -661,7 +643,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Cast<Pk, Ctx> {
                 (self.ast_type)(ast.ms.ty)?,
                 (self.ext_data)(ast.ms.ext),
             )),
-            comp_ext_data: (self.comp_ext_data)(ast.comp_ext_data)?,
+            comp_ext_data: (self.comp_ext_data)(ast.comp_ext_data),
         })
     }
 }

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -14,7 +14,7 @@ use sync::Arc;
 
 use crate::miniscript::context::SigType;
 use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
-use crate::miniscript::types::{self, ErrorKind, ExtData, Property, Type};
+use crate::miniscript::types::{self, ErrorKind, ExtData, Type};
 use crate::miniscript::ScriptContext;
 use crate::policy::Concrete;
 use crate::prelude::*;

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -31,7 +31,7 @@ impl Eq for OrdF64 {}
 // We could derive PartialOrd, but we can't derive Ord, and clippy wants us
 // to derive both or neither. Better to be explicit.
 impl PartialOrd for OrdF64 {
-    fn partial_cmp(&self, other: &OrdF64) -> Option<cmp::Ordering> { self.0.partial_cmp(&other.0) }
+    fn partial_cmp(&self, other: &OrdF64) -> Option<cmp::Ordering> { Some(self.cmp(other)) }
 }
 impl Ord for OrdF64 {
     fn cmp(&self, other: &OrdF64) -> cmp::Ordering {

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -953,11 +953,7 @@ where
             compile_binary!(&mut right, &mut left, [1.0, 1.0], Terminal::AndV);
             let mut zero_comp = BTreeMap::new();
             zero_comp.insert(
-                CompilationKey::from_type(
-                    Type::from_false(),
-                    ExtData::from_false().has_free_verify,
-                    dissat_prob,
-                ),
+                CompilationKey::from_type(Type::FALSE, ExtData::FALSE.has_free_verify, dissat_prob),
                 AstElemExt::terminal(Terminal::False),
             );
             compile_tern!(&mut left, &mut q_zero_right, &mut zero_comp, [1.0, 0.0]);

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -671,7 +671,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> AstElemExt<Pk, Ctx> {
 struct Cast<Pk: MiniscriptKey, Ctx: ScriptContext> {
     node: fn(Arc<Miniscript<Pk, Ctx>>) -> Terminal<Pk, Ctx>,
     ast_type: fn(types::Type) -> Result<types::Type, ErrorKind>,
-    ext_data: fn(types::ExtData) -> Result<types::ExtData, ErrorKind>,
+    ext_data: fn(types::ExtData) -> types::ExtData,
     comp_ext_data: fn(CompilerExtData) -> Result<CompilerExtData, types::ErrorKind>,
 }
 
@@ -681,7 +681,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Cast<Pk, Ctx> {
             ms: Arc::new(Miniscript::from_components_unchecked(
                 (self.node)(Arc::clone(&ast.ms)),
                 (self.ast_type)(ast.ms.ty)?,
-                (self.ext_data)(ast.ms.ext)?,
+                (self.ext_data)(ast.ms.ext),
             )),
             comp_ext_data: (self.comp_ext_data)(ast.comp_ext_data)?,
         })

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1093,7 +1093,7 @@ fn with_huffman_tree<Pk: MiniscriptKey>(
 /// any one of the conditions exclusively.
 #[cfg(feature = "compiler")]
 fn generate_combination<Pk: MiniscriptKey>(
-    policy_vec: &Vec<Arc<Policy<Pk>>>,
+    policy_vec: &[Arc<Policy<Pk>>],
     prob: f64,
     k: usize,
 ) -> Vec<(f64, Arc<Policy<Pk>>)> {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -29,7 +29,7 @@ use crate::prelude::*;
 use crate::sync::Arc;
 #[cfg(all(doc, not(feature = "compiler")))]
 use crate::Descriptor;
-use crate::{errstr, AbsLockTime, Error, ForEachKey, MiniscriptKey, Translator};
+use crate::{errstr, AbsLockTime, Error, ForEachKey, FromStrKey, MiniscriptKey, Translator};
 
 /// Maximum TapLeafs allowed in a compiled TapTree
 #[cfg(feature = "compiler")]
@@ -930,7 +930,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> str::FromStr for Policy<Pk> {
+impl<Pk: FromStrKey> str::FromStr for Policy<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Policy<Pk>, Error> {
         expression::check_valid_chars(s)?;
@@ -945,7 +945,7 @@ impl<Pk: crate::FromStrKey> str::FromStr for Policy<Pk> {
 serde_string_impl_pk!(Policy, "a miniscript concrete policy");
 
 #[rustfmt::skip]
-impl<Pk: crate::FromStrKey> Policy<Pk> {
+impl<Pk: FromStrKey> Policy<Pk> {
     /// Helper function for `from_tree` to parse subexpressions with
     /// names of the form x@y
     fn from_tree_prob(top: &expression::Tree, allow_prob: bool,)
@@ -1050,7 +1050,7 @@ impl<Pk: crate::FromStrKey> Policy<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> expression::FromTree for Policy<Pk> {
+impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Policy<Pk>, Error> {
         Policy::from_tree_prob(top, false).map(|(_, result)| result)
     }

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -15,7 +15,9 @@ use super::ENTAILMENT_MAX_TERMINALS;
 use crate::iter::{Tree, TreeLike};
 use crate::prelude::*;
 use crate::sync::Arc;
-use crate::{errstr, expression, AbsLockTime, Error, ForEachKey, MiniscriptKey, Translator};
+use crate::{
+    errstr, expression, AbsLockTime, Error, ForEachKey, FromStrKey, MiniscriptKey, Translator,
+};
 
 /// Abstract policy which corresponds to the semantics of a miniscript and
 /// which allows complex forms of analysis, e.g. filtering and normalization.
@@ -308,7 +310,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
     }
 }
 
-impl<Pk: crate::FromStrKey> str::FromStr for Policy<Pk> {
+impl<Pk: FromStrKey> str::FromStr for Policy<Pk> {
     type Err = Error;
     fn from_str(s: &str) -> Result<Policy<Pk>, Error> {
         expression::check_valid_chars(s)?;
@@ -320,7 +322,7 @@ impl<Pk: crate::FromStrKey> str::FromStr for Policy<Pk> {
 
 serde_string_impl_pk!(Policy, "a miniscript semantic policy");
 
-impl<Pk: crate::FromStrKey> expression::FromTree for Policy<Pk> {
+impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Policy<Pk>, Error> {
         match (top.name, top.args.len()) {
             ("UNSATISFIABLE", 0) => Ok(Policy::Unsatisfiable),


### PR DESCRIPTION
Something of a followup to #649, which specifically removes the `type_check` method from `Property`.

Basically, this whole trait is confused. Originally it was supposed to express "a recursively defined property of a Miniscript" which could be defined by a couple constructors and then automatically computed for any Miniscript. In fact, the trait required a separate constructor for every single Miniscript fragment so nothing was "automatic" except sometimes reusing code between the different hash fragments and between `older`/`after`.

Furthermore, every implementor of this trait had slightly different requirements, meaning that there were `unreachable!()`s throughout the code, functions that were never called (e.g. `Type::from_sha256` passing through to `Correctness::from_sha256` and `Malleability::from_sha256` when all three of those types implemented the function by calling `from_hash`, which *also* was defined by `Type::from_hash` calling `Correctness::from_hash` and `Malleability::from_hash`. So much boilerplate) and many instances of methods being implemented but ignoring arguments, or (worse) being generic over `Pk`/`Ctx` and ignoring those types entirely, or returning `Result` but always returing the `Ok` variant.

So basically, there was no value in being generic over the trait and the trait wasn't even a generalization of any of the types that implemented it.

**Adding to this** having the trait prevents us from having constfns in our type checking code, which sucks because we have a lot of common fixed fragments. It also prevents us from returning different error types from different parts of the typechecker, which is my specific goal in removing the trait.

This PR has a lot of commits but most of them are mechanical and/or small.