### PR TITLE
compiler: improve logic when deciding between conjunctions and multi/multi_a

### DIFF
--- a/examples/taproot.rs
+++ b/examples/taproot.rs
@@ -45,7 +45,7 @@ fn main() {
     let desc = pol.compile_tr(Some("UNSPENDABLE_KEY".to_string())).unwrap();
 
     let expected_desc =
-        Descriptor::<String>::from_str("tr(Ca,{and_v(v:pk(In),older(9)),multi_a(2,hA,S)})")
+        Descriptor::<String>::from_str("tr(Ca,{and_v(v:pk(In),older(9)),and_v(v:pk(hA),pk(S))})")
             .unwrap();
     assert_eq!(desc, expected_desc);
 
@@ -73,7 +73,7 @@ fn main() {
         );
         assert_eq!(
             iter.next().unwrap(),
-            (1u8, &Miniscript::<String, Tap>::from_str("multi_a(2,hA,S)").unwrap())
+            (1u8, &Miniscript::<String, Tap>::from_str("and_v(v:pk(hA),pk(S))").unwrap())
         );
         assert_eq!(iter.next(), None);
     }
@@ -97,19 +97,19 @@ fn main() {
     let real_desc = desc.translate_pk(&mut t).unwrap();
 
     // Max satisfaction weight for compilation, corresponding to the script-path spend
-    // `multi_a(2,PUBKEY_1,PUBKEY_2) at tap tree depth 1, having:
+    // `and_v(PUBKEY_1,PUBKEY_2) at tap tree depth 1, having:
     //
     //     max_witness_size = varint(control_block_size) + control_block size +
     //                        varint(script_size) + script_size + max_satisfaction_size
-    //                      = 1 + 65 + 1 + 70 + 132 = 269
+    //                      = 1 + 65 + 1 + 68 + 132 = 269
     let max_sat_wt = real_desc.max_weight_to_satisfy().unwrap();
-    assert_eq!(max_sat_wt, 269);
+    assert_eq!(max_sat_wt, 267);
 
     // Compute the bitcoin address and check if it matches
     let network = Network::Bitcoin;
     let addr = real_desc.address(network).unwrap();
     let expected_addr = bitcoin::Address::from_str(
-        "bc1pcc8ku64slu3wu04a6g376d2s8ck9y5alw5sus4zddvn8xgpdqw2swrghwx",
+        "bc1p4l2xzq7js40965s5w0fknd287kdlmt2dljte37zsc5a34u0h9c4q85snyd",
     )
     .unwrap()
     .assume_checked();

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -198,7 +198,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> policy::Liftable<Pk> for SortedMultiVec<Pk, Ctx> {
     fn lift(&self) -> Result<policy::semantic::Policy<Pk>, Error> {
-        let ret = policy::semantic::Policy::Threshold(
+        let ret = policy::semantic::Policy::Thresh(
             self.k,
             self.pks
                 .iter()

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -616,7 +616,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for TapTree<Pk> {
     fn lift(&self) -> Result<Policy<Pk>, Error> {
         fn lift_helper<Pk: MiniscriptKey>(s: &TapTree<Pk>) -> Result<Policy<Pk>, Error> {
             match *s {
-                TapTree::Tree { ref left, ref right, height: _ } => Ok(Policy::Threshold(
+                TapTree::Tree { ref left, ref right, height: _ } => Ok(Policy::Thresh(
                     1,
                     vec![Arc::new(lift_helper(left)?), Arc::new(lift_helper(right)?)],
                 )),
@@ -632,7 +632,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for TapTree<Pk> {
 impl<Pk: MiniscriptKey> Liftable<Pk> for Tr<Pk> {
     fn lift(&self) -> Result<Policy<Pk>, Error> {
         match &self.tree {
-            Some(root) => Ok(Policy::Threshold(
+            Some(root) => Ok(Policy::Thresh(
                 1,
                 vec![
                     Arc::new(Policy::Key(self.internal_key.clone())),

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -139,7 +139,7 @@ fn fmt_1<D: fmt::Debug + fmt::Display>(
     a: &D,
     is_debug: bool,
 ) -> fmt::Result {
-    f.write_str(&name)?;
+    f.write_str(name)?;
     conditional_fmt(f, a, is_debug)?;
     f.write_str(")")
 }
@@ -150,7 +150,7 @@ fn fmt_2<D: fmt::Debug + fmt::Display>(
     b: &D,
     is_debug: bool,
 ) -> fmt::Result {
-    f.write_str(&name)?;
+    f.write_str(name)?;
     conditional_fmt(f, a, is_debug)?;
     f.write_str(",")?;
     conditional_fmt(f, b, is_debug)?;
@@ -163,7 +163,7 @@ fn fmt_n<D: fmt::Debug + fmt::Display>(
     list: &[D],
     is_debug: bool,
 ) -> fmt::Result {
-    f.write_str(&name)?;
+    f.write_str(name)?;
     write!(f, "{}", first)?;
     for el in list {
         f.write_str(",")?;

--- a/src/miniscript/limits.rs
+++ b/src/miniscript/limits.rs
@@ -33,3 +33,5 @@ pub const MAX_BLOCK_WEIGHT: usize = 4000000;
 /// Maximum pubkeys as arguments to CHECKMULTISIG
 // https://github.com/bitcoin/bitcoin/blob/6acda4b00b3fc1bfac02f5de590e1a5386cbc779/src/script/script.h#L30
 pub const MAX_PUBKEYS_PER_MULTISIG: usize = 20;
+/// Maximum pubkeys in a CHECKSIGADD construction.
+pub const MAX_PUBKEYS_IN_CHECKSIGADD: usize = (bitcoin::Weight::MAX_BLOCK.to_wu() / 32) as usize;

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -220,7 +220,7 @@ impl Type {
 
     /// Constructor for the type of the `a:` fragment.
     pub const fn cast_alt(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
+        // FIXME need to do manual `?` because ? is not supported in constfns. (Also below.)
         Ok(Type {
             corr: match Correctness::cast_alt(self.corr) {
                 Ok(x) => x,
@@ -232,7 +232,6 @@ impl Type {
 
     /// Constructor for the type of the `s:` fragment.
     pub const fn cast_swap(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::cast_swap(self.corr) {
                 Ok(x) => x,
@@ -255,7 +254,6 @@ impl Type {
 
     /// Constructor for the type of the `d:` fragment.
     pub const fn cast_dupif(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::cast_dupif(self.corr) {
                 Ok(x) => x,
@@ -267,7 +265,6 @@ impl Type {
 
     /// Constructor for the type of the `v:` fragment.
     pub const fn cast_verify(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::cast_verify(self.corr) {
                 Ok(x) => x,
@@ -279,7 +276,6 @@ impl Type {
 
     /// Constructor for the type of the `j:` fragment.
     pub const fn cast_nonzero(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::cast_nonzero(self.corr) {
                 Ok(x) => x,
@@ -291,7 +287,6 @@ impl Type {
 
     /// Constructor for the type of the `n:` fragment.
     pub const fn cast_zeronotequal(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::cast_zeronotequal(self.corr) {
                 Ok(x) => x,
@@ -303,7 +298,6 @@ impl Type {
 
     /// Constructor for the type of the `t:` fragment.
     pub const fn cast_true(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::cast_true(self.corr) {
                 Ok(x) => x,
@@ -315,7 +309,6 @@ impl Type {
 
     /// Constructor for the type of the `u:` fragment.
     pub const fn cast_unlikely(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::cast_or_i_false(self.corr) {
                 Ok(x) => x,
@@ -327,7 +320,6 @@ impl Type {
 
     /// Constructor for the type of the `l:` fragment.
     pub const fn cast_likely(self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::cast_or_i_false(self.corr) {
                 Ok(x) => x,
@@ -339,7 +331,6 @@ impl Type {
 
     /// Constructor for the type of the `and_b` fragment.
     pub const fn and_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::and_b(left.corr, right.corr) {
                 Ok(x) => x,
@@ -351,7 +342,6 @@ impl Type {
 
     /// Constructor for the type of the `and_v` fragment.
     pub const fn and_v(left: Self, right: Self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::and_v(left.corr, right.corr) {
                 Ok(x) => x,
@@ -363,7 +353,6 @@ impl Type {
 
     /// Constructor for the type of the `or_b` fragment.
     pub const fn or_b(left: Self, right: Self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::or_b(left.corr, right.corr) {
                 Ok(x) => x,
@@ -375,7 +364,6 @@ impl Type {
 
     /// Constructor for the type of the `or_b` fragment.
     pub const fn or_d(left: Self, right: Self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::or_d(left.corr, right.corr) {
                 Ok(x) => x,
@@ -387,7 +375,6 @@ impl Type {
 
     /// Constructor for the type of the `or_c` fragment.
     pub const fn or_c(left: Self, right: Self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::or_c(left.corr, right.corr) {
                 Ok(x) => x,
@@ -410,7 +397,6 @@ impl Type {
 
     /// Constructor for the type of the `and_or` fragment.
     pub const fn and_or(a: Self, b: Self, c: Self) -> Result<Self, ErrorKind> {
-        // FIXME need to do manual `?` because ? is not supported in constfns.
         Ok(Type {
             corr: match Correctness::and_or(a.corr, b.corr, c.corr) {
                 Ok(x) => x,

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1008,7 +1008,7 @@ where
             compile_binary!(&mut l_comp[3], &mut r_comp[2], [lw, rw], Terminal::OrI);
             compile_binary!(&mut r_comp[3], &mut l_comp[2], [rw, lw], Terminal::OrI);
         }
-        Concrete::Threshold(k, ref subs) => {
+        Concrete::Thresh(k, ref subs) => {
             let n = subs.len();
             let k_over_n = k as f64 / n as f64;
 
@@ -1389,7 +1389,7 @@ mod tests {
         let policy: BPolicy = Concrete::Or(vec![
             (
                 127,
-                Arc::new(Concrete::Threshold(
+                Arc::new(Concrete::Thresh(
                     3,
                     key_pol[0..5].iter().map(|p| (p.clone()).into()).collect(),
                 )),
@@ -1398,7 +1398,7 @@ mod tests {
                 1,
                 Arc::new(Concrete::And(vec![
                     Arc::new(Concrete::Older(RelLockTime::from_height(10000))),
-                    Arc::new(Concrete::Threshold(
+                    Arc::new(Concrete::Thresh(
                         2,
                         key_pol[5..8].iter().map(|p| (p.clone()).into()).collect(),
                     )),
@@ -1519,7 +1519,7 @@ mod tests {
                 .iter()
                 .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
                 .collect();
-            let big_thresh = Concrete::Threshold(*k, pubkeys);
+            let big_thresh = Concrete::Thresh(*k, pubkeys);
             let big_thresh_ms: SegwitMiniScript = big_thresh.compile().unwrap();
             if *k == 21 {
                 // N * (PUSH + pubkey + CHECKSIGVERIFY)
@@ -1555,8 +1555,8 @@ mod tests {
             .collect();
 
         let thresh_res: Result<SegwitMiniScript, _> = Concrete::Or(vec![
-            (1, Arc::new(Concrete::Threshold(keys_a.len(), keys_a))),
-            (1, Arc::new(Concrete::Threshold(keys_b.len(), keys_b))),
+            (1, Arc::new(Concrete::Thresh(keys_a.len(), keys_a))),
+            (1, Arc::new(Concrete::Thresh(keys_b.len(), keys_b))),
         ])
         .compile();
         let script_size = thresh_res.clone().and_then(|m| Ok(m.script_size()));
@@ -1573,8 +1573,7 @@ mod tests {
             .iter()
             .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
             .collect();
-        let thresh_res: Result<SegwitMiniScript, _> =
-            Concrete::Threshold(keys.len(), keys).compile();
+        let thresh_res: Result<SegwitMiniScript, _> = Concrete::Thresh(keys.len(), keys).compile();
         let n_elements = thresh_res
             .clone()
             .and_then(|m| Ok(m.max_satisfaction_witness_elements()));
@@ -1595,7 +1594,7 @@ mod tests {
             .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
             .collect();
         let thresh_res: Result<SegwitMiniScript, _> =
-            Concrete::Threshold(keys.len() - 1, keys).compile();
+            Concrete::Thresh(keys.len() - 1, keys).compile();
         let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops.op_count()));
         assert_eq!(
             thresh_res,
@@ -1609,7 +1608,7 @@ mod tests {
             .iter()
             .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
             .collect();
-        let thresh_res = Concrete::Threshold(keys.len() - 1, keys).compile::<Legacy>();
+        let thresh_res = Concrete::Thresh(keys.len() - 1, keys).compile::<Legacy>();
         let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops.op_count()));
         assert_eq!(
             thresh_res,

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -505,12 +505,12 @@ mod tests {
                 Tr::<String>::from_str(
                     "tr(UNSPEND ,{
                 {
-                    {multi_a(7,B,C,D,E,F,G,H),multi_a(7,A,C,D,E,F,G,H)},
-                    {multi_a(7,A,B,D,E,F,G,H),multi_a(7,A,B,C,E,F,G,H)}
+                    {and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:pk(B),pk(C)),pk(D)),pk(E)),pk(F)),pk(G)),pk(H)),and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:pk(A),pk(C)),pk(D)),pk(E)),pk(F)),pk(G)),pk(H))},
+                    {and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:pk(A),pk(B)),pk(D)),pk(E)),pk(F)),pk(G)),pk(H)),and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:pk(A),pk(B)),pk(C)),pk(E)),pk(F)),pk(G)),pk(H))}
                 },
                 {
-                    {multi_a(7,A,B,C,D,F,G,H),multi_a(7,A,B,C,D,E,G,H)}
-                   ,{multi_a(7,A,B,C,D,E,F,H),multi_a(7,A,B,C,D,E,F,G)}
+                    {and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:pk(A),pk(B)),pk(C)),pk(D)),pk(F)),pk(G)),pk(H)),and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:pk(A),pk(B)),pk(C)),pk(D)),pk(E)),pk(G)),pk(H))},
+                    {and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:pk(A),pk(B)),pk(C)),pk(D)),pk(E)),pk(F)),pk(H)),and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:and_v(v:pk(A),pk(B)),pk(C)),pk(D)),pk(E)),pk(F)),pk(G))}
                 }})"
                     .replace(&['\t', ' ', '\n'][..], "")
                     .as_str(),
@@ -526,18 +526,19 @@ mod tests {
             let desc = pol
                 .compile_tr_private_experimental(Some(unspendable_key.clone()))
                 .unwrap();
+            println!("{}", desc);
             let expected_desc = Descriptor::Tr(
                 Tr::<String>::from_str(
                     "tr(UNSPEND,
                     {{
-                        {multi_a(3,A,D,E),multi_a(3,A,C,E)},
-                        {multi_a(3,A,C,D),multi_a(3,A,B,E)}\
+                        {and_v(v:and_v(v:pk(A),pk(D)),pk(E)),and_v(v:and_v(v:pk(A),pk(C)),pk(E))},
+                        {and_v(v:and_v(v:pk(A),pk(C)),pk(D)),and_v(v:and_v(v:pk(A),pk(B)),pk(E))}
                     },
                     {
-                        {multi_a(3,A,B,D),multi_a(3,A,B,C)},
+                        {and_v(v:and_v(v:pk(A),pk(B)),pk(D)),and_v(v:and_v(v:pk(A),pk(B)),pk(C))},
                         {
-                            {multi_a(3,C,D,E),multi_a(3,B,D,E)},
-                            {multi_a(3,B,C,E),multi_a(3,B,C,D)}
+                            {and_v(v:and_v(v:pk(C),pk(D)),pk(E)),and_v(v:and_v(v:pk(B),pk(D)),pk(E))},
+                            {and_v(v:and_v(v:pk(B),pk(C)),pk(E)),and_v(v:and_v(v:pk(B),pk(C)),pk(D))}
                     }}})"
                         .replace(&['\t', ' ', '\n'][..], "")
                         .as_str(),

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -47,7 +47,7 @@ pub enum Policy<Pk: MiniscriptKey> {
     /// A HASH160 whose preimage must be provided to satisfy the descriptor.
     Hash160(Pk::Hash160),
     /// A set of descriptors, satisfactions must be provided for `k` of them.
-    Threshold(usize, Vec<Arc<Policy<Pk>>>),
+    Thresh(usize, Vec<Arc<Policy<Pk>>>),
 }
 
 impl<Pk: MiniscriptKey> ForEachKey<Pk> for Policy<Pk> {
@@ -122,7 +122,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                 Hash160(ref h) => t.hash160(h).map(Hash160)?,
                 Older(ref n) => Older(*n),
                 After(ref n) => After(*n),
-                Threshold(ref k, ref subs) => Threshold(*k, (0..subs.len()).map(child_n).collect()),
+                Thresh(ref k, ref subs) => Thresh(*k, (0..subs.len()).map(child_n).collect()),
             };
             translated.push(Arc::new(new_policy));
         }
@@ -174,7 +174,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             let n_terminals_for_child_n = |n| n_terminals[data.child_indices[n]];
 
             let num = match data.node {
-                Threshold(_k, subs) => (0..subs.len()).map(n_terminals_for_child_n).sum(),
+                Thresh(_k, subs) => (0..subs.len()).map(n_terminals_for_child_n).sum(),
                 Trivial | Unsatisfiable => 0,
                 _leaf => 1,
             };
@@ -190,7 +190,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     fn first_constraint(&self) -> Policy<Pk> {
         debug_assert!(self.clone().normalized() == self.clone());
         match self {
-            &Policy::Threshold(_k, ref subs) => subs[0].first_constraint(),
+            &Policy::Thresh(_k, ref subs) => subs[0].first_constraint(),
             first => first.clone(),
         }
     }
@@ -201,19 +201,19 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     // normalized policy
     pub(crate) fn satisfy_constraint(self, witness: &Policy<Pk>, available: bool) -> Policy<Pk> {
         debug_assert!(self.clone().normalized() == self);
-        if let Policy::Threshold { .. } = *witness {
-            // We can't debug_assert on Policy::Threshold.
+        if let Policy::Thresh { .. } = *witness {
+            // We can't debug_assert on Policy::Thresh.
             panic!("should be unreachable")
         }
 
         let ret = match self {
-            Policy::Threshold(k, subs) => {
+            Policy::Thresh(k, subs) => {
                 let mut ret_subs = vec![];
                 for sub in subs {
                     ret_subs.push(sub.as_ref().clone().satisfy_constraint(witness, available));
                 }
                 let ret_subs = ret_subs.into_iter().map(Arc::new).collect();
-                Policy::Threshold(k, ret_subs)
+                Policy::Thresh(k, ret_subs)
             }
             ref leaf if leaf == witness => {
                 if available {
@@ -240,7 +240,7 @@ impl<Pk: MiniscriptKey> fmt::Debug for Policy<Pk> {
             Policy::Hash256(ref h) => write!(f, "hash256({})", h),
             Policy::Ripemd160(ref h) => write!(f, "ripemd160({})", h),
             Policy::Hash160(ref h) => write!(f, "hash160({})", h),
-            Policy::Threshold(k, ref subs) => {
+            Policy::Thresh(k, ref subs) => {
                 if k == subs.len() {
                     write!(f, "and(")?;
                 } else if k == 1 {
@@ -273,7 +273,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Policy<Pk> {
             Policy::Hash256(ref h) => write!(f, "hash256({})", h),
             Policy::Ripemd160(ref h) => write!(f, "ripemd160({})", h),
             Policy::Hash160(ref h) => write!(f, "hash160({})", h),
-            Policy::Threshold(k, ref subs) => {
+            Policy::Thresh(k, ref subs) => {
                 if k == subs.len() {
                     write!(f, "and(")?;
                 } else if k == 1 {
@@ -342,7 +342,7 @@ impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
                 for arg in &top.args {
                     subs.push(Arc::new(Policy::from_tree(arg)?));
                 }
-                Ok(Policy::Threshold(nsubs, subs))
+                Ok(Policy::Thresh(nsubs, subs))
             }
             ("or", nsubs) => {
                 if nsubs < 2 {
@@ -352,7 +352,7 @@ impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
                 for arg in &top.args {
                     subs.push(Arc::new(Policy::from_tree(arg)?));
                 }
-                Ok(Policy::Threshold(1, subs))
+                Ok(Policy::Thresh(1, subs))
             }
             ("thresh", nsubs) => {
                 if nsubs == 0 || nsubs == 1 {
@@ -379,7 +379,7 @@ impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
                 for arg in &top.args[1..] {
                     subs.push(Arc::new(Policy::from_tree(arg)?));
                 }
-                Ok(Policy::Threshold(thresh as usize, subs))
+                Ok(Policy::Thresh(thresh as usize, subs))
             }
             _ => Err(errstr(top.name)),
         }
@@ -391,7 +391,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// `Unsatisfiable`s. Does not reorder any branches; use `.sort`.
     pub fn normalized(self) -> Policy<Pk> {
         match self {
-            Policy::Threshold(k, subs) => {
+            Policy::Thresh(k, subs) => {
                 let mut ret_subs = Vec::with_capacity(subs.len());
 
                 let subs: Vec<_> = subs
@@ -416,15 +416,15 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                 for sub in subs {
                     match sub.as_ref() {
                         Policy::Trivial | Policy::Unsatisfiable => {}
-                        Policy::Threshold(ref k, ref subs) => {
+                        Policy::Thresh(ref k, ref subs) => {
                             match (is_and, is_or) {
                                 (true, true) => {
                                     // means m = n = 1, thresh(1,X) type thing.
-                                    ret_subs.push(Arc::new(Policy::Threshold(*k, subs.to_vec())));
+                                    ret_subs.push(Arc::new(Policy::Thresh(*k, subs.to_vec())));
                                 }
                                 (true, false) if *k == subs.len() => ret_subs.extend(subs.to_vec()), // and case
                                 (false, true) if *k == 1 => ret_subs.extend(subs.to_vec()), // or case
-                                _ => ret_subs.push(Arc::new(Policy::Threshold(*k, subs.to_vec()))),
+                                _ => ret_subs.push(Arc::new(Policy::Thresh(*k, subs.to_vec()))),
                             }
                         }
                         x => ret_subs.push(Arc::new(x.clone())),
@@ -440,11 +440,11 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                     // Only one strong reference because we created the Arc when pushing to ret_subs.
                     Arc::try_unwrap(policy).unwrap()
                 } else if is_and {
-                    Policy::Threshold(ret_subs.len(), ret_subs)
+                    Policy::Thresh(ret_subs.len(), ret_subs)
                 } else if is_or {
-                    Policy::Threshold(1, ret_subs)
+                    Policy::Thresh(1, ret_subs)
                 } else {
-                    Policy::Threshold(m, ret_subs)
+                    Policy::Thresh(m, ret_subs)
                 }
             }
             x => x,
@@ -515,14 +515,12 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             let new_policy = match data.node.as_ref() {
                 Older(ref t) => {
                     if relative::LockTime::from(*t).is_implied_by(age) {
-                        Some(Policy::Older(*t))
+                        Some(Older(*t))
                     } else {
-                        Some(Policy::Unsatisfiable)
+                        Some(Unsatisfiable)
                     }
                 }
-                Threshold(k, ref subs) => {
-                    Some(Threshold(*k, (0..subs.len()).map(child_n).collect()))
-                }
+                Thresh(k, ref subs) => Some(Thresh(*k, (0..subs.len()).map(child_n).collect())),
                 _ => None,
             };
             match new_policy {
@@ -554,9 +552,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                         Some(Unsatisfiable)
                     }
                 }
-                Threshold(k, ref subs) => {
-                    Some(Threshold(*k, (0..subs.len()).map(child_n).collect()))
-                }
+                Thresh(k, ref subs) => Some(Thresh(*k, (0..subs.len()).map(child_n).collect())),
                 _ => None,
             };
             match new_policy {
@@ -597,7 +593,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                 Trivial | After(..) | Older(..) | Sha256(..) | Hash256(..) | Ripemd160(..)
                 | Hash160(..) => Some(0),
                 Key(..) => Some(1),
-                Threshold(k, ref subs) => {
+                Thresh(k, ref subs) => {
                     let mut sublens = (0..subs.len())
                         .filter_map(minimum_n_keys_for_child_n)
                         .collect::<Vec<usize>>();
@@ -631,10 +627,10 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             let child_n = |n| Arc::clone(&sorted[data.child_indices[n]]);
 
             let new_policy = match data.node.as_ref() {
-                Threshold(k, ref subs) => {
+                Thresh(k, ref subs) => {
                     let mut subs = (0..subs.len()).map(child_n).collect::<Vec<_>>();
                     subs.sort();
-                    Some(Threshold(*k, subs))
+                    Some(Thresh(*k, subs))
                 }
                 _ => None,
             };
@@ -657,7 +653,7 @@ impl<'a, Pk: MiniscriptKey> TreeLike for &'a Policy<Pk> {
         match *self {
             Unsatisfiable | Trivial | Key(_) | After(_) | Older(_) | Sha256(_) | Hash256(_)
             | Ripemd160(_) | Hash160(_) => Tree::Nullary,
-            Threshold(_, ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
+            Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
         }
     }
 }
@@ -669,7 +665,7 @@ impl<Pk: MiniscriptKey> TreeLike for Arc<Policy<Pk>> {
         match self.as_ref() {
             Unsatisfiable | Trivial | Key(_) | After(_) | Older(_) | Sha256(_) | Hash256(_)
             | Ripemd160(_) | Hash160(_) => Tree::Nullary,
-            Threshold(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
+            Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
         }
     }
 }
@@ -744,7 +740,7 @@ mod tests {
         let policy = StringPolicy::from_str("or(pk(),older(1000))").unwrap();
         assert_eq!(
             policy,
-            Policy::Threshold(
+            Policy::Thresh(
                 1,
                 vec![
                     Policy::Key("".to_owned()).into(),
@@ -775,7 +771,7 @@ mod tests {
         let policy = StringPolicy::from_str("or(pk(),UNSATISFIABLE)").unwrap();
         assert_eq!(
             policy,
-            Policy::Threshold(
+            Policy::Thresh(
                 1,
                 vec![
                     Policy::Key("".to_owned()).into(),
@@ -791,7 +787,7 @@ mod tests {
         let policy = StringPolicy::from_str("and(pk(),UNSATISFIABLE)").unwrap();
         assert_eq!(
             policy,
-            Policy::Threshold(
+            Policy::Thresh(
                 2,
                 vec![
                     Policy::Key("".to_owned()).into(),
@@ -812,7 +808,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             policy,
-            Policy::Threshold(
+            Policy::Thresh(
                 2,
                 vec![
                     Policy::Older(RelLockTime::from_height(1000)).into(),
@@ -836,7 +832,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             policy,
-            Policy::Threshold(
+            Policy::Thresh(
                 2,
                 vec![
                     Policy::Older(RelLockTime::from_height(1000)).into(),
@@ -949,8 +945,7 @@ mod tests {
             "or(and(older(4096),thresh(2,pk(A),pk(B),pk(C))),thresh(11,pk(F1),pk(F2),pk(F3),pk(F4),pk(F5),pk(F6),pk(F7),pk(F8),pk(F9),pk(F10),pk(F11),pk(F12),pk(F13),pk(F14)))").unwrap();
         // Very bad idea to add master key,pk but let's have it have 50M blocks
         let master_key = StringPolicy::from_str("and(older(50000000),pk(master))").unwrap();
-        let new_liquid_pol =
-            Policy::Threshold(1, vec![liquid_pol.clone().into(), master_key.into()]);
+        let new_liquid_pol = Policy::Thresh(1, vec![liquid_pol.clone().into(), master_key.into()]);
 
         assert!(liquid_pol.clone().entails(new_liquid_pol.clone()).unwrap());
         assert!(!new_liquid_pol.entails(liquid_pol.clone()).unwrap());


### PR DESCRIPTION
The compiler logic when encountering thresholds of pks is currently a bit confused, and therefore chooses multi/multi_a in cases where this is not the most efficient compilation.

This PR fixes that, and also brings in a few other cleanup commits that I had laying around.

This does **not** fix #656, which I didn't know how to approach.