### PR TITLE
Experimenting reducing stack size of `Error`

### DIFF
--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -299,7 +299,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
             let witness = vec![];
             Ok((witness, script_sig))
         } else {
-            Err(Error::MissingSig(self.pk.to_public_key()))
+            Err(Error::MissingSig(Box::new(self.pk.to_public_key())))
         }
     }
 

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -336,7 +336,7 @@ impl<Pk: MiniscriptKey> Wpkh<Pk> {
     /// Checks whether the descriptor is safe.
     pub fn sanity_check(&self) -> Result<(), Error> {
         if self.pk.is_uncompressed() {
-            Err(Error::ContextError(ScriptContextError::CompressedOnly(self.pk.to_string())))
+            Err(Error::ContextError(Box::new(ScriptContextError::CompressedOnly(self.pk.to_string()))))
         } else {
             Ok(())
         }
@@ -408,7 +408,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Wpkh<Pk> {
             let witness = vec![sig_vec, self.pk.to_public_key().to_bytes()];
             Ok((witness, script_sig))
         } else {
-            Err(Error::MissingSig(self.pk.to_public_key()))
+            Err(Error::MissingSig(Box::new(self.pk.to_public_key())))
         }
     }
 

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -264,12 +264,12 @@ pub fn parse<Ctx: ScriptContext>(
                     // pubkey
                     Tk::Bytes33(pk) => {
                         let ret = Ctx::Key::from_slice(pk)
-                            .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?;
+                            .map_err(|e| Error::PubKeyCtxError(Box::new((e, Ctx::name_str()))))?;
                         term.reduce0(Terminal::PkK(ret))?
                     },
                     Tk::Bytes65(pk) => {
                         let ret = Ctx::Key::from_slice(pk)
-                            .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?;
+                            .map_err(|e| Error::PubKeyCtxError(Box::new((e, Ctx::name_str()))))?;
                         term.reduce0(Terminal::PkK(ret))?
                     },
                     // Note this does not collide with hash32 because they always followed by equal
@@ -285,7 +285,7 @@ pub fn parse<Ctx: ScriptContext>(
                     // after bytes32 means bytes32 is in a hashlock
                     // Finally for the first case, K being parsed as a solo expression is a Pk type
                     Tk::Bytes32(pk) => {
-                        let ret = Ctx::Key::from_slice(pk).map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?;
+                        let ret = Ctx::Key::from_slice(pk).map_err(|e| Error::PubKeyCtxError(Box::new((e, Ctx::name_str()))))?;
                         term.reduce0(Terminal::PkK(ret))?
                     },
                     // checksig
@@ -437,9 +437,9 @@ pub fn parse<Ctx: ScriptContext>(
                             match_token!(
                                 tokens,
                                 Tk::Bytes33(pk) => keys.push(<Ctx::Key>::from_slice(pk)
-                                    .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?),
+                                    .map_err(|e| Error::PubKeyCtxError(Box::new((e, Ctx::name_str()))))?),
                                 Tk::Bytes65(pk) => keys.push(<Ctx::Key>::from_slice(pk)
-                                    .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?),
+                                    .map_err(|e| Error::PubKeyCtxError(Box::new((e, Ctx::name_str()))))?),
                             );
                         }
                         let k = match_token!(
@@ -461,14 +461,14 @@ pub fn parse<Ctx: ScriptContext>(
                             match_token!(
                                 tokens,
                                 Tk::CheckSigAdd, Tk::Bytes32(pk) => keys.push(<Ctx::Key>::from_slice(pk)
-                                    .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?),
+                                    .map_err(|e| Error::PubKeyCtxError(Box::new((e, Ctx::name_str()))))?),
                             );
                         }
                         // Last key must be with a CheckSig
                         match_token!(
                             tokens,
                             Tk::CheckSig, Tk::Bytes32(pk) => keys.push(<Ctx::Key>::from_slice(pk)
-                                .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?),
+                                .map_err(|e| Error::PubKeyCtxError(Box::new((e, Ctx::name_str()))))?),
                         );
                         keys.reverse();
                         term.reduce0(Terminal::MultiA(k as usize, keys))?;

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -99,7 +99,7 @@ pub fn lex(script: &'_ script::Script) -> Result<Vec<Token<'_>>, Error> {
     let mut ret = Vec::with_capacity(script.len());
 
     for ins in script.instructions_minimal() {
-        match ins.map_err(Error::Script)? {
+        match ins.map_err(|e| Error::Script(Box::new(e)))? {
             script::Instruction::Op(opcodes::all::OP_BOOLAND) => {
                 ret.push(Token::BoolAnd);
             }
@@ -188,7 +188,7 @@ pub fn lex(script: &'_ script::Script) -> Result<Vec<Token<'_>>, Error> {
                     Some(op @ &Token::Equal)
                     | Some(op @ &Token::CheckSig)
                     | Some(op @ &Token::CheckMultiSig) => {
-                        return Err(Error::NonMinimalVerify(format!("{:?}", op)))
+                        return Err(Error::NonMinimalVerify(format!("{:?}", op).into()))
                     }
                     _ => {}
                 }
@@ -224,7 +224,7 @@ pub fn lex(script: &'_ script::Script) -> Result<Vec<Token<'_>>, Error> {
                                 ret.push(Token::Num(v as u32));
                             }
                             Ok(_) => return Err(Error::InvalidPush(bytes.to_owned().into())),
-                            Err(e) => return Err(Error::Script(e)),
+                            Err(e) => return Err(Error::Script(Box::new(e))),
                         }
                     }
                 }


### PR DESCRIPTION
This draft PR reduce the stack size of the crate::Error type from 72 bytes to 32 bytes by boxing bigger variants.

I noticed a very noticeable reduction in binary size produced which I can't explain
in comparison to master the rlib produced is reduced by 0.5% and big example of about 2%.

At the same time llvm lines emitted are almost the same.

Can someone explain this?