### PR TITLE
Derives `Hash` for pub items

### DIFF
--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -52,7 +52,7 @@ fn script_from_stack_elem<Ctx: ScriptContext>(
 }
 
 /// Helper type to indicate the origin of the bare pubkey that the interpereter uses
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum PubkeyType {
     Pk,
     Pkh,
@@ -62,7 +62,7 @@ pub enum PubkeyType {
 }
 
 /// Helper type to indicate the origin of the bare miniscript that the interpereter uses
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ScriptType {
     Bare,
     Sh,
@@ -72,7 +72,7 @@ pub enum ScriptType {
 }
 
 /// Structure representing a script under evaluation as a Miniscript
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub(super) enum Inner {
     /// The script being evaluated is a simple public key check (pay-to-pk,
     /// pay-to-pkhash or pay-to-witness-pkhash)

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -43,7 +43,7 @@ pub struct Interpreter<'txin> {
 // Ecdsa and Schnorr signatures
 
 /// A type for representing signatures supported as of bitcoin core 22.0
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum KeySigPair {
     /// A Full public key and corresponding Ecdsa signature
     Ecdsa(bitcoin::PublicKey, bitcoin::ecdsa::Signature),
@@ -429,7 +429,7 @@ impl<'txin> Interpreter<'txin> {
 }
 
 /// Type of HashLock used for SatisfiedConstraint structure
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum HashLockType {
     ///SHA 256 hashlock
     Sha256(sha256::Hash),
@@ -444,7 +444,7 @@ pub enum HashLockType {
 /// A satisfied Miniscript condition (Signature, Hashlock, Timelock)
 /// 'intp represents the lifetime of descriptor and `stack represents
 /// the lifetime of witness
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum SatisfiedConstraint {
     ///Public key and corresponding signature
     PublicKey {

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -24,7 +24,7 @@ use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal};
 ///    guarantees are not satisfied.
 /// 4. It has repeated public keys
 /// 5. raw pkh fragments without the pk. This could be obtained when parsing miniscript from script
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
 pub struct ExtParams {
     /// Allow parsing of non-safe miniscripts
     pub top_unsafe: bool,

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -13,7 +13,7 @@ use super::Error;
 use crate::prelude::*;
 
 /// Atom of a tokenized version of a script
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Token<'s> {
     BoolAnd,

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -551,7 +551,7 @@ impl_tuple_satisfier!(A, B, C, D, E, F);
 impl_tuple_satisfier!(A, B, C, D, E, F, G);
 impl_tuple_satisfier!(A, B, C, D, E, F, G, H);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Type of schnorr signature to produce
 pub enum SchnorrSigType {
     /// Key spend signature
@@ -566,7 +566,7 @@ pub enum SchnorrSigType {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 /// Placeholder for some data in a [`Plan`]
 ///
 /// [`Plan`]: crate::plan::Plan
@@ -697,7 +697,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Placeholder<Pk> {
 }
 
 /// A witness, if available, for a Miniscript fragment
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Witness<T> {
     /// Witness Available and the value of the witness
     Stack(Vec<T>),
@@ -874,7 +874,7 @@ impl<Pk: MiniscriptKey> Witness<Placeholder<Pk>> {
 }
 
 /// A (dis)satisfaction of a Miniscript fragment
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Satisfaction<T> {
     /// The actual witness stack
     pub stack: Witness<T>,

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -40,7 +40,7 @@ impl Ord for OrdF64 {
 }
 
 /// Detailed error type for compiler.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum CompilerError {
     /// Compiler has non-safe input policy.
     TopLevelNonSafe,
@@ -96,7 +96,7 @@ impl hash::Hash for OrdF64 {
 
 /// Compilation key: This represents the state of the best possible compilation
 /// of a given policy(implicitly keyed).
-#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
 struct CompilationKey {
     /// The type of the compilation result
     ty: Type,

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -73,7 +73,7 @@ pub enum Policy<Pk: MiniscriptKey> {
 }
 
 /// Detailed error type for concrete policies.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum PolicyError {
     /// `And` fragments only support two args.
     NonBinaryArgAnd,

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -52,7 +52,7 @@ pub trait Liftable<Pk: MiniscriptKey> {
 }
 
 /// Error occurring during lifting.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum LiftError {
     /// Cannot lift policies that have a combination of height and timelocks.
     HeightTimelockCombination,


### PR DESCRIPTION
This commit dervies `Hash` for enums and structs which also derives `Eq`.

Fixes #226 