### PR TITLE
Upgrade bech32 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
 
 [dependencies]
-bech32 = { version = "0.10.0-beta", default-features = false }
+bech32 = { version = "0.11.0", default-features = false }
 bitcoin = { version = "0.31.0", default-features = false }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.

--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -19,6 +19,7 @@ use crate::prelude::*;
 use crate::Error;
 
 const CHECKSUM_LENGTH: usize = 8;
+const CODE_LENGTH: usize = 32767;
 
 /// Compute the checksum of a descriptor.
 ///
@@ -142,6 +143,7 @@ const GEN: [u64; 5] = [0xf5dee51989, 0xa9fdca3312, 0x1bab10e32d, 0x3706b1677a, 0
 impl Checksum for DescriptorChecksum {
     type MidstateRepr = u64; // We need 40 bits (8 * 5).
     const CHECKSUM_LENGTH: usize = CHECKSUM_LENGTH;
+    const CODE_LENGTH: usize = CODE_LENGTH;
     const GENERATOR_SH: [u64; 5] = GEN;
     const TARGET_RESIDUE: u64 = 1;
 }


### PR DESCRIPTION
Upgrade to the newest release of the `bech32` crate.
