### PR TITLE
Depend on bitcoin `v0.32.0-rc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "11.0.0"
+version = "12.0.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-miniscript/"
@@ -13,7 +13,7 @@ edition = "2018"
 [features]
 default = ["std"]
 std = ["bitcoin/std", "bitcoin/secp-recovery", "bech32/std"]
-no-std = ["bitcoin/no-std", "bech32/alloc"]
+no-std = ["bech32/alloc"]
 compiler = []
 trace = []
 
@@ -23,15 +23,15 @@ base64 = ["bitcoin/base64"]
 
 [dependencies]
 bech32 = { version = "0.11.0", default-features = false }
-bitcoin = { version = "0.31.0", default-features = false }
+bitcoin = { version = "0.32.0-rc1", default-features = false }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0.103", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.147"
-bitcoin = { version = "0.31.0", features = ["base64"] }
-secp256k1 = {version = "0.28.0", features = ["rand-std"]}
+bitcoin = { version = "0.32.0-rc1", features = ["base64"] }
+secp256k1 = {version = "0.29.0", features = ["rand-std"]}
 
 [[example]]
 name = "htlc"
@@ -68,3 +68,35 @@ required-features = ["std", "base64", "compiler"]
 [workspace]
 members = ["bitcoind-tests", "fuzz"]
 exclude = ["embedded"]
+
+[patch.crates-io.bitcoind]
+git = "https://github.com/tcharding/bitcoind/"
+branch = "test-bitcoin"
+
+[patch.crates-io.bitcoincore-rpc]
+git = "https://github.com/tcharding/rust-bitcoincore-rpc"
+branch = "test-bitcoin"
+
+[patch.crates-io.base58ck]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin_hashes]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-internals]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-io]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-units]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"

--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 
 [dependencies]
 miniscript = {path = "../"}
-bitcoind = { version = "0.34.0" }
+bitcoind = { version = "0.36.0" }
 actual-rand = { package = "rand", version = "0.8.4"}
-secp256k1 = {version = "0.28.0", features = ["rand-std"]}
+secp256k1 = {version = "0.29.0", features = ["rand-std"]}

--- a/bitcoind-tests/tests/test_cpp.rs
+++ b/bitcoind-tests/tests/test_cpp.rs
@@ -168,9 +168,9 @@ pub fn test_from_cpp_ms(cl: &Client, testdata: &TestData) {
         // Get the required sighash message
         let amt = btc(1);
         let mut sighash_cache = bitcoin::sighash::SighashCache::new(&psbts[i].unsigned_tx);
-        let sighash_ty = bitcoin::sighash::EcdsaSighashType::All;
+        let sighash_type = bitcoin::sighash::EcdsaSighashType::All;
         let sighash = sighash_cache
-            .p2wsh_signature_hash(0, &ms.encode(), amt, sighash_ty)
+            .p2wsh_signature_hash(0, &ms.encode(), amt, sighash_type)
             .unwrap();
 
         // requires both signing and verification because we check the tx
@@ -179,11 +179,11 @@ pub fn test_from_cpp_ms(cl: &Client, testdata: &TestData) {
 
         // Finally construct the signature and add to psbt
         for sk in sks_reqd {
-            let sig = secp.sign_ecdsa(&msg, &sk);
+            let signature = secp.sign_ecdsa(&msg, &sk);
             let pk = pks[sks.iter().position(|&x| x == sk).unwrap()];
             psbts[i].inputs[0]
                 .partial_sigs
-                .insert(pk, bitcoin::ecdsa::Signature { sig, hash_ty: sighash_ty });
+                .insert(pk, bitcoin::ecdsa::Signature { signature, sighash_type });
         }
         // Add the hash preimages to the psbt
         psbts[i].inputs[0]

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -134,7 +134,7 @@ fn main() {
 
     psbt.inputs[0]
         .partial_sigs
-        .insert(pk1, bitcoin::ecdsa::Signature { sig: sig1, hash_ty });
+        .insert(pk1, bitcoin::ecdsa::Signature { signature: sig1, sighash_type: hash_ty });
 
     println!("{:#?}", psbt);
     println!("{}", psbt);
@@ -150,7 +150,7 @@ fn main() {
 fn get_vout(tx: &Transaction, spk: &Script) -> (OutPoint, TxOut) {
     for (i, txout) in tx.clone().output.into_iter().enumerate() {
         if spk == &txout.script_pubkey {
-            return (OutPoint::new(tx.txid(), i as u32), txout);
+            return (OutPoint::new(tx.compute_txid(), i as u32), txout);
         }
     }
     panic!("Only call get vout on functions which have the expected outpoint");

--- a/examples/sign_multisig.rs
+++ b/examples/sign_multisig.rs
@@ -118,7 +118,7 @@ fn list_of_three_arbitrary_public_keys() -> Vec<bitcoin::PublicKey> {
 // a valid signature for this transaction; Miniscript does not verify the validity.
 fn random_signature_from_the_blockchain() -> ecdsa::Signature {
     ecdsa::Signature {
-        sig: secp256k1::ecdsa::Signature::from_str(
+        signature: secp256k1::ecdsa::Signature::from_str(
             "3045\
              0221\
              00f7c3648c390d87578cd79c8016940aa8e3511c4104cb78daa8fb8e429375efc1\
@@ -126,6 +126,6 @@ fn random_signature_from_the_blockchain() -> ecdsa::Signature {
              531d75c136272f127a5dc14acc0722301cbddc222262934151f140da345af177",
         )
         .unwrap(),
-        hash_ty: bitcoin::sighash::EcdsaSighashType::All,
+        sighash_type: bitcoin::sighash::EcdsaSighashType::All,
     }
 }

--- a/examples/verify_tx.rs
+++ b/examples/verify_tx.rs
@@ -87,9 +87,9 @@ fn main() {
 
     let iter = interpreter.iter_custom(Box::new(|key_sig: &KeySigPair| {
         let (pk, ecdsa_sig) = key_sig.as_ecdsa().expect("Ecdsa Sig");
-        ecdsa_sig.hash_ty == bitcoin::sighash::EcdsaSighashType::All
+        ecdsa_sig.sighash_type == bitcoin::sighash::EcdsaSighashType::All
             && secp
-                .verify_ecdsa(&message, &ecdsa_sig.sig, &pk.inner)
+                .verify_ecdsa(&message, &ecdsa_sig.signature, &pk.inner)
                 .is_ok()
     }));
 

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -273,7 +273,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
 
     /// Obtains the corresponding script pubkey for this descriptor.
     pub fn address(&self, network: Network) -> Address {
-        Address::p2pkh(&self.pk.to_public_key(), network)
+        Address::p2pkh(self.pk.to_public_key(), network)
     }
 
     /// Obtains the underlying miniscript for this descriptor.

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -7,7 +7,6 @@ use core::str::FromStr;
 use std::error;
 
 use bitcoin::bip32::{self, XKeyIdentifier};
-use bitcoin::hashes::hex::FromHex;
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash, HashEngine};
 use bitcoin::key::XOnlyPublicKey;
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1267,8 +1267,8 @@ mod tests {
             ) -> Option<bitcoin::ecdsa::Signature> {
                 if *pk == self.pk {
                     Some(bitcoin::ecdsa::Signature {
-                        sig: self.sig,
-                        hash_ty: bitcoin::sighash::EcdsaSighashType::All,
+                        signature: self.sig,
+                        sighash_type: bitcoin::sighash::EcdsaSighashType::All,
                     })
                 } else {
                     None
@@ -1534,11 +1534,11 @@ mod tests {
 
             satisfier.insert(
                 a,
-                bitcoin::ecdsa::Signature { sig: sig_a, hash_ty: EcdsaSighashType::All },
+                bitcoin::ecdsa::Signature { signature: sig_a, sighash_type: EcdsaSighashType::All },
             );
             satisfier.insert(
                 b,
-                bitcoin::ecdsa::Signature { sig: sig_b, hash_ty: EcdsaSighashType::All },
+                bitcoin::ecdsa::Signature { signature: sig_b, sighash_type: EcdsaSighashType::All },
             );
 
             satisfier

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -374,15 +374,23 @@ impl<Pk: MiniscriptKey> Wpkh<Pk> {
 impl<Pk: MiniscriptKey + ToPublicKey> Wpkh<Pk> {
     /// Obtains the corresponding script pubkey for this descriptor.
     pub fn script_pubkey(&self) -> ScriptBuf {
-        let addr = Address::p2wpkh(&self.pk.to_public_key(), Network::Bitcoin)
+        use core::convert::TryFrom;
+        let pk = self.pk.to_public_key();
+        let compressed = bitcoin::key::CompressedPublicKey::try_from(pk)
             .expect("wpkh descriptors have compressed keys");
+
+        let addr = Address::p2wpkh(&compressed, Network::Bitcoin);
         addr.script_pubkey()
     }
 
     /// Obtains the corresponding script pubkey for this descriptor.
     pub fn address(&self, network: Network) -> Address {
-        Address::p2wpkh(&self.pk.to_public_key(), network)
-            .expect("Rust Miniscript types don't allow uncompressed pks in segwit descriptors")
+        use core::convert::TryFrom;
+        let pk = self.pk.to_public_key();
+        let compressed = bitcoin::key::CompressedPublicKey::try_from(pk)
+            .expect("Rust Miniscript types don't allow uncompressed pks in segwit descriptors");
+
+        Address::p2wpkh(&compressed, network)
     }
 
     /// Obtains the underlying miniscript for this descriptor.
@@ -394,7 +402,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Wpkh<Pk> {
         // the previous txo's scriptPubKey.
         // The item 5:
         //     - For P2WPKH witness program, the scriptCode is `0x1976a914{20-byte-pubkey-hash}88ac`.
-        let addr = Address::p2pkh(&self.pk.to_public_key(), Network::Bitcoin);
+        let addr = Address::p2pkh(self.pk.to_public_key(), Network::Bitcoin);
         addr.script_pubkey()
     }
 

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -95,7 +95,7 @@ pub enum Error {
     /// Schnorr Signature error
     SchnorrSig(bitcoin::taproot::SigFromSliceError),
     /// Errors in signature hash calculations
-    SighashError(bitcoin::sighash::Error),
+    SighashError(bitcoin::sighash::InvalidSighashTypeError),
     /// Taproot Annex Unsupported
     TapAnnexUnsupported,
     /// An uncompressed public key was encountered in a context where it is
@@ -242,8 +242,8 @@ impl From<secp256k1::Error> for Error {
 }
 
 #[doc(hidden)]
-impl From<bitcoin::sighash::Error> for Error {
-    fn from(e: bitcoin::sighash::Error) -> Error { Error::SighashError(e) }
+impl From<bitcoin::sighash::InvalidSighashTypeError> for Error {
+    fn from(e: bitcoin::sighash::InvalidSighashTypeError) -> Error { Error::SighashError(e) }
 }
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,9 @@ pub enum Error {
     /// rust-bitcoin script error
     Script(script::Error),
     /// rust-bitcoin address error
-    AddrError(bitcoin::address::Error),
+    AddrError(bitcoin::address::ParseError),
+    /// rust-bitcoin p2sh address error
+    AddrP2shError(bitcoin::address::P2shError),
     /// A `CHECKMULTISIG` opcode was preceded by a number > 20
     CmsTooManyKeys(u32),
     /// A tapscript multi_a cannot support more than Weight::MAX_BLOCK/32 keys
@@ -513,6 +515,7 @@ impl fmt::Display for Error {
             },
             Error::Script(ref e) => fmt::Display::fmt(e, f),
             Error::AddrError(ref e) => fmt::Display::fmt(e, f),
+            Error::AddrP2shError(ref e) => fmt::Display::fmt(e, f),
             Error::CmsTooManyKeys(n) => write!(f, "checkmultisig with {} keys", n),
             Error::Unprintable(x) => write!(f, "unprintable character 0x{:02x}", x),
             Error::ExpectedChar(c) => write!(f, "expected {}", c),
@@ -593,6 +596,7 @@ impl error::Error for Error {
             | MultipathDescLenMismatch => None,
             Script(e) => Some(e),
             AddrError(e) => Some(e),
+            AddrP2shError(e) => Some(e),
             Secp(e) => Some(e),
             #[cfg(feature = "compiler")]
             CompilerError(e) => Some(e),
@@ -635,8 +639,13 @@ impl From<bitcoin::secp256k1::Error> for Error {
 }
 
 #[doc(hidden)]
-impl From<bitcoin::address::Error> for Error {
-    fn from(e: bitcoin::address::Error) -> Error { Error::AddrError(e) }
+impl From<bitcoin::address::ParseError> for Error {
+    fn from(e: bitcoin::address::ParseError) -> Error { Error::AddrError(e) }
+}
+
+#[doc(hidden)]
+impl From<bitcoin::address::P2shError> for Error {
+    fn from(e: bitcoin::address::P2shError) -> Error { Error::AddrP2shError(e) }
 }
 
 #[doc(hidden)]

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -48,7 +48,7 @@ impl ParseableKey for bitcoin::secp256k1::XOnlyPublicKey {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyParseError {
     /// Bitcoin PublicKey parse error
-    FullKeyParseError(bitcoin::key::Error),
+    FullKeyParseError(bitcoin::key::FromSliceError),
     /// Xonly key parse Error
     XonlyKeyParseError(bitcoin::secp256k1::Error),
 }

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1288,8 +1288,8 @@ mod tests {
                 _h: &TapLeafHash,
             ) -> Option<bitcoin::taproot::Signature> {
                 Some(bitcoin::taproot::Signature {
-                    sig: self.0,
-                    hash_ty: bitcoin::sighash::TapSighashType::Default,
+                    signature: self.0,
+                    sighash_type: bitcoin::sighash::TapSighashType::Default,
                 })
             }
         }
@@ -1419,8 +1419,8 @@ mod tests {
             ) -> Option<bitcoin::taproot::Signature> {
                 if pk == &self.1 {
                     Some(bitcoin::taproot::Signature {
-                        sig: self.0,
-                        hash_ty: bitcoin::sighash::TapSighashType::Default,
+                        signature: self.0,
+                        sighash_type: bitcoin::sighash::TapSighashType::Default,
                     })
                 } else {
                     None

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1312,7 +1312,7 @@ mod tests {
     #[test]
     #[allow(clippy::needless_range_loop)]
     fn compile_misc() {
-        let (keys, sig) = pubkeys_and_a_sig(10);
+        let (keys, signature) = pubkeys_and_a_sig(10);
         let key_pol: Vec<BPolicy> = keys.iter().map(|k| Concrete::Key(*k)).collect();
 
         let policy: BPolicy = Concrete::Key(keys[0]);
@@ -1399,8 +1399,10 @@ mod tests {
         assert_eq!(abs.n_keys(), 5);
         assert_eq!(abs.minimum_n_keys(), Some(3));
 
-        let bitcoinsig =
-            bitcoin::ecdsa::Signature { sig, hash_ty: bitcoin::sighash::EcdsaSighashType::All };
+        let bitcoinsig = bitcoin::ecdsa::Signature {
+            signature,
+            sighash_type: bitcoin::sighash::EcdsaSighashType::All,
+        };
         let sigvec = bitcoinsig.to_vec();
 
         let no_sat = BTreeMap::<bitcoin::PublicKey, bitcoin::ecdsa::Signature>::new();

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -174,7 +174,7 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
             // Partial sigs loses the compressed flag that is necessary
             // TODO: See https://github.com/rust-bitcoin/rust-bitcoin/pull/836
             // The type checker will fail again after we update to 0.28 and this can be removed
-            let addr = bitcoin::Address::p2pkh(&pk, bitcoin::Network::Bitcoin);
+            let addr = bitcoin::Address::p2pkh(pk, bitcoin::Network::Bitcoin);
             *script_pubkey == addr.script_pubkey()
         });
         match partial_sig_contains_pk {
@@ -184,11 +184,16 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
     } else if script_pubkey.is_p2wpkh() {
         // 3. `Wpkh`: creates a `wpkh` descriptor if the partial sig has corresponding pk.
         let partial_sig_contains_pk = inp.partial_sigs.iter().find(|&(&pk, _sig)| {
-            // Indirect way to check the equivalence of pubkey-hashes.
-            // Create a pubkey hash and check if they are the same.
-            let addr = bitcoin::Address::p2wpkh(&pk, bitcoin::Network::Bitcoin)
-                .expect("Address corresponding to valid pubkey");
-            *script_pubkey == addr.script_pubkey()
+            use core::convert::TryFrom;
+            match bitcoin::key::CompressedPublicKey::try_from(pk) {
+                Ok(compressed) => {
+                    // Indirect way to check the equivalence of pubkey-hashes.
+                    // Create a pubkey hash and check if they are the same.
+                    let addr = bitcoin::Address::p2wpkh(&compressed, bitcoin::Network::Bitcoin);
+                    *script_pubkey == addr.script_pubkey()
+                }
+                Err(_) => false,
+            }
         });
         match partial_sig_contains_pk {
             Some((pk, _sig)) => Ok(Descriptor::new_wpkh(*pk)?),
@@ -244,9 +249,17 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
                 } else if redeem_script.is_p2wpkh() {
                     // 6. `ShWpkh` case
                     let partial_sig_contains_pk = inp.partial_sigs.iter().find(|&(&pk, _sig)| {
-                        let addr = bitcoin::Address::p2wpkh(&pk, bitcoin::Network::Bitcoin)
-                            .expect("Address corresponding to valid pubkey");
-                        *redeem_script == addr.script_pubkey()
+                        use core::convert::TryFrom;
+                        match bitcoin::key::CompressedPublicKey::try_from(pk) {
+                            Ok(compressed) => {
+                                let addr = bitcoin::Address::p2wpkh(
+                                    &compressed,
+                                    bitcoin::Network::Bitcoin,
+                                );
+                                *redeem_script == addr.script_pubkey()
+                            }
+                            Err(_) => false,
+                        }
                     });
                     match partial_sig_contains_pk {
                         Some((pk, _sig)) => Ok(Descriptor::new_sh_wpkh(*pk)?),


### PR DESCRIPTION
Test the latest bitcoin release candidate. Includes bumping the version numbers so we can use this branch to test crates further up the stack.
    
Requires the `rc-fixes` branch.
