### PR TITLE
Manually implement is_uncompressed for BitcoinKey

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -123,6 +123,13 @@ impl MiniscriptKey for BitcoinKey {
     type Hash256 = hash256::Hash;
     type Ripemd160 = ripemd160::Hash;
     type Hash160 = hash160::Hash;
+
+    fn is_uncompressed(&self) -> bool {
+        match *self {
+            BitcoinKey::Fullkey(pk) => !pk.compressed,
+            BitcoinKey::XOnlyPublicKey(_) => false,
+        }
+    }
 }
 
 impl<'txin> Interpreter<'txin> {


### PR DESCRIPTION
The `interpreter::BitcoinKey` uses the default implementation of `MiniscriptKey`, which means `is_uncompressed` returns `false`. However if the full key is a `bitcoin::PublicKey` it may be compressed.

Manually implement `MiniscriptKey::is_uncompressed` for `BitcoinKey` and return the compressedness of the inner full key.

Originally done, and discussed, in #620.