### PR TITLE
Remove explicit link target

### DIFF
--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -563,7 +563,7 @@ pub trait PsbtExt {
     ///
     /// Based on the sighash
     /// flag specified in the [`Psbt`] sighash field. If the input sighash flag psbt field is `None`
-    /// the [`sighash::TapSighashType::Default`](bitcoin::sighash::TapSighashType::Default) is chosen
+    /// the [`sighash::TapSighashType::Default`] is chosen
     /// for for taproot spends, otherwise [`EcdsaSighashType::All`](bitcoin::sighash::EcdsaSighashType::All) is chosen.
     /// If the utxo at `idx` is a taproot output, returns a [`PsbtSighashMsg::TapSighash`] variant.
     /// If the utxo at `idx` is a pre-taproot segwit output, returns a [`PsbtSighashMsg::SegwitV0Sighash`] variant.


### PR DESCRIPTION
When building the rustdocs clippy emits:

  warning: redundant explicit link target

As suggested, remove the explicit link target. Do not fix column width because this rustdoc block is already a mess - just make the change while keeping the diff small.