### PR TITLE
Fix all lint errors and warnings

### DIFF
--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -19,7 +19,7 @@ fn main() {
     let secp256k1 = secp256k1::Secp256k1::new();
 
     let s = "wsh(t:or_c(pk(027a3565454fe1b749bccaef22aff72843a9c3efefd7b16ac54537a0c23f0ec0de),v:thresh(1,pkh(032d672a1a91cc39d154d366cd231983661b0785c7f27bc338447565844f4a6813),a:pkh(03417129311ed34c242c012cd0a3e0b9bca0065f742d0dfb63c78083ea6a02d4d9),a:pkh(025a687659658baeabdfc415164528065be7bcaade19342241941e556557f01e28))))#7hut9ukn";
-    let bridge_descriptor = Descriptor::from_str(&s).unwrap();
+    let bridge_descriptor = Descriptor::from_str(s).unwrap();
     //let bridge_descriptor = Descriptor::<bitcoin::PublicKey>::from_str(&s).expect("parse descriptor string");
     assert!(bridge_descriptor.sanity_check().is_ok());
     println!("Bridge pubkey script: {}", bridge_descriptor.script_pubkey());

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -133,7 +133,7 @@ fn main() {
 
     psbt.inputs[0]
         .partial_sigs
-        .insert(pk1, bitcoin::ecdsa::Signature { sig: sig1, hash_ty: hash_ty });
+        .insert(pk1, bitcoin::ecdsa::Signature { sig: sig1, hash_ty });
 
     println!("{:#?}", psbt);
     println!("{}", psbt);

--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -81,10 +81,11 @@ fn main() {
 
     let (outpoint, witness_utxo) = get_vout(&depo_tx, &bridge_descriptor.script_pubkey());
 
-    let mut txin = TxIn::default();
-    txin.previous_output = outpoint;
-
-    txin.sequence = Sequence::from_height(26); //Sequence::MAX; //
+    let txin = TxIn {
+        previous_output: outpoint,
+        sequence: Sequence::from_height(26),
+        ..Default::default()
+    };
     psbt.unsigned_tx.input.push(txin);
 
     psbt.unsigned_tx.output.push(TxOut {

--- a/examples/taproot.rs
+++ b/examples/taproot.rs
@@ -136,8 +136,8 @@ fn hardcoded_xonlypubkeys() -> Vec<XOnlyPublicKey> {
         ],
     ];
     let mut keys: Vec<XOnlyPublicKey> = vec![];
-    for idx in 0..4 {
-        keys.push(XOnlyPublicKey::from_slice(&serialized_keys[idx][..]).unwrap());
+    for key in serialized_keys {
+        keys.push(XOnlyPublicKey::from_slice(&key).unwrap());
     }
     keys
 }

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1351,6 +1351,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_range_loop)]
     fn compile_misc() {
         let (keys, sig) = pubkeys_and_a_sig(10);
         let key_pol: Vec<BPolicy> = keys.iter().map(|k| Concrete::Key(*k)).collect();

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1617,7 +1617,7 @@ mod tests {
             .map(|pubkey| Arc::new(Concrete::Key(*pubkey)))
             .collect();
         let thresh_res = Concrete::Thresh(keys.len() - 1, keys).compile::<Legacy>();
-        let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops.op_count()));
+        let ops_count = thresh_res.clone().map(|m| m.ext.ops.op_count());
         assert_eq!(
             thresh_res,
             Err(CompilerError::LimitsExceeded),

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1273,7 +1273,7 @@ mod tests {
             ret.push(pk);
         }
         let sig = secp.sign_ecdsa(
-            &secp256k1::Message::from_digest(sk.clone()), // Not a digest but 32 bytes nonetheless.
+            &secp256k1::Message::from_digest(sk), // Not a digest but 32 bytes nonetheless.
             &secp256k1::SecretKey::from_slice(&sk[..]).expect("secret key"),
         );
         (ret, sig)
@@ -1355,7 +1355,7 @@ mod tests {
         let (keys, sig) = pubkeys_and_a_sig(10);
         let key_pol: Vec<BPolicy> = keys.iter().map(|k| Concrete::Key(*k)).collect();
 
-        let policy: BPolicy = Concrete::Key(keys[0].clone());
+        let policy: BPolicy = Concrete::Key(keys[0]);
         let ms: SegwitMiniScript = policy.compile().unwrap();
         assert_eq!(
             ms.encode(),

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1567,7 +1567,7 @@ mod tests {
             (1, Arc::new(Concrete::Thresh(keys_b.len(), keys_b))),
         ])
         .compile();
-        let script_size = thresh_res.clone().and_then(|m| Ok(m.script_size()));
+        let script_size = thresh_res.clone().map(|m| m.script_size());
         assert_eq!(
             thresh_res,
             Err(CompilerError::LimitsExceeded),
@@ -1584,7 +1584,7 @@ mod tests {
         let thresh_res: Result<SegwitMiniScript, _> = Concrete::Thresh(keys.len(), keys).compile();
         let n_elements = thresh_res
             .clone()
-            .and_then(|m| Ok(m.max_satisfaction_witness_elements()));
+            .map(|m| m.max_satisfaction_witness_elements());
         assert_eq!(
             thresh_res,
             Err(CompilerError::LimitsExceeded),
@@ -1603,7 +1603,7 @@ mod tests {
             .collect();
         let thresh_res: Result<SegwitMiniScript, _> =
             Concrete::Thresh(keys.len() - 1, keys).compile();
-        let ops_count = thresh_res.clone().and_then(|m| Ok(m.ext.ops.op_count()));
+        let ops_count = thresh_res.clone().map(|m| m.ext.ops.op_count());
         assert_eq!(
             thresh_res,
             Err(CompilerError::LimitsExceeded),

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -1105,7 +1105,7 @@ mod compiler_tests {
         let policies: Vec<Arc<Concrete<String>>> = vec!["pk(A)", "pk(B)", "pk(C)", "pk(D)"]
             .into_iter()
             .map(|st| policy_str!("{}", st))
-            .map(|p| Arc::new(p))
+            .map(Arc::new)
             .collect();
 
         let combinations = generate_combination(&policies, 1.0, 2);
@@ -1133,10 +1133,7 @@ mod compiler_tests {
         let expected_comb = vec![comb_a, comb_b, comb_c, comb_d]
             .into_iter()
             .map(|sub_pol| {
-                (
-                    0.25,
-                    Arc::new(Policy::Thresh(2, sub_pol.into_iter().map(|p| Arc::new(p)).collect())),
-                )
+                (0.25, Arc::new(Policy::Thresh(2, sub_pol.into_iter().map(Arc::new).collect())))
             })
             .collect::<Vec<_>>();
         assert_eq!(combinations, expected_comb);

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -453,7 +453,7 @@ mod tests {
                 .iter()
                 .zip(node_probabilities.iter())
                 .collect::<Vec<_>>();
-            sorted_policy_prob.sort_by(|a, b| (a.1).partial_cmp(&b.1).unwrap());
+            sorted_policy_prob.sort_by(|a, b| (a.1).partial_cmp(b.1).unwrap());
             let sorted_policies = sorted_policy_prob
                 .into_iter()
                 .map(|(x, _prob)| x)


### PR DESCRIPTION
After doing #668 I wanted to be able to use the `just sane` command before pushing PRs, so fix the lint issues.
