### PR TITLE
test: Add max_weight_to_satisfy test

### DIFF
--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -54,26 +54,36 @@ fn script_from_stack_elem<Ctx: ScriptContext>(
 /// Helper type to indicate the origin of the bare pubkey that the interpereter uses
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum PubkeyType {
+    /// TODO
     Pk,
+    /// TODO
     Pkh,
+    /// TODO
     Wpkh,
+    /// TODO
     ShWpkh,
+    /// TODO
     Tr, // Key Spend
 }
 
 /// Helper type to indicate the origin of the bare miniscript that the interpereter uses
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ScriptType {
+    /// TODO
     Bare,
+    /// TODO
     Sh,
+    /// TODO
     Wsh,
+    /// TODO
     ShWsh,
+    /// TODO
     Tr, // Script Spend
 }
 
 /// Structure representing a script under evaluation as a Miniscript
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
-pub(super) enum Inner {
+pub enum Inner {
     /// The script being evaluated is a simple public key check (pay-to-pk,
     /// pay-to-pkhash or pay-to-witness-pkhash)
     // Technically, this allows representing a (XonlyKey, Sh) output but we make sure

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -20,8 +20,10 @@ use crate::prelude::*;
 use crate::{hash256, Descriptor, Miniscript, Terminal, ToPublicKey};
 
 mod error;
-mod inner;
-mod stack;
+/// TODO
+pub mod inner;
+/// TODO
+pub mod stack;
 
 pub use self::error::Error;
 use self::error::PkEvalErrInner;
@@ -30,13 +32,17 @@ use crate::MiniscriptKey;
 
 /// An iterable Miniscript-structured representation of the spending of a coin
 pub struct Interpreter<'txin> {
-    inner: inner::Inner,
-    stack: Stack<'txin>,
+    /// TODO
+    pub inner: inner::Inner,
+    /// TODO
+    pub stack: Stack<'txin>,
     /// For non-Taproot spends, the scriptCode; for Taproot script-spends, this
     /// is the leaf script; for key-spends it is `None`.
-    script_code: Option<bitcoin::ScriptBuf>,
-    sequence: Sequence,
-    lock_time: absolute::LockTime,
+    pub script_code: Option<bitcoin::ScriptBuf>,
+    /// TODO
+    pub sequence: Sequence,
+    /// TODO
+    pub lock_time: absolute::LockTime,
 }
 
 // A type representing functions for checking signatures that accept both
@@ -84,10 +90,11 @@ impl KeySigPair {
 // require changing Miniscript struct to three generics Miniscript<Pk, Pkh, Ctx> and bound on
 // all of the methods of Miniscript to ensure that Pkh = Pk::Hash
 #[derive(Hash, Eq, Ord, PartialEq, PartialOrd, Clone, Copy, Debug)]
-enum BitcoinKey {
-    // Full key
+/// TODO
+pub enum BitcoinKey {
+    /// Full key
     Fullkey(bitcoin::PublicKey),
-    // Xonly key
+    /// Xonly key
     XOnlyPublicKey(bitcoin::key::XOnlyPublicKey),
 }
 


### PR DESCRIPTION
Add a test for `max_weight_to_satisfy`.  Marking as a draft for now since I had to change the visibility of a few things which may not be desirable.  However, I'm looking to possibly use this in an external crate, so the visibility may need to be adjusted to make that viable.  Also of note that most key types return an error when tying to compute the satisfaction weight.