### PR TITLE
Use `Threshold` type in concrete policy and in Terminal::multi/multi_a

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1492,7 +1492,7 @@ mod tests {
     #[test]
     fn roundtrip_tests() {
         let descriptor = Descriptor::<bitcoin::PublicKey>::from_str("multi");
-        assert_eq!(descriptor.unwrap_err().to_string(), "unexpected «no arguments given»")
+        assert_eq!(descriptor.unwrap_err().to_string(), "expected threshold, found terminal",);
     }
 
     #[test]

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -29,7 +29,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// them.
     pub fn branches(&self) -> Vec<&Miniscript<Pk, Ctx>> {
         match self.node {
-            Terminal::PkK(_) | Terminal::PkH(_) | Terminal::RawPkH(_) | Terminal::Multi(_, _) => {
+            Terminal::PkK(_) | Terminal::PkH(_) | Terminal::RawPkH(_) | Terminal::Multi(_) => {
                 vec![]
             }
 
@@ -94,10 +94,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// NB: The function analyzes only single miniscript item and not any of its descendants in AST.
     pub fn get_nth_pk(&self, n: usize) -> Option<Pk> {
         match (&self.node, n) {
-            (&Terminal::PkK(ref key), 0) | (&Terminal::PkH(ref key), 0) => Some(key.clone()),
-            (&Terminal::Multi(_, ref keys), _) | (&Terminal::MultiA(_, ref keys), _) => {
-                keys.get(n).cloned()
-            }
+            (Terminal::PkK(key), 0) | (Terminal::PkH(key), 0) => Some(key.clone()),
+            (Terminal::Multi(thresh), _) => thresh.data().get(n).cloned(),
+            (Terminal::MultiA(thresh), _) => thresh.data().get(n).cloned(),
             _ => None,
         }
     }

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -902,25 +902,8 @@ impl ExtData {
             Terminal::False => Self::FALSE,
             Terminal::PkK(..) => Self::pk_k::<Ctx>(),
             Terminal::PkH(..) | Terminal::RawPkH(..) => Self::pk_h::<Ctx>(),
-            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
-                if k == 0 {
-                    return Err(Error {
-                        fragment_string: fragment.to_string(),
-                        error: ErrorKind::ZeroThreshold,
-                    });
-                }
-                if k > pks.len() {
-                    return Err(Error {
-                        fragment_string: fragment.to_string(),
-                        error: ErrorKind::OverThreshold(k, pks.len()),
-                    });
-                }
-                match *fragment {
-                    Terminal::Multi(..) => Self::multi(k, pks.len()),
-                    Terminal::MultiA(..) => Self::multi_a(k, pks.len()),
-                    _ => unreachable!(),
-                }
-            }
+            Terminal::Multi(ref thresh) => Self::multi(thresh.k(), thresh.n()),
+            Terminal::MultiA(ref thresh) => Self::multi_a(thresh.k(), thresh.n()),
             Terminal::After(t) => Self::after(t),
             Terminal::Older(t) => Self::older(t),
             Terminal::Sha256(..) => Self::sha256(),

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -436,25 +436,8 @@ impl Type {
             Terminal::False => Ok(Self::FALSE),
             Terminal::PkK(..) => Ok(Self::pk_k()),
             Terminal::PkH(..) | Terminal::RawPkH(..) => Ok(Self::pk_h()),
-            Terminal::Multi(k, ref pks) | Terminal::MultiA(k, ref pks) => {
-                if k == 0 {
-                    return Err(Error {
-                        fragment_string: fragment.to_string(),
-                        error: ErrorKind::ZeroThreshold,
-                    });
-                }
-                if k > pks.len() {
-                    return Err(Error {
-                        fragment_string: fragment.to_string(),
-                        error: ErrorKind::OverThreshold(k, pks.len()),
-                    });
-                }
-                match *fragment {
-                    Terminal::Multi(..) => Ok(Self::multi()),
-                    Terminal::MultiA(..) => Ok(Self::multi_a()),
-                    _ => unreachable!(),
-                }
-            }
+            Terminal::Multi(..) => Ok(Self::multi()),
+            Terminal::MultiA(..) => Ok(Self::multi_a()),
             Terminal::After(_) => Ok(Self::time()),
             Terminal::Older(_) => Ok(Self::time()),
             Terminal::Sha256(..) => Ok(Self::hash()),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -164,14 +164,15 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
                 // unwrap to be removed in a later commit
                 Semantic::Thresh(Threshold::new(k, semantic_subs).unwrap())
             }
-            Terminal::Multi(k, ref keys) | Terminal::MultiA(k, ref keys) => Semantic::Thresh(
-                Threshold::new(
-                    k,
-                    keys.iter()
-                        .map(|k| Arc::new(Semantic::Key(k.clone())))
-                        .collect(),
-                )
-                .unwrap(), // unwrap to be removed in a later commit
+            Terminal::Multi(ref thresh) => Semantic::Thresh(
+                thresh
+                    .map_ref(|key| Arc::new(Semantic::Key(key.clone())))
+                    .forget_maximum(),
+            ),
+            Terminal::MultiA(ref thresh) => Semantic::Thresh(
+                thresh
+                    .map_ref(|key| Arc::new(Semantic::Key(key.clone())))
+                    .forget_maximum(),
             ),
         }
         .normalized();

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -223,11 +223,8 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
                 let semantic_subs = semantic_subs?.into_iter().map(Arc::new).collect();
                 Semantic::Thresh(Threshold::new(1, semantic_subs).unwrap())
             }
-            Concrete::Thresh(k, ref subs) => {
-                let semantic_subs: Result<Vec<Semantic<Pk>>, Error> =
-                    subs.iter().map(Liftable::lift).collect();
-                let semantic_subs = semantic_subs?.into_iter().map(Arc::new).collect();
-                Semantic::Thresh(Threshold::new(k, semantic_subs).unwrap())
+            Concrete::Thresh(ref thresh) => {
+                Semantic::Thresh(thresh.translate_ref(|sub| Liftable::lift(sub).map(Arc::new))?)
             }
         }
         .normalized();
@@ -307,13 +304,13 @@ mod tests {
             ConcretePol::from_str("thresh(2,pk(),thresh(0))")
                 .unwrap_err()
                 .to_string(),
-            "Threshold k must be greater than 0 and less than or equal to n 0<k<=n"
+            "thresholds in Miniscript must be nonempty",
         );
         assert_eq!(
             ConcretePol::from_str("thresh(2,pk(),thresh(0,pk()))")
                 .unwrap_err()
                 .to_string(),
-            "Threshold k must be greater than 0 and less than or equal to n 0<k<=n"
+            "thresholds in Miniscript must have k > 0",
         );
         assert_eq!(
             ConcretePol::from_str("and(pk())").unwrap_err().to_string(),


### PR DESCRIPTION
Some more large but mostly-mechanical diffs. This is able to eliminate a bunch of error paths, though the actual error variants can't be removed until we also convert Terminal::thresh in the next PR(s). At that point we will start to see the real benefits of this type because fallible functions will become fallible and massive amounts of compiler error-checking can just go away entirely.

Also removes the allocation in `SortedMulti::constructor_check` that was pointed out in #660.