### PR TITLE
Use threshold in Terminal and Satisfaction

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1498,7 +1498,7 @@ mod tests {
     #[test]
     fn empty_thresh() {
         let descriptor = Descriptor::<bitcoin::PublicKey>::from_str("thresh");
-        assert_eq!(descriptor.unwrap_err().to_string(), "unexpected «no arguments given»")
+        assert_eq!(descriptor.unwrap_err().to_string(), "expected threshold, found terminal");
     }
 
     #[test]

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -800,16 +800,20 @@ where
                         None => return Some(Err(Error::UnexpectedStackEnd)),
                     }
                 }
-                Terminal::Thresh(ref _k, ref subs) if node_state.n_evaluated == 0 => {
+                Terminal::Thresh(ref thresh) if node_state.n_evaluated == 0 => {
                     self.push_evaluation_state(node_state.node, 1, 0);
-                    self.push_evaluation_state(&subs[0], 0, 0);
+                    self.push_evaluation_state(&thresh.data()[0], 0, 0);
                 }
-                Terminal::Thresh(k, ref subs) if node_state.n_evaluated == subs.len() => {
+                Terminal::Thresh(ref thresh) if node_state.n_evaluated == thresh.n() => {
                     match self.stack.pop() {
-                        Some(stack::Element::Dissatisfied) if node_state.n_satisfied == k => {
+                        Some(stack::Element::Dissatisfied)
+                            if node_state.n_satisfied == thresh.k() =>
+                        {
                             self.stack.push(stack::Element::Satisfied)
                         }
-                        Some(stack::Element::Satisfied) if node_state.n_satisfied == k - 1 => {
+                        Some(stack::Element::Satisfied)
+                            if node_state.n_satisfied == thresh.k() - 1 =>
+                        {
                             self.stack.push(stack::Element::Satisfied)
                         }
                         Some(stack::Element::Satisfied) | Some(stack::Element::Dissatisfied) => {
@@ -821,7 +825,7 @@ where
                         None => return Some(Err(Error::UnexpectedStackEnd)),
                     }
                 }
-                Terminal::Thresh(ref _k, ref subs) if node_state.n_evaluated != 0 => {
+                Terminal::Thresh(ref thresh) if node_state.n_evaluated != 0 => {
                     match self.stack.pop() {
                         Some(stack::Element::Dissatisfied) => {
                             self.push_evaluation_state(
@@ -829,7 +833,11 @@ where
                                 node_state.n_evaluated + 1,
                                 node_state.n_satisfied,
                             );
-                            self.push_evaluation_state(&subs[node_state.n_evaluated], 0, 0);
+                            self.push_evaluation_state(
+                                &thresh.data()[node_state.n_evaluated],
+                                0,
+                                0,
+                            );
                         }
                         Some(stack::Element::Satisfied) => {
                             self.push_evaluation_state(
@@ -837,7 +845,11 @@ where
                                 node_state.n_evaluated + 1,
                                 node_state.n_satisfied + 1,
                             );
-                            self.push_evaluation_state(&subs[node_state.n_evaluated], 0, 0);
+                            self.push_evaluation_state(
+                                &thresh.data()[node_state.n_evaluated],
+                                0,
+                                0,
+                            );
                         }
                         Some(stack::Element::Push(_v)) => {
                             return Some(Err(Error::UnexpectedStackElementPush))

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -37,7 +37,7 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> TreeLike for &'a Miniscript<Pk, 
             | OrC(ref left, ref right)
             | OrI(ref left, ref right) => Tree::Binary(left, right),
             AndOr(ref a, ref b, ref c) => Tree::Nary(Arc::from([a.as_ref(), b, c])),
-            Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::as_ref).collect()),
+            Thresh(ref thresh) => Tree::Nary(thresh.iter().map(Arc::as_ref).collect()),
         }
     }
 }
@@ -64,7 +64,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TreeLike for Arc<Miniscript<Pk, Ctx>
             AndOr(ref a, ref b, ref c) => {
                 Tree::Nary(Arc::from([Arc::clone(a), Arc::clone(b), Arc::clone(c)]))
             }
-            Thresh(_, ref subs) => Tree::Nary(subs.iter().map(Arc::clone).collect()),
+            Thresh(ref thresh) => Tree::Nary(thresh.iter().map(Arc::clone).collect()),
         }
     }
 }

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -181,7 +181,7 @@ pub enum Terminal<Pk: MiniscriptKey, Ctx: ScriptContext> {
     OrI(Arc<Miniscript<Pk, Ctx>>, Arc<Miniscript<Pk, Ctx>>),
     // Thresholds
     /// `[E] ([W] ADD)* k EQUAL`
-    Thresh(usize, Vec<Arc<Miniscript<Pk, Ctx>>>),
+    Thresh(Threshold<Arc<Miniscript<Pk, Ctx>>, 0>),
     /// `k (<key>)* n CHECKMULTISIG`
     Multi(Threshold<Pk, MAX_PUBKEYS_PER_MULTISIG>),
     /// `<key> CHECKSIG (<key> CHECKSIGADD)*(n-1) k NUMEQUAL`
@@ -549,7 +549,7 @@ pub fn parse<Ctx: ScriptContext>(
                 for _ in 0..n {
                     subs.push(Arc::new(term.pop().unwrap()));
                 }
-                term.reduce0(Terminal::Thresh(k, subs))?;
+                term.reduce0(Terminal::Thresh(Threshold::new(k, subs).map_err(Error::Threshold)?))?;
             }
             Some(NonTerm::EndIf) => {
                 match_token!(

--- a/src/miniscript/iter.rs
+++ b/src/miniscript/iter.rs
@@ -50,7 +50,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 
             Terminal::AndOr(ref node1, ref node2, ref node3) => vec![node1, node2, node3],
 
-            Terminal::Thresh(_, ref node_vec) => node_vec.iter().map(Arc::deref).collect(),
+            Terminal::Thresh(ref thresh) => thresh.iter().map(Arc::deref).collect(),
 
             _ => vec![],
         }
@@ -82,7 +82,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
             | (1, Terminal::AndOr(_, node, _))
             | (2, Terminal::AndOr(_, _, node)) => Some(node),
 
-            (n, Terminal::Thresh(_, node_vec)) => node_vec.get(n).map(|x| &**x),
+            (n, Terminal::Thresh(thresh)) => thresh.data().get(n).map(|x| &**x),
 
             _ => None,
         }

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -148,11 +148,10 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
                 Terminal::After(n) => script_num_size(n.to_consensus_u32() as usize) + 1,
                 Terminal::Older(n) => script_num_size(n.to_consensus_u32() as usize) + 1,
                 Terminal::Verify(ref sub) => usize::from(!sub.ext.has_free_verify),
-                Terminal::Thresh(k, ref subs) => {
-                    assert!(!subs.is_empty(), "threshold must be nonempty");
-                    script_num_size(k) // k
+                Terminal::Thresh(ref thresh) => {
+                    script_num_size(thresh.k()) // k
                         + 1 // EQUAL
-                        + subs.len() // ADD
+                        + thresh.n() // ADD
                         - 1 // no ADD on first element
                 }
                 Terminal::Multi(ref thresh) => {
@@ -492,9 +491,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
                 Terminal::OrD(..) => Terminal::OrD(child_n(0), child_n(1)),
                 Terminal::OrC(..) => Terminal::OrC(child_n(0), child_n(1)),
                 Terminal::OrI(..) => Terminal::OrI(child_n(0), child_n(1)),
-                Terminal::Thresh(k, ref subs) => {
-                    Terminal::Thresh(k, (0..subs.len()).map(child_n).collect())
-                }
+                Terminal::Thresh(ref thresh) => Terminal::Thresh(
+                    thresh.map_from_post_order_iter(&data.child_indices, &translated),
+                ),
                 Terminal::Multi(ref thresh) => Terminal::Multi(thresh.translate_ref(|k| t.pk(k))?),
                 Terminal::MultiA(ref thresh) => {
                     Terminal::MultiA(thresh.translate_ref(|k| t.pk(k))?)

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -6,7 +6,7 @@
 //! scriptpubkeys.
 //!
 
-use core::{cmp, fmt, i64, mem};
+use core::{cmp, fmt, mem};
 
 use bitcoin::hashes::hash160;
 use bitcoin::key::XOnlyPublicKey;

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -19,7 +19,8 @@ use crate::plan::AssetProvider;
 use crate::prelude::*;
 use crate::util::witness_size;
 use crate::{
-    AbsLockTime, Miniscript, MiniscriptKey, RelLockTime, ScriptContext, Terminal, ToPublicKey,
+    AbsLockTime, Miniscript, MiniscriptKey, RelLockTime, ScriptContext, Terminal, Threshold,
+    ToPublicKey,
 };
 
 /// Type alias for 32 byte Preimage.
@@ -930,8 +931,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
 
     // produce a non-malleable satisafaction for thesh frag
     fn thresh<Ctx, Sat, F>(
-        k: usize,
-        subs: &[Arc<Miniscript<Pk, Ctx>>],
+        thresh: &Threshold<Arc<Miniscript<Pk, Ctx>>, 0>,
         stfr: &Sat,
         root_has_sig: bool,
         leaf_hash: &TapLeafHash,
@@ -945,7 +945,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
             Satisfaction<Placeholder<Pk>>,
         ) -> Satisfaction<Placeholder<Pk>>,
     {
-        let mut sats = subs
+        let mut sats = thresh
             .iter()
             .map(|s| {
                 Self::satisfy_helper(
@@ -959,7 +959,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
             })
             .collect::<Vec<_>>();
         // Start with the to-return stack set to all dissatisfactions
-        let mut ret_stack = subs
+        let mut ret_stack = thresh
             .iter()
             .map(|s| {
                 Self::dissatisfy_helper(
@@ -976,7 +976,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         // Sort everything by (sat cost - dissat cost), except that
         // satisfactions without signatures beat satisfactions with
         // signatures
-        let mut sat_indices = (0..subs.len()).collect::<Vec<_>>();
+        let mut sat_indices = (0..thresh.n()).collect::<Vec<_>>();
         sat_indices.sort_by_key(|&i| {
             let stack_weight = match (&sats[i].stack, &ret_stack[i].stack) {
                 (&Witness::Unavailable, _) | (&Witness::Impossible, _) => i64::MAX,
@@ -995,7 +995,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
             (is_impossible, sats[i].has_sig, stack_weight)
         });
 
-        for i in 0..k {
+        for i in 0..thresh.k() {
             mem::swap(&mut ret_stack[sat_indices[i]], &mut sats[sat_indices[i]]);
         }
 
@@ -1004,8 +1004,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         // then the threshold branch is impossible to satisfy
         // For example, the fragment thresh(2, hash, 0, 0, 0)
         // is has an impossible witness
-        assert!(k > 0);
-        if sats[sat_indices[k - 1]].stack == Witness::Impossible {
+        if sats[sat_indices[thresh.k() - 1]].stack == Witness::Impossible {
             Satisfaction {
                 stack: Witness::Impossible,
                 // If the witness is impossible, we don't care about the
@@ -1024,9 +1023,8 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         // For example, the fragment thresh(2, hash, hash, 0, 0)
         // is uniquely satisfyiable because there is no satisfaction
         // for the 0 fragment
-        else if k < sat_indices.len()
-            && !sats[sat_indices[k]].has_sig
-            && sats[sat_indices[k]].stack != Witness::Impossible
+        else if !sats[sat_indices[thresh.k()]].has_sig
+            && sats[sat_indices[thresh.k()]].stack != Witness::Impossible
         {
             // All arguments should be `d`, so dissatisfactions have no
             // signatures; and in this branch we assume too many weak
@@ -1062,8 +1060,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
 
     // produce a possily malleable satisafaction for thesh frag
     fn thresh_mall<Ctx, Sat, F>(
-        k: usize,
-        subs: &[Arc<Miniscript<Pk, Ctx>>],
+        thresh: &Threshold<Arc<Miniscript<Pk, Ctx>>, 0>,
         stfr: &Sat,
         root_has_sig: bool,
         leaf_hash: &TapLeafHash,
@@ -1077,7 +1074,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
             Satisfaction<Placeholder<Pk>>,
         ) -> Satisfaction<Placeholder<Pk>>,
     {
-        let mut sats = subs
+        let mut sats = thresh
             .iter()
             .map(|s| {
                 Self::satisfy_helper(
@@ -1091,7 +1088,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
             })
             .collect::<Vec<_>>();
         // Start with the to-return stack set to all dissatisfactions
-        let mut ret_stack = subs
+        let mut ret_stack = thresh
             .iter()
             .map(|s| {
                 Self::dissatisfy_helper(
@@ -1108,7 +1105,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         // Sort everything by (sat cost - dissat cost), except that
         // satisfactions without signatures beat satisfactions with
         // signatures
-        let mut sat_indices = (0..subs.len()).collect::<Vec<_>>();
+        let mut sat_indices = (0..thresh.n()).collect::<Vec<_>>();
         sat_indices.sort_by_key(|&i| {
             // For malleable satifactions, directly choose smallest weights
             match (&sats[i].stack, &ret_stack[i].stack) {
@@ -1122,7 +1119,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         });
 
         // swap the satisfactions
-        for i in 0..k {
+        for i in 0..thresh.k() {
             mem::swap(&mut ret_stack[sat_indices[i]], &mut sats[sat_indices[i]]);
         }
 
@@ -1236,8 +1233,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
             Satisfaction<Placeholder<Pk>>,
         ) -> Satisfaction<Placeholder<Pk>>,
         G: FnMut(
-            usize,
-            &[Arc<Miniscript<Pk, Ctx>>],
+            &Threshold<Arc<Miniscript<Pk, Ctx>>, 0>,
             &Sat,
             bool,
             &TapLeafHash,
@@ -1496,7 +1492,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                 )
             }
             Terminal::Thresh(ref thresh) => {
-                thresh_fn(thresh.k(), thresh.data(), stfr, root_has_sig, leaf_hash, min_fn)
+                thresh_fn(thresh, stfr, root_has_sig, leaf_hash, min_fn)
             }
             Terminal::Multi(ref thresh) => {
                 // Collect all available signatures
@@ -1606,8 +1602,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
             Satisfaction<Placeholder<Pk>>,
         ) -> Satisfaction<Placeholder<Pk>>,
         G: FnMut(
-            usize,
-            &[Arc<Miniscript<Pk, Ctx>>],
+            &Threshold<Arc<Miniscript<Pk, Ctx>>, 0>,
             &Sat,
             bool,
             &TapLeafHash,

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -1495,8 +1495,8 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                     },
                 )
             }
-            Terminal::Thresh(k, ref subs) => {
-                thresh_fn(k, subs, stfr, root_has_sig, leaf_hash, min_fn)
+            Terminal::Thresh(ref thresh) => {
+                thresh_fn(thresh.k(), thresh.data(), stfr, root_has_sig, leaf_hash, min_fn)
             }
             Terminal::Multi(ref thresh) => {
                 // Collect all available signatures
@@ -1755,8 +1755,8 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                 // Dissatisfactions don't need to non-malleable. Use minimum_mall always
                 Satisfaction::minimum_mall(dissat_1, dissat_2)
             }
-            Terminal::Thresh(_, ref subs) => Satisfaction {
-                stack: subs.iter().fold(Witness::empty(), |acc, sub| {
+            Terminal::Thresh(ref thresh) => Satisfaction {
+                stack: thresh.iter().fold(Witness::empty(), |acc, sub| {
                     let nsat = Self::dissatisfy_helper(
                         &sub.node,
                         stfr,

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -6,7 +6,7 @@
 use core::cmp;
 use core::iter::once;
 
-use super::{Error, ErrorKind, ScriptContext};
+use super::{Error, ScriptContext};
 use crate::miniscript::context::SigType;
 use crate::prelude::*;
 use crate::{script_num_size, AbsLockTime, MiniscriptKey, RelLockTime, Terminal};
@@ -953,21 +953,8 @@ impl ExtData {
                 let ctype = c.ext;
                 Self::and_or(atype, btype, ctype)
             }
-            Terminal::Thresh(k, ref subs) => {
-                if k == 0 {
-                    return Err(Error {
-                        fragment_string: fragment.to_string(),
-                        error: ErrorKind::ZeroThreshold,
-                    });
-                }
-                if k > subs.len() {
-                    return Err(Error {
-                        fragment_string: fragment.to_string(),
-                        error: ErrorKind::OverThreshold(k, subs.len()),
-                    });
-                }
-
-                Self::threshold(k, subs.len(), |n| subs[n].ext)
+            Terminal::Thresh(ref thresh) => {
+                Self::threshold(thresh.k(), thresh.n(), |n| thresh.data()[n].ext)
             }
         };
         ret.sanity_checks();

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -157,13 +157,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Terminal<Pk, Ctx> {
                 Arc::new(left.node.lift()?),
                 Arc::new(right.node.lift()?),
             )),
-            Terminal::Thresh(k, ref subs) => {
-                let semantic_subs: Result<Vec<Semantic<Pk>>, Error> =
-                    subs.iter().map(|s| s.node.lift()).collect();
-                let semantic_subs = semantic_subs?.into_iter().map(Arc::new).collect();
-                // unwrap to be removed in a later commit
-                Semantic::Thresh(Threshold::new(k, semantic_subs).unwrap())
-            }
+            Terminal::Thresh(ref thresh) => thresh
+                .translate_ref(|sub| sub.lift().map(Arc::new))
+                .map(Semantic::Thresh)?,
             Terminal::Multi(ref thresh) => Semantic::Thresh(
                 thresh
                     .map_ref(|key| Arc::new(Semantic::Key(key.clone())))


### PR DESCRIPTION
This completes the "threshold" conversion and completely drops the various ad-hoc error paths related to threshold values (most of which were just random strings).

The next set of PRs will be related to cleaning up errors in general a bit, to strongly-type things and add span information. But I am struggling a bit with how to box the associated error types for the MiniscriptKey types so it may be a while. (Very hard to do this in a std/nostd compatible way and the final result will probably be inconvenient/annoying for users.)