### PR TITLE
CI: Pin cc for MSRV build

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -9,8 +9,15 @@ rustc --version
 
 # Cache the toolchain we are using.
 NIGHTLY=false
+MSRV=false
 if cargo --version | grep nightly; then
     NIGHTLY=true
+elif cargo --version | grep "1\.56"; then
+    MSRV=true
+fi
+
+if [ "$MSRV" = true ]; then
+    cargo update -p cc --precise 1.0.79
 fi
 
 # Format if told to


### PR DESCRIPTION
The `cc` dependency just stopped working for MSRV build with error

    error: package `cc v1.0.96` cannot be built because it requires
    rustc 1.63 or newer, while the currently active rustc version is
    1.56.1

Pin `cc` back to an earlier version for MSRV build.