### PR TITLE
Demonstrate usage of new bitcoind-json-rpc repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,15 @@ required-features = ["std", "base64", "compiler"]
 [workspace]
 members = ["bitcoind-tests", "fuzz"]
 exclude = ["embedded"]
+
+[patch.crates-io.bitcoind]
+git = "https://github.com/tcharding/rust-bitcoind-json-rpc"
+branch = "06-06-miniscript"
+
+[patch.crates-io.bitcoind-json-rpc-types]
+git = "https://github.com/tcharding/rust-bitcoind-json-rpc"
+branch = "06-06-miniscript"
+
+[patch.crates-io.bitcoind-json-rpc-client]
+git = "https://github.com/tcharding/rust-bitcoind-json-rpc"
+branch = "06-06-miniscript"

--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -9,6 +9,36 @@ publish = false
 
 [dependencies]
 miniscript = {path = "../"}
-bitcoind = { version = "0.36.0" }
+bitcoind = { version = "0.37.0" }
 actual-rand = { package = "rand", version = "0.8.4"}
 secp256k1 = {version = "0.29.0", features = ["rand-std"]}
+
+[features]
+# Enable the same feature in `bitcoind`.
+"26_0" = ["bitcoind/26_0"]
+"25_2" = ["bitcoind/25_2"]
+"25_1" = ["bitcoind/25_1"]
+"25_0" = ["bitcoind/25_0"]
+"24_2" = ["bitcoind/24_2"]
+"24_1" = ["bitcoind/24_1"]
+"24_0_1" = ["bitcoind/24_0_1"]
+"23_2" = ["bitcoind/23_2"]
+"23_1" = ["bitcoind/23_1"]
+"23_0" = ["bitcoind/23_0"]
+"22_1" = ["bitcoind/22_1"]
+"22_0" = ["bitcoind/22_0"]
+"0_21_2" = ["bitcoind/0_21_2"]
+"0_20_2" = ["bitcoind/0_20_2"]
+"0_19_1" = ["bitcoind/0_19_1"]
+"0_18_1" = ["bitcoind/0_18_1"]
+"0_17_2" = ["bitcoind/0_17_2"]
+
+
+[patch.crates-io.bitcoind]
+git = "https://github.com/tcharding/rust-bitcoind-json-rpc"
+
+[patch.crates-io.bitcoind-json-rpc-types]
+git = "https://github.com/tcharding/rust-bitcoind-json-rpc"
+
+[patch.crates-io.bitcoind-json-rpc-client]
+git = "https://github.com/tcharding/rust-bitcoind-json-rpc"


### PR DESCRIPTION
Demo use of the new repo, has bugs in amount parsing somewhere but I wanted to push this up before the weekend.

Uses: https://github.com/tcharding/rust-bitcoind-json-rpc

Introduces testing against bitcoind versions
- `v26.0`
- `v25.2`
- `v25.1`
- `v25.0`
- `v24.2`
- `v24.1`
- `v24.0.1`
- `v23.2`
- `v23.1`
- `v23.0`
- `v22.1`
- `v22.0`
- `v0.21.2`
- `v0.20.2`
- `v0.19.1`
- `v0.18.1`
- `v0.17.1`
