### PR TITLE
plan: make LoggerAssetProvider constructible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ impl<E> TranslateErr<E> {
     /// - SegwitV0 does not allow uncompressed keys and x_only keys
     /// - Tapscript does not allow uncompressed keys
     /// - Translating into multi-path descriptors should have same number of path
-    /// for all the keys in the descriptor
+    ///   for all the keys in the descriptor
     ///
     /// # Panics
     ///

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -108,7 +108,7 @@ pub trait AssetProvider<Pk: MiniscriptKey> {
 
 /// Wrapper around [`Assets`] that logs every query and value returned
 #[cfg(feature = "std")]
-pub struct LoggerAssetProvider(Assets);
+pub struct LoggerAssetProvider<'a>(pub &'a Assets);
 
 #[cfg(feature = "std")]
 macro_rules! impl_log_method {
@@ -123,7 +123,7 @@ macro_rules! impl_log_method {
 }
 
 #[cfg(feature = "std")]
-impl AssetProvider<DefiniteDescriptorKey> for LoggerAssetProvider {
+impl<'a> AssetProvider<DefiniteDescriptorKey> for LoggerAssetProvider<'a> {
     impl_log_method!(provider_lookup_ecdsa_sig, pk: &DefiniteDescriptorKey, -> bool);
     impl_log_method!(provider_lookup_tap_key_spend_sig, pk: &DefiniteDescriptorKey, -> Option<usize>);
     impl_log_method!(provider_lookup_tap_leaf_script_sig, pk: &DefiniteDescriptorKey, leaf_hash: &TapLeafHash, -> Option<usize>);


### PR DESCRIPTION
It looks like we have an example AssetProvider that is intended to be used for testing/debugging. It looks useful but evidently has never been used because it was impossible to construct.

Recent versions of rust nightly notice this and output a warning about this, which is causing CI to fail, so we need to fix it.

My solution is to make the inner `Assets` public (and also a reference, since there is no need to take ownership) so that people can easily construct and deconstruct the type.