### PR TITLE
release 12.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 12.1.0 - July 9, 2024
+
+- Make `LoggerAssetProvider` constructible [#697](https://github.com/rust-bitcoin/rust-miniscript/pull/697)
+- Explicitly track recursion depth in fragments [#704](https://github.com/rust-bitcoin/rust-miniscript/pull/704)
+
 # 12.0.0 - May 22, 2024
 
 - Update MSRV to Rust `v1.56.1` [#639](https://github.com/rust-bitcoin/rust-miniscript/pull/639)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "12.0.0"
+version = "12.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-miniscript/"


### PR DESCRIPTION
Turns out there were only two tiny changes in the last six months. One changes the API so this is a minor bump rather than a patch bump.