### PR TITLE
CI: Use specific revision of maintainer-tools

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
+          rev: b2ac115
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -45,6 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
+          rev: b2ac115
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@nightly
@@ -67,6 +69,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
+          rev: b2ac115
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -91,6 +94,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
+          rev: b2ac115
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@nightly
@@ -115,6 +119,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
+          rev: b2ac115
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
@@ -137,6 +142,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
+          rev: b2ac115
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@nightly
@@ -159,6 +165,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
+          rev: b2ac115
           path: maintainer-tools
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
We don't want to pull the maintainer tools repo from master otherwise we cannot patch it, we should use a specific revision.

This was an oversite in the original work when introducing the maintainer tools `run_task` script.

Use commit:

b2ac115 Merge rust-bitcoin/rust-bitcoin-maintainer-tools#4: Add CI shell scripts