### PR TITLE
fix: possible absolute locktime overflow error

### DIFF
--- a/src/primitives/absolute_locktime.rs
+++ b/src/primitives/absolute_locktime.rs
@@ -7,7 +7,7 @@ use core::{cmp, fmt};
 use bitcoin::absolute;
 
 /// Maximum allowed absolute locktime value.
-pub const MAX_ABSOLUTE_LOCKTIME: u32 = 0x8000_0000;
+pub const MAX_ABSOLUTE_LOCKTIME: u32 = 0x7FFF_FFFF;
 
 /// Minimum allowed absolute locktime value.
 ///


### PR DESCRIPTION
Maximum absolute locktime is 2^31 - 1, not 2^31 in miniscript.

reference: https://github.com/bitcoin/bitcoin/blob/master/src/script/miniscript.h#L2281
