### PR TITLE
Refactor `extract_key` logic in Taproot compiler

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -19,6 +19,7 @@ jobs:
         # over that limit with fuzzing because of the hour run time.
         fuzz_target: [
 compile_descriptor,
+compile_taproot,
 parse_descriptor,
 parse_descriptor_secret,
 roundtrip_concrete,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,6 +20,10 @@ name = "compile_descriptor"
 path = "fuzz_targets/compile_descriptor.rs"
 
 [[bin]]
+name = "compile_taproot"
+path = "fuzz_targets/compile_taproot.rs"
+
+[[bin]]
 name = "parse_descriptor"
 path = "fuzz_targets/parse_descriptor.rs"
 

--- a/fuzz/fuzz_targets/compile_taproot.rs
+++ b/fuzz/fuzz_targets/compile_taproot.rs
@@ -1,0 +1,37 @@
+#![allow(unexpected_cfgs)]
+
+use std::str::FromStr;
+
+use honggfuzz::fuzz;
+use miniscript::{policy, Miniscript, Tap};
+use policy::Liftable;
+
+type Script = Miniscript<String, Tap>;
+type Policy = policy::Concrete<String>;
+
+fn do_test(data: &[u8]) {
+    let data_str = String::from_utf8_lossy(data);
+    if let Ok(pol) = Policy::from_str(&data_str) {
+        // Compile
+        if let Ok(desc) = pol.compile::<Tap>() {
+            // Lift
+            assert_eq!(desc.lift().unwrap().sorted(), pol.lift().unwrap().sorted());
+            // Try to roundtrip the output of the compiler
+            let output = desc.to_string();
+            if let Ok(desc) = Script::from_str(&output) {
+                let rtt = desc.to_string();
+                assert_eq!(output.to_lowercase(), rtt.to_lowercase());
+            } else {
+                panic!("compiler output something unparseable: {}", output)
+            }
+        }
+    }
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -22,7 +22,7 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-honggfuzz = { version = "0.5.55", default-features = false }
+honggfuzz = { version = "0.5.56", default-features = false }
 miniscript = { path = "..", features = [ "compiler" ] }
 
 regex = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,9 @@ pub enum Error {
     /// Compiler related errors
     CompilerError(crate::policy::compiler::CompilerError),
     /// Errors related to policy
-    PolicyError(policy::concrete::PolicyError),
+    SemanticPolicy(policy::semantic::PolicyError),
+    /// Errors related to policy
+    ConcretePolicy(policy::concrete::PolicyError),
     /// Errors related to lifting
     LiftError(policy::LiftError),
     /// Forward script context related errors
@@ -529,7 +531,8 @@ impl fmt::Display for Error {
             Error::ContextError(ref e) => fmt::Display::fmt(e, f),
             #[cfg(feature = "compiler")]
             Error::CompilerError(ref e) => fmt::Display::fmt(e, f),
-            Error::PolicyError(ref e) => fmt::Display::fmt(e, f),
+            Error::SemanticPolicy(ref e) => fmt::Display::fmt(e, f),
+            Error::ConcretePolicy(ref e) => fmt::Display::fmt(e, f),
             Error::LiftError(ref e) => fmt::Display::fmt(e, f),
             Error::MaxRecursiveDepthExceeded => write!(
                 f,
@@ -595,7 +598,8 @@ impl error::Error for Error {
             Secp(e) => Some(e),
             #[cfg(feature = "compiler")]
             CompilerError(e) => Some(e),
-            PolicyError(e) => Some(e),
+            ConcretePolicy(e) => Some(e),
+            SemanticPolicy(e) => Some(e),
             LiftError(e) => Some(e),
             ContextError(e) => Some(e),
             AnalysisError(e) => Some(e),
@@ -647,11 +651,6 @@ impl From<bitcoin::address::P2shError> for Error {
 #[cfg(feature = "compiler")]
 impl From<crate::policy::compiler::CompilerError> for Error {
     fn from(e: crate::policy::compiler::CompilerError) -> Error { Error::CompilerError(e) }
-}
-
-#[doc(hidden)]
-impl From<policy::concrete::PolicyError> for Error {
-    fn from(e: policy::concrete::PolicyError) -> Error { Error::PolicyError(e) }
 }
 
 fn errstr(s: &str) -> Error { Error::Unexpected(s.to_owned()) }

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1511,7 +1511,7 @@ mod tests {
     }
 
     #[test]
-    fn segwit_limits() {
+    fn segwit_limits_1() {
         // Hit the maximum witness script size limit.
         // or(thresh(52, [pubkey; 52]), thresh(52, [pubkey; 52])) results in a 3642-bytes long
         // witness script with only 54 stack elements
@@ -1537,7 +1537,10 @@ mod tests {
             "Compilation succeeded with a witscript size of '{:?}'",
             script_size,
         );
+    }
 
+    #[test]
+    fn segwit_limits_2() {
         // Hit the maximum witness stack elements limit
         let (keys, _) = pubkeys_and_a_sig(100);
         let keys: Vec<Arc<Concrete<bitcoin::PublicKey>>> = keys

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -578,23 +578,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// Gets the number of [TapLeaf](`TapTree::Leaf`)s considering exhaustive root-level [`Policy::Or`]
     /// and [`Policy::Thresh`] disjunctions for the `TapTree`.
     #[cfg(feature = "compiler")]
-    fn num_tap_leaves(&self) -> usize {
-        use Policy::*;
-
-        let mut nums = vec![];
-        for data in self.rtl_post_order_iter() {
-            let num = match data.node {
-                Or(subs) => (0..subs.len()).map(|_| nums.pop().unwrap()).sum(),
-                Thresh(thresh) if thresh.is_or() => {
-                    (0..thresh.n()).map(|_| nums.pop().unwrap()).sum()
-                }
-                _ => 1,
-            };
-            nums.push(num);
-        }
-        // Ok to unwrap because we know we processed at least one node.
-        nums.pop().unwrap()
-    }
+    fn num_tap_leaves(&self) -> usize { self.tapleaf_probability_iter().count() }
 
     /// Does checks on the number of `TapLeaf`s.
     #[cfg(feature = "compiler")]

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -242,14 +242,17 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                                     continue;
                                 }
                                 let compilation = compiler::best_compilation::<Pk, Tap>(pol)?;
-                                compilation.sanity_check()?;
+                                compilation
+                                    .sanity_check()
+                                    .expect("compiler produces sane output");
                                 leaf_compilations.push((OrdF64(prob), compilation));
                             }
-                            let tap_tree = with_huffman_tree::<Pk>(leaf_compilations)?;
+                            let tap_tree = with_huffman_tree::<Pk>(leaf_compilations).unwrap();
                             Some(tap_tree)
                         }
                     },
-                )?;
+                )
+                .expect("compiler produces sane output");
                 Ok(tree)
             }
         }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -194,7 +194,7 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Concrete<Pk> {
     fn lift(&self) -> Result<Semantic<Pk>, Error> {
         // do not lift if there is a possible satisfaction
         // involving combination of timelocks and heightlocks
-        self.check_timelocks()?;
+        self.check_timelocks().map_err(Error::ConcretePolicy)?;
         let ret = match *self {
             Concrete::Unsatisfiable => Semantic::Unsatisfiable,
             Concrete::Trivial => Semantic::Trivial,


### PR DESCRIPTION
Right now our Taproot compiler does some complicated analysis to identify a key within a policy that may be extracted to use as an internal key. Specifically, if you look at the "disjunction tree" at the root of a policy, every leaf of this tree can be a tapbranch and any leaf which is just a pubkey-check and nothing else is a candidate to be the internal key.

However, our logic to do this is convoluted, has many unnecessary error paths, and lots of gratuitous allocations (which ironically make the code harder, not easier, to follow).

This PR smooths all that out by introducing a new iterator over the potential tapbranches of a policy (along with their probabilities). It also cleans up much of the error handling in the policy module, eliminating 3 calls to the stringly-typed `errstr` function.