### PR TITLE
[backport] Several small fixes for 12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# # 12.3.0 - August 31, 2024
+
+- Fix incorrect string serialization of `and_b` [#735](https://github.com/rust-bitcoin/rust-miniscript/pull/735)
+
 # # 12.2.0 - July 20, 2024
 
 - Fix panics while decoding large miniscripts from script [#712](https://github.com/rust-bitcoin/rust-miniscript/pull/712)

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.2.0"
+version = "12.3.0"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.2.0"
+version = "12.3.0"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "12.2.0"
+version = "12.3.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-miniscript/"

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -587,9 +587,6 @@ fn parse_tr_tree(s: &str) -> Result<expression::Tree, Error> {
             return Err(Error::Unexpected("invalid taproot internal key".to_string()));
         }
         let internal_key = expression::Tree { name: key.name, args: vec![] };
-        if script.is_empty() {
-            return Ok(expression::Tree { name: "tr", args: vec![internal_key] });
-        }
         let (tree, rest) = expression::Tree::from_slice_delim(script, 1, '{')?;
         if rest.is_empty() {
             Ok(expression::Tree { name: "tr", args: vec![internal_key, tree] })
@@ -768,6 +765,14 @@ mod tests {
             }
          })";
         desc.replace(&[' ', '\n'][..], "")
+    }
+
+    #[test]
+    fn regression_736() {
+        crate::Descriptor::<crate::DescriptorPublicKey>::from_str(
+            "tr(0000000000000000000000000000000000000000000000000000000000000002,)",
+        )
+        .unwrap_err();
     }
 
     #[test]

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -62,7 +62,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Terminal<Pk, Ctx> {
             Terminal::AndB(ref l, ref r) => fmt_2(f, "and_b(", l, r, is_debug),
             Terminal::AndOr(ref a, ref b, ref c) => {
                 if c.node == Terminal::False {
-                    fmt_2(f, "and_b(", a, b, is_debug)
+                    fmt_2(f, "and_n(", a, b, is_debug)
                 } else {
                     f.write_str("andor(")?;
                     conditional_fmt(f, a, is_debug)?;

--- a/src/primitives/relative_locktime.rs
+++ b/src/primitives/relative_locktime.rs
@@ -65,7 +65,7 @@ impl RelLockTime {
 impl convert::TryFrom<Sequence> for RelLockTime {
     type Error = RelLockTimeError;
     fn try_from(seq: Sequence) -> Result<Self, RelLockTimeError> {
-        if seq.is_relative_lock_time() {
+        if seq.is_relative_lock_time() && seq != Sequence::ZERO {
             Ok(RelLockTime(seq))
         } else {
             Err(RelLockTimeError { value: seq.to_consensus_u32() })


### PR DESCRIPTION
We are incorrectly serializing and_n as "and_b", and incorrectly parsing `tr(<key>,)`.

In master the `and_b` thing is fixed by https://github.com/rust-bitcoin/rust-miniscript/pull/722 which rewrites the Display impl completely and the `tr(<key>,)` thing will be fixed as part of a coming series of PRs to clean up expression parsing.

Also includes #740 since it showed up in time.