### PR TITLE
fix: zero sequence check on relative time

### DIFF
--- a/src/primitives/relative_locktime.rs
+++ b/src/primitives/relative_locktime.rs
@@ -65,7 +65,7 @@ impl RelLockTime {
 impl convert::TryFrom<Sequence> for RelLockTime {
     type Error = RelLockTimeError;
     fn try_from(seq: Sequence) -> Result<Self, RelLockTimeError> {
-        if seq.is_relative_lock_time() {
+        if seq.is_relative_lock_time() && seq != Sequence::ZERO {
             Ok(RelLockTime(seq))
         } else {
             Err(RelLockTimeError { value: seq.to_consensus_u32() })


### PR DESCRIPTION
I've just found out RelLockTime misses zero sequence check, which must be disallowed for miniscript.