### PR TITLE
fix: sync max multi_a pubkey with core

### DIFF
--- a/src/miniscript/limits.rs
+++ b/src/miniscript/limits.rs
@@ -34,4 +34,5 @@ pub const MAX_BLOCK_WEIGHT: usize = 4000000;
 // https://github.com/bitcoin/bitcoin/blob/6acda4b00b3fc1bfac02f5de590e1a5386cbc779/src/script/script.h#L30
 pub const MAX_PUBKEYS_PER_MULTISIG: usize = 20;
 /// Maximum pubkeys in a CHECKSIGADD construction.
-pub const MAX_PUBKEYS_IN_CHECKSIGADD: usize = (bitcoin::Weight::MAX_BLOCK.to_wu() / 32) as usize;
+// https://github.com/bitcoin/bitcoin/blob/99b06b7f1d4194fb8036b90e5308101645f968e7/src/script/script.h#L36
+pub const MAX_PUBKEYS_IN_CHECKSIGADD: usize = 999;


### PR DESCRIPTION
Although this is checked indirectly by checking MAX_STACK_SIZE, it'd be better to check in threshold explicitly as core does.