### PR TITLE
fix: zero sequence check for from_height

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1211,7 +1211,7 @@ mod tests {
         assert_eq!(
             older_satisfied.unwrap(),
             vec![SatisfiedConstraint::RelativeTimelock {
-                n: crate::RelLockTime::from_height(1000).into()
+                n: crate::RelLockTime::from_height(1000).unwrap().into()
             }]
         );
 

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1191,10 +1191,10 @@ mod tests {
         let mut abs = miniscript.lift().unwrap();
         assert_eq!(abs.n_keys(), 5);
         assert_eq!(abs.minimum_n_keys(), Some(2));
-        abs = abs.at_age(RelLockTime::from_height(10000).into());
+        abs = abs.at_age(RelLockTime::from_height(10000).unwrap().into());
         assert_eq!(abs.n_keys(), 5);
         assert_eq!(abs.minimum_n_keys(), Some(2));
-        abs = abs.at_age(RelLockTime::from_height(9999).into());
+        abs = abs.at_age(RelLockTime::from_height(9999).unwrap().into());
         assert_eq!(abs.n_keys(), 3);
         assert_eq!(abs.minimum_n_keys(), Some(3));
         abs = abs.at_age(RelLockTime::ZERO.into());
@@ -1554,7 +1554,7 @@ mod tests {
             (
                 format!("or_d(pk({}),and_v(v:pk({}),older(12960)))", key_missing, key_present),
                 None,
-                Some(RelLockTime::from_height(12960)),
+                Some(RelLockTime::from_height(12960).unwrap()),
             ),
             (
                 format!(
@@ -1562,12 +1562,12 @@ mod tests {
                     key_present, key_missing
                 ),
                 Some(AbsLockTime::from_consensus(11).unwrap()),
-                Some(RelLockTime::from_height(10)),
+                Some(RelLockTime::from_height(10).unwrap()),
             ),
             (
                 format!("and_v(v:and_v(v:pk({}),older(10)),older(20))", key_present),
                 None,
-                Some(RelLockTime::from_height(20)),
+                Some(RelLockTime::from_height(20).unwrap()),
             ),
             (
                 format!(
@@ -1575,7 +1575,7 @@ mod tests {
                     key_present, key_missing
                 ),
                 None,
-                Some(RelLockTime::from_height(10)),
+                Some(RelLockTime::from_height(10).unwrap()),
             ),
         ];
 

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1379,7 +1379,7 @@ mod tests {
             (
                 1,
                 Arc::new(Concrete::And(vec![
-                    Arc::new(Concrete::Older(RelLockTime::from_height(10000))),
+                    Arc::new(Concrete::Older(RelLockTime::from_height(10000).unwrap())),
                     Arc::new(Concrete::Thresh(
                         Threshold::from_iter(2, key_pol[5..8].iter().map(|p| (p.clone()).into()))
                             .unwrap(),
@@ -1409,10 +1409,10 @@ mod tests {
         let mut abs = policy.lift().unwrap();
         assert_eq!(abs.n_keys(), 8);
         assert_eq!(abs.minimum_n_keys(), Some(2));
-        abs = abs.at_age(RelLockTime::from_height(10000).into());
+        abs = abs.at_age(RelLockTime::from_height(10000).unwrap().into());
         assert_eq!(abs.n_keys(), 8);
         assert_eq!(abs.minimum_n_keys(), Some(2));
-        abs = abs.at_age(RelLockTime::from_height(9999).into());
+        abs = abs.at_age(RelLockTime::from_height(9999).unwrap().into());
         assert_eq!(abs.n_keys(), 5);
         assert_eq!(abs.minimum_n_keys(), Some(3));
         abs = abs.at_age(RelLockTime::ZERO.into());
@@ -1442,15 +1442,15 @@ mod tests {
         assert!(ms.satisfy(no_sat).is_err());
         assert!(ms.satisfy(&left_sat).is_ok());
         assert!(ms
-            .satisfy((&right_sat, RelLockTime::from_height(10001)))
+            .satisfy((&right_sat, RelLockTime::from_height(10001).unwrap(),))
             .is_ok());
         //timelock not met
         assert!(ms
-            .satisfy((&right_sat, RelLockTime::from_height(9999)))
+            .satisfy((&right_sat, RelLockTime::from_height(9999).unwrap()))
             .is_err());
 
         assert_eq!(
-            ms.satisfy((left_sat, RelLockTime::from_height(9999)))
+            ms.satisfy((left_sat, RelLockTime::from_height(9999).unwrap()))
                 .unwrap(),
             vec![
                 // sat for left branch
@@ -1462,7 +1462,7 @@ mod tests {
         );
 
         assert_eq!(
-            ms.satisfy((right_sat, RelLockTime::from_height(10000)))
+            ms.satisfy((right_sat, RelLockTime::from_height(10000).unwrap()))
                 .unwrap(),
             vec![
                 // sat for right branch

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -357,7 +357,7 @@ mod tests {
             Semantic::Thresh(Threshold::or(
                 Arc::new(Semantic::Thresh(Threshold::and(
                     Arc::new(Semantic::Key(key_a)),
-                    Arc::new(Semantic::Older(RelLockTime::from_height(42)))
+                    Arc::new(Semantic::Older(RelLockTime::from_height(42).unwrap()))
                 ))),
                 Arc::new(Semantic::Key(key_b))
             )),

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -725,26 +725,33 @@ mod tests {
         assert_eq!(
             policy
                 .clone()
-                .at_age(RelLockTime::from_height(10000).into()),
+                .at_age(RelLockTime::from_height(10000).unwrap().into()),
             policy
         );
         assert_eq!(policy.n_keys(), 1);
         assert_eq!(policy.minimum_n_keys(), Some(1));
 
         let policy = StringPolicy::from_str("older(1000)").unwrap();
-        assert_eq!(policy, Policy::Older(RelLockTime::from_height(1000)));
+        assert_eq!(policy, Policy::Older(RelLockTime::from_height(1000).unwrap()));
         assert_eq!(policy.absolute_timelocks(), vec![]);
         assert_eq!(policy.relative_timelocks(), vec![1000]);
         assert_eq!(policy.clone().at_age(RelLockTime::ZERO.into()), Policy::Unsatisfiable);
         assert_eq!(
-            policy.clone().at_age(RelLockTime::from_height(999).into()),
+            policy
+                .clone()
+                .at_age(RelLockTime::from_height(999).unwrap().into()),
             Policy::Unsatisfiable
         );
-        assert_eq!(policy.clone().at_age(RelLockTime::from_height(1000).into()), policy);
         assert_eq!(
             policy
                 .clone()
-                .at_age(RelLockTime::from_height(10000).into()),
+                .at_age(RelLockTime::from_height(1000).unwrap().into()),
+            policy
+        );
+        assert_eq!(
+            policy
+                .clone()
+                .at_age(RelLockTime::from_height(10000).unwrap().into()),
             policy
         );
         assert_eq!(policy.n_keys(), 0);
@@ -755,24 +762,28 @@ mod tests {
             policy,
             Policy::Thresh(Threshold::or(
                 Policy::Key("".to_owned()).into(),
-                Policy::Older(RelLockTime::from_height(1000)).into(),
+                Policy::Older(RelLockTime::from_height(1000).unwrap()).into(),
             ))
         );
         assert_eq!(policy.relative_timelocks(), vec![1000]);
         assert_eq!(policy.absolute_timelocks(), vec![]);
         assert_eq!(policy.clone().at_age(RelLockTime::ZERO.into()), Policy::Key("".to_owned()));
         assert_eq!(
-            policy.clone().at_age(RelLockTime::from_height(999).into()),
+            policy
+                .clone()
+                .at_age(RelLockTime::from_height(999).unwrap().into()),
             Policy::Key("".to_owned())
         );
         assert_eq!(
-            policy.clone().at_age(RelLockTime::from_height(1000).into()),
+            policy
+                .clone()
+                .at_age(RelLockTime::from_height(1000).unwrap().into()),
             policy.clone().normalized()
         );
         assert_eq!(
             policy
                 .clone()
-                .at_age(RelLockTime::from_height(10000).into()),
+                .at_age(RelLockTime::from_height(10000).unwrap().into()),
             policy.clone().normalized()
         );
         assert_eq!(policy.n_keys(), 1);
@@ -816,11 +827,11 @@ mod tests {
                 Threshold::new(
                     2,
                     vec![
-                        Policy::Older(RelLockTime::from_height(1000)).into(),
-                        Policy::Older(RelLockTime::from_height(10000)).into(),
-                        Policy::Older(RelLockTime::from_height(1000)).into(),
-                        Policy::Older(RelLockTime::from_height(2000)).into(),
-                        Policy::Older(RelLockTime::from_height(2000)).into(),
+                        Policy::Older(RelLockTime::from_height(1000).unwrap()).into(),
+                        Policy::Older(RelLockTime::from_height(10000).unwrap()).into(),
+                        Policy::Older(RelLockTime::from_height(1000).unwrap()).into(),
+                        Policy::Older(RelLockTime::from_height(2000).unwrap()).into(),
+                        Policy::Older(RelLockTime::from_height(2000).unwrap()).into(),
                     ]
                 )
                 .unwrap()
@@ -843,9 +854,9 @@ mod tests {
                 Threshold::new(
                     2,
                     vec![
-                        Policy::Older(RelLockTime::from_height(1000)).into(),
-                        Policy::Older(RelLockTime::from_height(10000)).into(),
-                        Policy::Older(RelLockTime::from_height(1000)).into(),
+                        Policy::Older(RelLockTime::from_height(1000).unwrap()).into(),
+                        Policy::Older(RelLockTime::from_height(10000).unwrap()).into(),
+                        Policy::Older(RelLockTime::from_height(1000).unwrap()).into(),
                         Policy::Unsatisfiable.into(),
                         Policy::Unsatisfiable.into(),
                     ]
@@ -967,7 +978,7 @@ mod tests {
             .entails(
                 liquid_pol
                     .clone()
-                    .at_age(RelLockTime::from_height(4095).into())
+                    .at_age(RelLockTime::from_height(4095).unwrap().into())
             )
             .unwrap());
 

--- a/src/primitives/relative_locktime.rs
+++ b/src/primitives/relative_locktime.rs
@@ -48,7 +48,9 @@ impl RelLockTime {
     pub fn to_consensus_u32(self) -> u32 { self.0.to_consensus_u32() }
 
     /// Takes a 16-bit number of blocks and produces a relative locktime from it.
-    pub fn from_height(height: u16) -> Self { RelLockTime(Sequence::from_height(height)) }
+    pub fn from_height(height: u16) -> Result<Self, RelLockTimeError> {
+        convert::TryFrom::try_from(Sequence::from_height(height))
+    }
 
     /// Takes a 16-bit number of 512-second time intervals and produces a relative locktime from it.
     pub fn from_512_second_intervals(time: u16) -> Self {


### PR DESCRIPTION
This is following https://github.com/rust-bitcoin/rust-miniscript/pull/740.
I missed `from_height` also needs to check if zero.
I'm afraid as it's API breaking change.