### PR TITLE
fix: differentiate max witness script size upon context

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1690,7 +1690,7 @@ mod tests {
         );
         assert_eq!(
             segwit_multi_ms.unwrap_err().to_string(),
-            "The Miniscript corresponding Script would be larger than MAX_STANDARD_P2WSH_SCRIPT_SIZE bytes."
+            "The Miniscript corresponding Script cannot be larger than 3600 bytes, but got 4110 bytes."
         );
         assert_eq!(
             bare_multi_ms.unwrap_err().to_string(),


### PR DESCRIPTION
`MaxWitnessScriptSizeExceeded` is used in the context of `SegwitV0` and `Tap`, where each of max witness script size differs. Moreover, even in the same context of `SegwitV0`, max witness script size differ whether it's standard or consensus rule. I just let `MaxWitnessScriptSizeExceeded` receive param `usize` to differentiate max witness script size upon context, which can fix the wrong err message of `"The Miniscript corresponding Script would be larger than MAX_STANDARD_P2WSH_SCRIPT_SIZE  bytes."` when `SegwitV0` consensus and `Tap` context