### PR TITLE
feature: improve context err

### DIFF
--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -434,7 +434,7 @@ impl ScriptContext for Legacy {
         ms: &Miniscript<Pk, Self>,
     ) -> Result<(), ScriptContextError> {
         match ms.ext.ops.op_count() {
-            None => Err(ScriptContextError::MaxOpCountExceeded),
+            None => Err(ScriptContextError::ImpossibleSatisfaction),
             Some(op_count) if op_count > MAX_OPS_PER_SCRIPT => {
                 Err(ScriptContextError::MaxOpCountExceeded)
             }
@@ -543,7 +543,7 @@ impl ScriptContext for Segwitv0 {
         ms: &Miniscript<Pk, Self>,
     ) -> Result<(), ScriptContextError> {
         match ms.ext.ops.op_count() {
-            None => Err(ScriptContextError::MaxOpCountExceeded),
+            None => Err(ScriptContextError::ImpossibleSatisfaction),
             Some(op_count) if op_count > MAX_OPS_PER_SCRIPT => {
                 Err(ScriptContextError::MaxOpCountExceeded)
             }
@@ -773,7 +773,7 @@ impl ScriptContext for BareCtx {
         ms: &Miniscript<Pk, Self>,
     ) -> Result<(), ScriptContextError> {
         match ms.ext.ops.op_count() {
-            None => Err(ScriptContextError::MaxOpCountExceeded),
+            None => Err(ScriptContextError::ImpossibleSatisfaction),
             Some(op_count) if op_count > MAX_OPS_PER_SCRIPT => {
                 Err(ScriptContextError::MaxOpCountExceeded)
             }

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1686,7 +1686,7 @@ mod tests {
         // Should panic for exceeding the max consensus size, as multi properly used
         assert_eq!(
             legacy_multi_ms.unwrap_err().to_string(),
-            "The Miniscript corresponding Script would be larger than MAX_SCRIPT_ELEMENT_SIZE bytes."
+            "The Miniscript corresponding Script cannot be larger than 520 bytes, but got 685 bytes."
         );
         assert_eq!(
             segwit_multi_ms.unwrap_err().to_string(),
@@ -1694,7 +1694,7 @@ mod tests {
         );
         assert_eq!(
             bare_multi_ms.unwrap_err().to_string(),
-            "The Miniscript corresponding Script would be larger than MAX_SCRIPT_SIZE bytes."
+            "The Miniscript corresponding Script cannot be larger than 10000 bytes, but got 10275 bytes."
         );
     }
 }


### PR DESCRIPTION
919bc4b6c2ad37e94c446871de10a96c84b29f29
- use `ImpossibleSatisfaction` when op_count is None instead of `MaxOpCountExceeded`.

51a50ae3e81b02c4e8f4759df62186b53c5459ba
- unify error message for satisfaction-kind error and scriptPubKey-kind error so that these error can contain max(limit) with what it got(actual).