### PR TITLE
Segwitv0 compilation of x-only keys panics

### DIFF
--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1648,6 +1648,14 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn segwitv0_xonly_pk() {
+        let x_only_key = "08c0fcf8895f4361b4fc77afe2ad53b0bd27dcebfd863421b2b246dc283d4103";
+        let policy: Concrete<bitcoin::XOnlyPublicKey> = policy_str!("pk({})", x_only_key);
+        // Should Err, but currently panics
+        policy.compile::<Segwitv0>().unwrap_err();
+    }
 }
 
 #[cfg(bench)]


### PR DESCRIPTION
It should `Err`, but currently panics. The PR adds a test case demonstrating the issue (but not a fix):

```
test policy::compiler::tests::segwitv0_xonly_pk ... FAILED

---- policy::compiler::tests::segwitv0_xonly_pk stdout ----
thread 'policy::compiler::tests::segwitv0_xonly_pk' panicked at src/policy/compiler.rs:526:52:
Terminal creation must always succeed: ContextError(XOnlyKeysNotAllowed("08c0fcf8895f4361b4fc77afe2ad53b0bd27dcebfd863421b2b246dc283d4103", "Segwitv0"))
```

Parsing a `wsh(pk(XONLY))` straight into a `Descriptor` does work as expected and raises an `Err`, as covered by [this test case](https://github.com/rust-bitcoin/rust-miniscript/blob/aa3691d1738caffa153774767be6f40e071b4aef/src/descriptor/mod.rs#L1894-L1895).