### PR TITLE
feat: check policy validity to prevent duplicate check

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -174,7 +174,7 @@ mod private {
             if (res.ext.tree_height as u32) > MAX_RECURSION_DEPTH {
                 return Err(Error::MaxRecursiveDepthExceeded);
             }
-            Ctx::check_global_consensus_validity(&res)?;
+            Ctx::check_global_validity(&res)?;
             Ok(res)
         }
 
@@ -742,7 +742,6 @@ where
     for ch in frag_wrap.chars().rev() {
         // Check whether the wrapper is valid under the current context
         let ms = Miniscript::from_ast(unwrapped)?;
-        Ctx::check_global_validity(&ms)?;
         match ch {
             'a' => unwrapped = Terminal::Alt(Arc::new(ms)),
             's' => unwrapped = Terminal::Swap(Arc::new(ms)),
@@ -759,7 +758,6 @@ where
     }
     // Check whether the unwrapped miniscript is valid under the current context
     let ms = Miniscript::from_ast(unwrapped)?;
-    Ctx::check_global_validity(&ms)?;
     Ok(ms)
 }
 


### PR DESCRIPTION
- `Miniscript::from_ast()` only executes `check_global_consensus_validity()` which does not include `check_global_policy_validity()`. Change to use `check_global_validity()` to check both consensus and policy validness.
- `wrap_into_miniscript()` executes `check_global_validity()` internally after `Miniscript::from_ast()`. As `Miniscript::from_ast()` now executes `check_global_validity()`,  it doesn't have to check duplicately.

I was originally thinking to change `check_global_validity()` inside `wrap_into_miniscript()` to `check_global_policy_validity()`(as consensus check is done by `from_ast()`). I think it's better to strengthen the validness check in `from_ast()`, and do nothing in `wrap_into_miniscript()`.