### PR TITLE
Rewrite expression parser to be non-recursive

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -118,28 +118,12 @@ as follows:
 ```
 #[cfg(test)]
 mod tests {
-    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
-        let mut b = 0;
-        for (idx, c) in hex.as_bytes().iter().enumerate() {
-            b <<= 4;
-            match *c {
-                b'A'...b'F' => b |= c - b'A' + 10,
-                b'a'...b'f' => b |= c - b'a' + 10,
-                b'0'...b'9' => b |= c - b'0',
-                _ => panic!("Bad hex"),
-            }
-            if (idx & 1) == 1 {
-                out.push(b);
-                b = 0;
-            }
-        }
-    }
+    use miniscript::bitcoin::hex::FromHex;
 
     #[test]
     fn duplicate_crash() {
-        let mut a = Vec::new();
-        extend_vec_from_hex("048531e80700ae6400670000af5168", &mut a);
-        super::do_test(&a);
+        let v = Vec::from_hex("abcd").unwrap();
+        super::do_test(&v);
     }
 }
 ```

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -370,15 +370,10 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Pkh<Pk> {
 
 impl<Pk: FromStrKey> FromTree for Pkh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
-        if top.name == "pkh" && top.args.len() == 1 {
-            Ok(Pkh::new(expression::terminal(&top.args[0], |pk| Pk::from_str(pk))?)?)
-        } else {
-            Err(Error::Unexpected(format!(
-                "{}({} args) while parsing pkh descriptor",
-                top.name,
-                top.args.len(),
-            )))
-        }
+        let top = top
+            .verify_toplevel("pkh", 1..=1)
+            .map_err(Error::ParseTree)?;
+        Ok(Pkh::new(expression::terminal(top, |pk| Pk::from_str(pk))?)?)
     }
 }
 

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -372,7 +372,8 @@ impl<Pk: FromStrKey> FromTree for Pkh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         let top = top
             .verify_toplevel("pkh", 1..=1)
-            .map_err(Error::ParseTree)?;
+            .map_err(From::from)
+            .map_err(Error::Parse)?;
         Ok(Pkh::new(expression::terminal(top, |pk| Pk::from_str(pk))?)?)
     }
 }

--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -8,8 +8,8 @@
 //! [BIP-380]: <https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki>
 
 use core::convert::TryFrom;
-use core::fmt;
 use core::iter::FromIterator;
+use core::{array, fmt};
 
 use bech32::primitives::checksum::PackedFe32;
 use bech32::{Checksum, Fe32};
@@ -115,10 +115,10 @@ pub fn verify_checksum(s: &str) -> Result<&str, Error> {
         eng.input_unchecked(s[..last_hash_pos].as_bytes());
 
         let expected = eng.checksum_chars();
-        let mut actual = ['_'; CHECKSUM_LENGTH];
-        for (act, ch) in actual.iter_mut().zip(checksum_str.chars()) {
-            *act = ch;
-        }
+
+        let mut iter = checksum_str.chars();
+        let actual: [char; CHECKSUM_LENGTH] =
+            array::from_fn(|_| iter.next().expect("length checked above"));
 
         if expected != actual {
             return Err(Error::InvalidChecksum { actual, expected });

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1852,9 +1852,10 @@ mod tests {
         // https://github.com/bitcoin/bitcoin/blob/7ae86b3c6845873ca96650fc69beb4ae5285c801/src/test/descriptor_tests.cpp#L355-L360
         macro_rules! check_invalid_checksum {
             ($secp: ident,$($desc: expr),*) => {
+                use crate::{ParseError, ParseTreeError};
                 $(
                     match Descriptor::parse_descriptor($secp, $desc) {
-                        Err(Error::ParseTree(crate::ParseTreeError::Checksum(_))) => {},
+                        Err(Error::Parse(ParseError::Tree(ParseTreeError::Checksum(_)))) => {},
                         Err(e) => panic!("Expected bad checksum for {}, got '{}'", $desc, e),
                         _ => panic!("Invalid checksum treated as valid: {}", $desc),
                     };

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1102,7 +1102,7 @@ mod tests {
             StdDescriptor::from_str("sh(sortedmulti)")
                 .unwrap_err()
                 .to_string(),
-            "expected threshold, found terminal",
+            "sortedmulti must have at least 1 children, but found 0"
         ); //issue 202
         assert_eq!(
             StdDescriptor::from_str(&format!("sh(sortedmulti(2,{}))", &TEST_PK[3..69]))

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -248,21 +248,16 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Wsh<Pk> {
 
 impl<Pk: FromStrKey> crate::expression::FromTree for Wsh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
-        if top.name == "wsh" && top.args.len() == 1 {
-            let top = &top.args[0];
-            if top.name == "sortedmulti" {
-                return Ok(Wsh { inner: WshInner::SortedMulti(SortedMultiVec::from_tree(top)?) });
-            }
-            let sub = Miniscript::from_tree(top)?;
-            Segwitv0::top_level_checks(&sub)?;
-            Ok(Wsh { inner: WshInner::Ms(sub) })
-        } else {
-            Err(Error::Unexpected(format!(
-                "{}({} args) while parsing wsh descriptor",
-                top.name,
-                top.args.len(),
-            )))
+        let top = top
+            .verify_toplevel("wsh", 1..=1)
+            .map_err(Error::ParseTree)?;
+
+        if top.name == "sortedmulti" {
+            return Ok(Wsh { inner: WshInner::SortedMulti(SortedMultiVec::from_tree(top)?) });
         }
+        let sub = Miniscript::from_tree(top)?;
+        Segwitv0::top_level_checks(&sub)?;
+        Ok(Wsh { inner: WshInner::Ms(sub) })
     }
 }
 
@@ -488,15 +483,10 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Wpkh<Pk> {
 
 impl<Pk: FromStrKey> crate::expression::FromTree for Wpkh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
-        if top.name == "wpkh" && top.args.len() == 1 {
-            Ok(Wpkh::new(expression::terminal(&top.args[0], |pk| Pk::from_str(pk))?)?)
-        } else {
-            Err(Error::Unexpected(format!(
-                "{}({} args) while parsing wpkh descriptor",
-                top.name,
-                top.args.len(),
-            )))
-        }
+        let top = top
+            .verify_toplevel("wpkh", 1..=1)
+            .map_err(Error::ParseTree)?;
+        Ok(Wpkh::new(expression::terminal(top, |pk| Pk::from_str(pk))?)?)
     }
 }
 

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -250,7 +250,8 @@ impl<Pk: FromStrKey> crate::expression::FromTree for Wsh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         let top = top
             .verify_toplevel("wsh", 1..=1)
-            .map_err(Error::ParseTree)?;
+            .map_err(From::from)
+            .map_err(Error::Parse)?;
 
         if top.name == "sortedmulti" {
             return Ok(Wsh { inner: WshInner::SortedMulti(SortedMultiVec::from_tree(top)?) });
@@ -485,7 +486,8 @@ impl<Pk: FromStrKey> crate::expression::FromTree for Wpkh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
         let top = top
             .verify_toplevel("wpkh", 1..=1)
-            .map_err(Error::ParseTree)?;
+            .map_err(From::from)
+            .map_err(Error::Parse)?;
         Ok(Wpkh::new(expression::terminal(top, |pk| Pk::from_str(pk))?)?)
     }
 }

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -82,7 +82,10 @@ impl<Pk: MiniscriptKey> fmt::Display for Sh<Pk> {
 
 impl<Pk: FromStrKey> crate::expression::FromTree for Sh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
-        let top = top.verify_toplevel("sh", 1..=1).map_err(Error::ParseTree)?;
+        let top = top
+            .verify_toplevel("sh", 1..=1)
+            .map_err(From::from)
+            .map_err(Error::Parse)?;
 
         let inner = match top.name {
             "wsh" => ShInner::Wsh(Wsh::from_tree(top)?),

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -82,26 +82,19 @@ impl<Pk: MiniscriptKey> fmt::Display for Sh<Pk> {
 
 impl<Pk: FromStrKey> crate::expression::FromTree for Sh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
-        if top.name == "sh" && top.args.len() == 1 {
-            let top = &top.args[0];
-            let inner = match top.name {
-                "wsh" => ShInner::Wsh(Wsh::from_tree(top)?),
-                "wpkh" => ShInner::Wpkh(Wpkh::from_tree(top)?),
-                "sortedmulti" => ShInner::SortedMulti(SortedMultiVec::from_tree(top)?),
-                _ => {
-                    let sub = Miniscript::from_tree(top)?;
-                    Legacy::top_level_checks(&sub)?;
-                    ShInner::Ms(sub)
-                }
-            };
-            Ok(Sh { inner })
-        } else {
-            Err(Error::Unexpected(format!(
-                "{}({} args) while parsing sh descriptor",
-                top.name,
-                top.args.len(),
-            )))
-        }
+        let top = top.verify_toplevel("sh", 1..=1).map_err(Error::ParseTree)?;
+
+        let inner = match top.name {
+            "wsh" => ShInner::Wsh(Wsh::from_tree(top)?),
+            "wpkh" => ShInner::Wpkh(Wpkh::from_tree(top)?),
+            "sortedmulti" => ShInner::SortedMulti(SortedMultiVec::from_tree(top)?),
+            _ => {
+                let sub = Miniscript::from_tree(top)?;
+                Legacy::top_level_checks(&sub)?;
+                ShInner::Ms(sub)
+            }
+        };
+        Ok(Sh { inner })
     }
 }
 

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -64,6 +64,9 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
         Pk: FromStr,
         <Pk as FromStr>::Err: fmt::Display,
     {
+        tree.verify_toplevel("sortedmulti", 1..)
+            .map_err(Error::ParseTree)?;
+
         let ret = Self {
             inner: tree
                 .to_null_threshold()

--- a/src/descriptor/sortedmulti.rs
+++ b/src/descriptor/sortedmulti.rs
@@ -65,7 +65,8 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> SortedMultiVec<Pk, Ctx> {
         <Pk as FromStr>::Err: fmt::Display,
     {
         tree.verify_toplevel("sortedmulti", 1..)
-            .map_err(Error::ParseTree)?;
+            .map_err(From::from)
+            .map_err(Error::Parse)?;
 
         let ret = Self {
             inner: tree

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,53 @@
+// Written in 2019 by Andrew Poelstra <apoelstra@wpsoftware.net>
+// SPDX-License-Identifier: CC0-1.0
+
+//! Errors
+
+use core::fmt;
+#[cfg(feature = "std")]
+use std::error;
+
+use crate::blanket_traits::StaticDebugAndDisplay;
+use crate::Box;
+/// An error parsing a Miniscript object (policy, descriptor or miniscript)
+/// from a string.
+#[derive(Debug)]
+pub enum ParseError {
+    /// Failed to parse a public key or hash.
+    ///
+    /// Note that the error information is lost for nostd compatibility reasons. See
+    /// <https://users.rust-lang.org/t/how-to-box-an-error-type-retaining-std-error-only-when-std-is-enabled/>.
+    FromStr(Box<dyn StaticDebugAndDisplay>),
+    /// Error parsing a string into an expression tree.
+    Tree(crate::ParseTreeError),
+}
+
+impl ParseError {
+    /// Boxes a `FromStr` error for a `Pk` (or associated types) into a `ParseError`
+    pub(crate) fn box_from_str<E: StaticDebugAndDisplay>(e: E) -> Self {
+        ParseError::FromStr(Box::new(e))
+    }
+}
+
+impl From<crate::ParseTreeError> for ParseError {
+    fn from(e: crate::ParseTreeError) -> Self { Self::Tree(e) }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParseError::FromStr(ref e) => e.fmt(f),
+            ParseError::Tree(ref e) => e.fmt(f),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            ParseError::FromStr(..) => None,
+            ParseError::Tree(ref e) => Some(e),
+        }
+    }
+}

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -429,8 +429,7 @@ mod tests {
             ",
             )
             .unwrap();
-            let mut dummy_sig = [0u8; 48];
-            dummy_sig.copy_from_slice(&dummy_sig_vec[..]);
+            let dummy_sig = <[u8; 48]>::try_from(&dummy_sig_vec[..]).unwrap();
 
             let pkhash = key.to_pubkeyhash(SigType::Ecdsa).into();
             let wpkhash = key.to_pubkeyhash(SigType::Ecdsa).into();

--- a/src/interpreter/stack.rs
+++ b/src/interpreter/stack.rs
@@ -261,7 +261,7 @@ impl<'txin> Stack<'txin> {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
                     hash: HashLockType::Sha256(*hash),
-                    preimage: preimage_from_sl(preimage),
+                    preimage: <[u8; 32]>::try_from(preimage).expect("length checked above"),
                 }))
             } else {
                 self.push(Element::Dissatisfied);
@@ -286,7 +286,7 @@ impl<'txin> Stack<'txin> {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
                     hash: HashLockType::Hash256(*hash),
-                    preimage: preimage_from_sl(preimage),
+                    preimage: <[u8; 32]>::try_from(preimage).expect("length checked above"),
                 }))
             } else {
                 self.push(Element::Dissatisfied);
@@ -311,7 +311,7 @@ impl<'txin> Stack<'txin> {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
                     hash: HashLockType::Hash160(*hash),
-                    preimage: preimage_from_sl(preimage),
+                    preimage: <[u8; 32]>::try_from(preimage).expect("length checked above"),
                 }))
             } else {
                 self.push(Element::Dissatisfied);
@@ -336,7 +336,7 @@ impl<'txin> Stack<'txin> {
                 self.push(Element::Satisfied);
                 Some(Ok(SatisfiedConstraint::HashLock {
                     hash: HashLockType::Ripemd160(*hash),
-                    preimage: preimage_from_sl(preimage),
+                    preimage: <[u8; 32]>::try_from(preimage).expect("length checked above"),
                 }))
             } else {
                 self.push(Element::Dissatisfied);
@@ -374,16 +374,5 @@ impl<'txin> Stack<'txin> {
         } else {
             Some(Err(Error::UnexpectedStackEnd))
         }
-    }
-}
-
-// Helper function to compute preimage from slice
-fn preimage_from_sl(sl: &[u8]) -> [u8; 32] {
-    if sl.len() != 32 {
-        unreachable!("Internal: Preimage length checked to be 32")
-    } else {
-        let mut preimage = [0u8; 32];
-        preimage.copy_from_slice(sl);
-        preimage
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,10 +423,6 @@ pub enum Error {
     AddrError(bitcoin::address::ParseError),
     /// rust-bitcoin p2sh address error
     AddrP2shError(bitcoin::address::P2shError),
-    /// A `CHECKMULTISIG` opcode was preceded by a number > 20
-    CmsTooManyKeys(u32),
-    /// A tapscript multi_a cannot support more than Weight::MAX_BLOCK/32 keys
-    MultiATooManyKeys(u64),
     /// While parsing backward, hit beginning of script
     UnexpectedStart,
     /// Got something we were not expecting
@@ -504,7 +500,6 @@ impl fmt::Display for Error {
             Error::Script(ref e) => fmt::Display::fmt(e, f),
             Error::AddrError(ref e) => fmt::Display::fmt(e, f),
             Error::AddrP2shError(ref e) => fmt::Display::fmt(e, f),
-            Error::CmsTooManyKeys(n) => write!(f, "checkmultisig with {} keys", n),
             Error::UnexpectedStart => f.write_str("unexpected start of script"),
             Error::Unexpected(ref s) => write!(f, "unexpected «{}»", s),
             Error::MultiColon(ref s) => write!(f, "«{}» has multiple instances of «:»", s),
@@ -539,7 +534,6 @@ impl fmt::Display for Error {
             Error::PubKeyCtxError(ref pk, ref ctx) => {
                 write!(f, "Pubkey error: {} under {} scriptcontext", pk, ctx)
             }
-            Error::MultiATooManyKeys(k) => write!(f, "MultiA too many keys {}", k),
             Error::TrNoScriptCode => write!(f, "No script code for Tr descriptors"),
             Error::MultipathDescLenMismatch => write!(f, "At least two BIP389 key expressions in the descriptor contain tuples of derivation indexes of different lengths"),
             Error::AbsoluteLockTime(ref e) => e.fmt(f),
@@ -560,8 +554,6 @@ impl std::error::Error for Error {
             InvalidOpcode(_)
             | NonMinimalVerify(_)
             | InvalidPush(_)
-            | CmsTooManyKeys(_)
-            | MultiATooManyKeys(_)
             | UnexpectedStart
             | Unexpected(_)
             | MultiColon(_)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ mod pub_macros;
 mod benchmarks;
 mod blanket_traits;
 pub mod descriptor;
+mod error;
 pub mod expression;
 pub mod interpreter;
 pub mod iter;
@@ -128,8 +129,6 @@ mod test_utils;
 mod util;
 
 use core::{fmt, hash, str};
-#[cfg(feature = "std")]
-use std::error;
 
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
 use bitcoin::hex::DisplayHex;
@@ -137,6 +136,7 @@ use bitcoin::{script, Opcode};
 
 pub use crate::blanket_traits::FromStrKey;
 pub use crate::descriptor::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey};
+pub use crate::error::ParseError;
 pub use crate::expression::{ParseThresholdError, ParseTreeError};
 pub use crate::interpreter::Interpreter;
 pub use crate::miniscript::analyzable::{AnalysisError, ExtParams};
@@ -494,6 +494,8 @@ pub enum Error {
     ParseThreshold(ParseThresholdError),
     /// Invalid expression tree.
     ParseTree(ParseTreeError),
+    /// Invalid expression tree.
+    Parse(ParseError),
 }
 
 // https://github.com/sipa/miniscript/pull/5 for discussion on this number
@@ -556,13 +558,14 @@ impl fmt::Display for Error {
             Error::Threshold(ref e) => e.fmt(f),
             Error::ParseThreshold(ref e) => e.fmt(f),
             Error::ParseTree(ref e) => e.fmt(f),
+            Error::Parse(ref e) => e.fmt(f),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
+impl std::error::Error for Error {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         use self::Error::*;
 
         match self {
@@ -607,6 +610,7 @@ impl error::Error for Error {
             Threshold(e) => Some(e),
             ParseThreshold(e) => Some(e),
             ParseTree(e) => Some(e),
+            Parse(e) => Some(e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,8 +493,6 @@ pub enum Error {
     /// Invalid threshold.
     ParseThreshold(ParseThresholdError),
     /// Invalid expression tree.
-    ParseTree(ParseTreeError),
-    /// Invalid expression tree.
     Parse(ParseError),
 }
 
@@ -557,7 +555,6 @@ impl fmt::Display for Error {
             Error::RelativeLockTime(ref e) => e.fmt(f),
             Error::Threshold(ref e) => e.fmt(f),
             Error::ParseThreshold(ref e) => e.fmt(f),
-            Error::ParseTree(ref e) => e.fmt(f),
             Error::Parse(ref e) => e.fmt(f),
         }
     }
@@ -609,7 +606,6 @@ impl std::error::Error for Error {
             RelativeLockTime(e) => Some(e),
             Threshold(e) => Some(e),
             ParseThreshold(e) => Some(e),
-            ParseTree(e) => Some(e),
             Parse(e) => Some(e),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,10 +427,6 @@ pub enum Error {
     CmsTooManyKeys(u32),
     /// A tapscript multi_a cannot support more than Weight::MAX_BLOCK/32 keys
     MultiATooManyKeys(u64),
-    /// Encountered unprintable character in descriptor
-    Unprintable(u8),
-    /// expected character while parsing descriptor; didn't find one
-    ExpectedChar(char),
     /// While parsing backward, hit beginning of script
     UnexpectedStart,
     /// Got something we were not expecting
@@ -451,8 +447,6 @@ pub enum Error {
     CouldNotSatisfy,
     /// Typechecking failed
     TypeCheck(String),
-    /// General error in creating descriptor
-    BadDescriptor(String),
     /// Forward-secp related errors
     Secp(bitcoin::secp256k1::Error),
     #[cfg(feature = "compiler")]
@@ -511,8 +505,6 @@ impl fmt::Display for Error {
             Error::AddrError(ref e) => fmt::Display::fmt(e, f),
             Error::AddrP2shError(ref e) => fmt::Display::fmt(e, f),
             Error::CmsTooManyKeys(n) => write!(f, "checkmultisig with {} keys", n),
-            Error::Unprintable(x) => write!(f, "unprintable character 0x{:02x}", x),
-            Error::ExpectedChar(c) => write!(f, "expected {}", c),
             Error::UnexpectedStart => f.write_str("unexpected start of script"),
             Error::Unexpected(ref s) => write!(f, "unexpected «{}»", s),
             Error::MultiColon(ref s) => write!(f, "«{}» has multiple instances of «:»", s),
@@ -523,7 +515,6 @@ impl fmt::Display for Error {
             Error::MissingSig(ref pk) => write!(f, "missing signature for key {:?}", pk),
             Error::CouldNotSatisfy => f.write_str("could not satisfy"),
             Error::TypeCheck(ref e) => write!(f, "typecheck: {}", e),
-            Error::BadDescriptor(ref e) => write!(f, "Invalid descriptor: {}", e),
             Error::Secp(ref e) => fmt::Display::fmt(e, f),
             Error::ContextError(ref e) => fmt::Display::fmt(e, f),
             #[cfg(feature = "compiler")]
@@ -571,8 +562,6 @@ impl std::error::Error for Error {
             | InvalidPush(_)
             | CmsTooManyKeys(_)
             | MultiATooManyKeys(_)
-            | Unprintable(_)
-            | ExpectedChar(_)
             | UnexpectedStart
             | Unexpected(_)
             | MultiColon(_)
@@ -583,7 +572,6 @@ impl std::error::Error for Error {
             | MissingSig(_)
             | CouldNotSatisfy
             | TypeCheck(_)
-            | BadDescriptor(_)
             | MaxRecursiveDepthExceeded
             | NonStandardBareScript
             | ImpossibleSatisfaction

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -802,6 +802,7 @@ impl<Pk: FromStrKey, Ctx: ScriptContext> crate::expression::FromTree for Miniscr
     /// Parse an expression tree into a Miniscript. As a general rule, this
     /// should not be called directly; rather go through the descriptor API.
     fn from_tree(top: &expression::Tree) -> Result<Miniscript<Pk, Ctx>, Error> {
+        top.verify_no_curly_braces().map_err(Error::ParseTree)?;
         let inner: Terminal<Pk, Ctx> = expression::FromTree::from_tree(top)?;
         Miniscript::from_ast(inner)
     }

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -802,7 +802,9 @@ impl<Pk: FromStrKey, Ctx: ScriptContext> crate::expression::FromTree for Miniscr
     /// Parse an expression tree into a Miniscript. As a general rule, this
     /// should not be called directly; rather go through the descriptor API.
     fn from_tree(top: &expression::Tree) -> Result<Miniscript<Pk, Ctx>, Error> {
-        top.verify_no_curly_braces().map_err(Error::ParseTree)?;
+        top.verify_no_curly_braces()
+            .map_err(From::from)
+            .map_err(Error::Parse)?;
         let inner: Terminal<Pk, Ctx> = expression::FromTree::from_tree(top)?;
         Miniscript::from_ast(inner)
     }

--- a/src/primitives/threshold.rs
+++ b/src/primitives/threshold.rs
@@ -40,6 +40,15 @@ impl std::error::Error for ThresholdError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
 }
 
+/// Check whether `k` and `n` are valid for an instance of [`Self`].
+pub fn validate_k_n<const MAX: usize>(k: usize, n: usize) -> Result<(), ThresholdError> {
+    if k == 0 || k > n || (MAX > 0 && n > MAX) {
+        Err(ThresholdError { k, n, max: (MAX > 0).then_some(MAX) })
+    } else {
+        Ok(())
+    }
+}
+
 /// Structure representing a k-of-n threshold collection of some arbitrary
 /// object `T`.
 ///
@@ -54,11 +63,8 @@ pub struct Threshold<T, const MAX: usize> {
 impl<T, const MAX: usize> Threshold<T, MAX> {
     /// Constructs a threshold directly from a threshold value and collection.
     pub fn new(k: usize, inner: Vec<T>) -> Result<Self, ThresholdError> {
-        if k == 0 || k > inner.len() || (MAX > 0 && inner.len() > MAX) {
-            Err(ThresholdError { k, n: inner.len(), max: (MAX > 0).then_some(MAX) })
-        } else {
-            Ok(Threshold { k, inner })
-        }
+        validate_k_n::<MAX>(k, inner.len())?;
+        Ok(Threshold { k, inner })
     }
 
     /// Constructs a threshold from a threshold value and an iterator that yields collection

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -340,38 +340,28 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for PsbtInputSatisfier<'_> {
         self.psbt.inputs[self.index]
             .hash160_preimages
             .get(&Pk::to_hash160(h))
-            .and_then(|x: &Vec<u8>| try_vec_as_preimage32(x))
+            .and_then(|x: &Vec<u8>| <[u8; 32]>::try_from(&x[..]).ok())
     }
 
     fn lookup_sha256(&self, h: &Pk::Sha256) -> Option<Preimage32> {
         self.psbt.inputs[self.index]
             .sha256_preimages
             .get(&Pk::to_sha256(h))
-            .and_then(|x: &Vec<u8>| try_vec_as_preimage32(x))
+            .and_then(|x: &Vec<u8>| <[u8; 32]>::try_from(&x[..]).ok())
     }
 
     fn lookup_hash256(&self, h: &Pk::Hash256) -> Option<Preimage32> {
         self.psbt.inputs[self.index]
             .hash256_preimages
             .get(&sha256d::Hash::from_byte_array(Pk::to_hash256(h).to_byte_array())) // upstream psbt operates on hash256
-            .and_then(|x: &Vec<u8>| try_vec_as_preimage32(x))
+            .and_then(|x: &Vec<u8>| <[u8; 32]>::try_from(&x[..]).ok())
     }
 
     fn lookup_ripemd160(&self, h: &Pk::Ripemd160) -> Option<Preimage32> {
         self.psbt.inputs[self.index]
             .ripemd160_preimages
             .get(&Pk::to_ripemd160(h))
-            .and_then(|x: &Vec<u8>| try_vec_as_preimage32(x))
-    }
-}
-
-fn try_vec_as_preimage32(vec: &[u8]) -> Option<Preimage32> {
-    if vec.len() == 32 {
-        let mut arr = [0u8; 32];
-        arr.copy_from_slice(vec);
-        Some(arr)
-    } else {
-        None
+            .and_then(|x: &Vec<u8>| <[u8; 32]>::try_from(&x[..]).ok())
     }
 }
 


### PR DESCRIPTION
This PR does several things but the only big commit is "unify Taproot and non-Taproot parsing" which replaces the ad-hoc logic in `Tr::from_str` to handle Taproot parsing with unified expression-parsing logic.

In addition to this, we also:
* rewrite the expression parser to be non-recursive, which is a reduction in LOC thanks to our prepatory work
* introduces an `error` module whose types will eventually replace the top-level `Error` enum
* relatedly, drops several error variants including the stringly-typed `BadDescriptor` (it does not get rid of `Unexpected` which is *also* a stringly-typed catch-all error, but we will..)

