### PR TITLE
feat: remove inefficient if check on match lex

### DIFF
--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -138,10 +138,10 @@ pub fn lex(script: &'_ script::Script) -> Result<Vec<Token<'_>>, Error> {
                 ret.push(Token::CheckMultiSig);
                 ret.push(Token::Verify);
             }
-            script::Instruction::Op(op) if op == opcodes::all::OP_CSV => {
+            script::Instruction::Op(opcodes::all::OP_CSV) => {
                 ret.push(Token::CheckSequenceVerify);
             }
-            script::Instruction::Op(op) if op == opcodes::all::OP_CLTV => {
+            script::Instruction::Op(opcodes::all::OP_CLTV) => {
                 ret.push(Token::CheckLockTimeVerify);
             }
             script::Instruction::Op(opcodes::all::OP_FROMALTSTACK) => {


### PR DESCRIPTION
I'm not sure whether it's intentional, but this pattern(match and then if) could make lexer little slower for `OP_CSV` and `OP_CLTV`(and `Error::InvalidOpcode`) as they aren't caught in match arms but `if` block like below(which causes additional check).

```rust
...
script::Instruction::Op(op) => {
                if op == opcodes::all::OP_CSV {
                    ret.push(Token::CheckSequenceVerify);
                } else if op == opcodes::all::OP_CLTV {
                    ret.push(Token::CheckLockTimeVerify);
                } else {
                    return Err(Error::InvalidOpcode(op))
                }
}
```