### PR TITLE
cleanups: Eliminate `errstr` and (nearly) eliminate `Unexpected`

### DIFF
--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -370,11 +370,10 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Pkh<Pk> {
 
 impl<Pk: FromStrKey> FromTree for Pkh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
-        let top = top
-            .verify_toplevel("pkh", 1..=1)
-            .map_err(From::from)
+        let pk = top
+            .verify_terminal_parent("pkh", "public key")
             .map_err(Error::Parse)?;
-        Ok(Pkh::new(expression::terminal(top, |pk| Pk::from_str(pk))?)?)
+        Pkh::new(pk).map_err(Error::ContextError)
     }
 }
 

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -484,11 +484,10 @@ impl<Pk: MiniscriptKey> Liftable<Pk> for Wpkh<Pk> {
 
 impl<Pk: FromStrKey> crate::expression::FromTree for Wpkh<Pk> {
     fn from_tree(top: &expression::Tree) -> Result<Self, Error> {
-        let top = top
-            .verify_toplevel("wpkh", 1..=1)
-            .map_err(From::from)
+        let pk = top
+            .verify_terminal_parent("wpkh", "public key")
             .map_err(Error::Parse)?;
-        Ok(Wpkh::new(expression::terminal(top, |pk| Pk::from_str(pk))?)?)
+        Wpkh::new(pk).map_err(Error::ContextError)
     }
 }
 

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -524,21 +524,11 @@ impl<Pk: FromStrKey> crate::expression::FromTree for Tr<Pk> {
                 }
             } else if item.index == 1 {
                 // First child of tr, which must be the internal key
-                if !item.node.args.is_empty() {
-                    return Err(Error::Parse(ParseError::Tree(
-                        ParseTreeError::IncorrectNumberOfChildren {
-                            description: "internal key",
-                            n_children: item.node.args.len(),
-                            minimum: Some(0),
-                            maximum: Some(0),
-                        },
-                    )));
-                }
-                internal_key = Some(
-                    Pk::from_str(item.node.name)
-                        .map_err(ParseError::box_from_str)
-                        .map_err(Error::Parse)?,
-                );
+                internal_key = item
+                    .node
+                    .verify_terminal("internal key")
+                    .map_err(Error::Parse)
+                    .map(Some)?;
             } else {
                 // From here on we are into the taptree.
                 if item.n_children_yielded == 0 {

--- a/src/expression/error.rs
+++ b/src/expression/error.rs
@@ -76,6 +76,13 @@ pub enum ParseTreeError {
         /// The position of the opening curly brace.
         pos: usize,
     },
+    ///  Multiple separators (':' or '@') appeared in a node name.
+    MultipleSeparators {
+        /// The separator in question.
+        separator: char,
+        /// The position of the second separator.
+        pos: usize,
+    },
     /// Data occurred after the final ).
     TrailingCharacter {
         /// The first trailing character.
@@ -149,6 +156,13 @@ impl fmt::Display for ParseTreeError {
                 }?;
                 write!(f, ", but found {}", n_children)
             }
+            ParseTreeError::MultipleSeparators { separator, pos } => {
+                write!(
+                    f,
+                    "separator '{}' occured multiple times (second time at position {})",
+                    separator, pos
+                )
+            }
             ParseTreeError::TrailingCharacter { ch, pos } => {
                 write!(f, "trailing data `{}...` (position {})", ch, pos)
             }
@@ -169,6 +183,7 @@ impl std::error::Error for ParseTreeError {
             | ParseTreeError::IllegalCurlyBrace { .. }
             | ParseTreeError::IncorrectName { .. }
             | ParseTreeError::IncorrectNumberOfChildren { .. }
+            | ParseTreeError::MultipleSeparators { .. }
             | ParseTreeError::TrailingCharacter { .. }
             | ParseTreeError::UnknownName { .. } => None,
         }

--- a/src/expression/error.rs
+++ b/src/expression/error.rs
@@ -83,6 +83,11 @@ pub enum ParseTreeError {
         /// Its byte-index into the string.
         pos: usize,
     },
+    /// A node's name was not recognized.
+    UnknownName {
+        /// The name that was not recognized.
+        name: String,
+    },
 }
 
 impl From<checksum::Error> for ParseTreeError {
@@ -147,6 +152,7 @@ impl fmt::Display for ParseTreeError {
             ParseTreeError::TrailingCharacter { ch, pos } => {
                 write!(f, "trailing data `{}...` (position {})", ch, pos)
             }
+            ParseTreeError::UnknownName { name } => write!(f, "unrecognized name '{}'", name),
         }
     }
 }
@@ -163,7 +169,8 @@ impl std::error::Error for ParseTreeError {
             | ParseTreeError::IllegalCurlyBrace { .. }
             | ParseTreeError::IncorrectName { .. }
             | ParseTreeError::IncorrectNumberOfChildren { .. }
-            | ParseTreeError::TrailingCharacter { .. } => None,
+            | ParseTreeError::TrailingCharacter { .. }
+            | ParseTreeError::UnknownName { .. } => None,
         }
     }
 }

--- a/src/expression/error.rs
+++ b/src/expression/error.rs
@@ -212,6 +212,10 @@ pub enum ParseThresholdError {
     NoChildren,
     /// The threshold value appeared to be a sub-expression rather than a number.
     KNotTerminal,
+    /// A 1-of-n threshold was used in a context it was not allowed.
+    IllegalOr,
+    /// A n-of-n threshold was used in a context it was not allowed.
+    IllegalAnd,
     /// Failed to parse the threshold value.
     ParseK(ParseNumError),
     /// Threshold parameters were invalid.
@@ -225,6 +229,12 @@ impl fmt::Display for ParseThresholdError {
         match *self {
             NoChildren => f.write_str("expected threshold, found terminal"),
             KNotTerminal => f.write_str("expected positive integer, found expression"),
+            IllegalOr => f.write_str(
+                "1-of-n thresholds not allowed here; please use an 'or' fragment instead",
+            ),
+            IllegalAnd => f.write_str(
+                "n-of-n thresholds not allowed here; please use an 'and' fragment instead",
+            ),
             ParseK(ref x) => write!(f, "failed to parse threshold value: {}", x),
             Threshold(ref e) => e.fmt(f),
         }
@@ -237,8 +247,7 @@ impl std::error::Error for ParseThresholdError {
         use ParseThresholdError::*;
 
         match *self {
-            NoChildren => None,
-            KNotTerminal => None,
+            NoChildren | KNotTerminal | IllegalOr | IllegalAnd => None,
             ParseK(ref e) => Some(e),
             Threshold(ref e) => Some(e),
         }

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -137,6 +137,20 @@ impl<'a> Tree<'a> {
         }
     }
 
+    /// Check that a tree node has exactly two children.
+    ///
+    /// If so, return them.
+    ///
+    /// The `description` argument is only used to populate the error return,
+    /// and is not validated in any way.
+    pub fn verify_binary(
+        &self,
+        description: &'static str,
+    ) -> Result<(&Self, &Self), ParseTreeError> {
+        self.verify_n_children(description, 2..=2)?;
+        Ok((&self.args[0], &self.args[1]))
+    }
+
     /// Check that a tree has no curly-brace children in it.
     pub fn verify_no_curly_braces(&self) -> Result<(), ParseTreeError> {
         for tree in self.pre_order_iter() {
@@ -351,36 +365,6 @@ where
 {
     if term.args.is_empty() {
         convert(term.name).map_err(|e| Error::Unexpected(e.to_string()))
-    } else {
-        Err(errstr(term.name))
-    }
-}
-
-/// Attempts to parse an expression with exactly one child
-pub fn unary<L, T, F>(term: &Tree, convert: F) -> Result<T, Error>
-where
-    L: FromTree,
-    F: FnOnce(L) -> T,
-{
-    if term.args.len() == 1 {
-        let left = FromTree::from_tree(&term.args[0])?;
-        Ok(convert(left))
-    } else {
-        Err(errstr(term.name))
-    }
-}
-
-/// Attempts to parse an expression with exactly two children
-pub fn binary<L, R, T, F>(term: &Tree, convert: F) -> Result<T, Error>
-where
-    L: FromTree,
-    R: FromTree,
-    F: FnOnce(L, R) -> T,
-{
-    if term.args.len() == 2 {
-        let left = FromTree::from_tree(&term.args[0])?;
-        let right = FromTree::from_tree(&term.args[1])?;
-        Ok(convert(left, right))
     } else {
         Err(errstr(term.name))
     }

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -79,6 +79,25 @@ pub trait FromTree: Sized {
 }
 
 impl<'a> Tree<'a> {
+    /// Split the name by a separating character.
+    ///
+    /// If the separator is present, returns the prefix before the separator and
+    /// the suffix after the separator. Otherwise returns the whole name.
+    ///
+    /// If the separator occurs multiple times, returns an error.
+    pub fn name_separated(&self, separator: char) -> Result<(Option<&str>, &str), ParseTreeError> {
+        let mut name_split = self.name.splitn(3, separator);
+        match (name_split.next(), name_split.next(), name_split.next()) {
+            (None, _, _) => unreachable!("'split' always yields at least one element"),
+            (Some(_), None, _) => Ok((None, self.name)),
+            (Some(prefix), Some(name), None) => Ok((Some(prefix), name)),
+            (Some(_), Some(_), Some(suffix)) => Err(ParseTreeError::MultipleSeparators {
+                separator,
+                pos: self.children_pos - suffix.len() - 1,
+            }),
+        }
+    }
+
     /// Check that a tree node has the given number of children.
     ///
     /// The `description` argument is only used to populate the error return,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ use bitcoin::{script, Opcode};
 pub use crate::blanket_traits::FromStrKey;
 pub use crate::descriptor::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey};
 pub use crate::error::ParseError;
-pub use crate::expression::{ParseThresholdError, ParseTreeError};
+pub use crate::expression::{ParseNumError, ParseThresholdError, ParseTreeError};
 pub use crate::interpreter::Interpreter;
 pub use crate::miniscript::analyzable::{AnalysisError, ExtParams};
 pub use crate::miniscript::context::{BareCtx, Legacy, ScriptContext, Segwitv0, SigType, Tap};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,8 +449,6 @@ pub enum Error {
     /// Compiler related errors
     CompilerError(crate::policy::compiler::CompilerError),
     /// Errors related to policy
-    SemanticPolicy(policy::semantic::PolicyError),
-    /// Errors related to policy
     ConcretePolicy(policy::concrete::PolicyError),
     /// Errors related to lifting
     LiftError(policy::LiftError),
@@ -514,7 +512,6 @@ impl fmt::Display for Error {
             Error::ContextError(ref e) => fmt::Display::fmt(e, f),
             #[cfg(feature = "compiler")]
             Error::CompilerError(ref e) => fmt::Display::fmt(e, f),
-            Error::SemanticPolicy(ref e) => fmt::Display::fmt(e, f),
             Error::ConcretePolicy(ref e) => fmt::Display::fmt(e, f),
             Error::LiftError(ref e) => fmt::Display::fmt(e, f),
             Error::MaxRecursiveDepthExceeded => write!(
@@ -577,7 +574,6 @@ impl std::error::Error for Error {
             #[cfg(feature = "compiler")]
             CompilerError(e) => Some(e),
             ConcretePolicy(e) => Some(e),
-            SemanticPolicy(e) => Some(e),
             LiftError(e) => Some(e),
             ContextError(e) => Some(e),
             AnalysisError(e) => Some(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,8 +628,6 @@ impl From<crate::policy::compiler::CompilerError> for Error {
     fn from(e: crate::policy::compiler::CompilerError) -> Error { Error::CompilerError(e) }
 }
 
-fn errstr(s: &str) -> Error { Error::Unexpected(s.to_owned()) }
-
 /// The size of an encoding of a number in Script
 pub fn script_num_size(n: usize) -> usize {
     match n {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,10 +427,6 @@ pub enum Error {
     UnexpectedStart,
     /// Got something we were not expecting
     Unexpected(String),
-    /// Name of a fragment contained `:` multiple times
-    MultiColon(String),
-    /// Name of a fragment contained `@` but we were not parsing an OR
-    AtOutsideOr(String),
     /// Encountered a wrapping character that we don't recognize
     UnknownWrapper(char),
     /// Parsed a miniscript and the result was not of type T
@@ -500,8 +496,6 @@ impl fmt::Display for Error {
             Error::AddrP2shError(ref e) => fmt::Display::fmt(e, f),
             Error::UnexpectedStart => f.write_str("unexpected start of script"),
             Error::Unexpected(ref s) => write!(f, "unexpected «{}»", s),
-            Error::MultiColon(ref s) => write!(f, "«{}» has multiple instances of «:»", s),
-            Error::AtOutsideOr(ref s) => write!(f, "«{}» contains «@» in non-or() context", s),
             Error::UnknownWrapper(ch) => write!(f, "unknown wrapper «{}:»", ch),
             Error::NonTopLevel(ref s) => write!(f, "non-T miniscript: {}", s),
             Error::Trailing(ref s) => write!(f, "trailing tokens: {}", s),
@@ -553,8 +547,6 @@ impl std::error::Error for Error {
             | InvalidPush(_)
             | UnexpectedStart
             | Unexpected(_)
-            | MultiColon(_)
-            | AtOutsideOr(_)
             | UnknownWrapper(_)
             | NonTopLevel(_)
             | Trailing(_)

--- a/src/miniscript/astelem.rs
+++ b/src/miniscript/astelem.rs
@@ -128,11 +128,9 @@ impl<Pk: FromStrKey, Ctx: ScriptContext> crate::expression::FromTree for Termina
                         .map_err(Error::Parse)
                 })
                 .map(Terminal::MultiA),
-            _ => Err(Error::Unexpected(format!(
-                "{}({} args) while parsing Miniscript",
-                top.name,
-                top.args.len(),
-            ))),
+            x => Err(Error::Parse(crate::ParseError::Tree(crate::ParseTreeError::UnknownName {
+                name: x.to_owned(),
+            }))),
         }?;
         let ms = super::wrap_into_miniscript(unwrapped, frag_wrap)?;
         Ok(ms.node)

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -678,11 +678,11 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 ///
 /// Returns the fragment name (right of the `:`) and a list of wrappers
 /// (left of the `:`).
-fn split_expression_name(name: &str) -> Result<(&str, Cow<str>), Error> {
+fn split_expression_name(full_name: &str) -> Result<(&str, Cow<str>), Error> {
     let mut aliased_wrap;
     let frag_name;
     let frag_wrap;
-    let mut name_split = name.split(':');
+    let mut name_split = full_name.split(':');
     match (name_split.next(), name_split.next(), name_split.next()) {
         (None, _, _) => {
             frag_name = "";
@@ -702,7 +702,9 @@ fn split_expression_name(name: &str) -> Result<(&str, Cow<str>), Error> {
         }
         (Some(wrap), Some(name), None) => {
             if wrap.is_empty() {
-                return Err(Error::Unexpected(name.to_owned()));
+                return Err(Error::Parse(crate::ParseError::Tree(
+                    crate::ParseTreeError::UnknownName { name: full_name.to_owned() },
+                )));
             }
             if name == "pk" {
                 frag_name = "pk_k";
@@ -720,7 +722,7 @@ fn split_expression_name(name: &str) -> Result<(&str, Cow<str>), Error> {
             }
         }
         (Some(_), Some(_), Some(_)) => {
-            return Err(Error::MultiColon(name.to_owned()));
+            return Err(Error::MultiColon(full_name.to_owned()));
         }
     }
     Ok((frag_name, frag_wrap))

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -672,69 +672,11 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
 
 /// Utility function used when parsing a script from an expression tree.
 ///
-/// Checks that the name of each fragment has at most one `:`, splits
-/// the name at the `:`, and implements aliases for the old `pk`/`pk_h`
-/// fragments.
-///
-/// Returns the fragment name (right of the `:`) and a list of wrappers
-/// (left of the `:`).
-fn split_expression_name(full_name: &str) -> Result<(&str, Cow<str>), Error> {
-    let mut aliased_wrap;
-    let frag_name;
-    let frag_wrap;
-    let mut name_split = full_name.split(':');
-    match (name_split.next(), name_split.next(), name_split.next()) {
-        (None, _, _) => {
-            frag_name = "";
-            frag_wrap = "".into();
-        }
-        (Some(name), None, _) => {
-            if name == "pk" {
-                frag_name = "pk_k";
-                frag_wrap = "c".into();
-            } else if name == "pkh" {
-                frag_name = "pk_h";
-                frag_wrap = "c".into();
-            } else {
-                frag_name = name;
-                frag_wrap = "".into();
-            }
-        }
-        (Some(wrap), Some(name), None) => {
-            if wrap.is_empty() {
-                return Err(Error::Parse(crate::ParseError::Tree(
-                    crate::ParseTreeError::UnknownName { name: full_name.to_owned() },
-                )));
-            }
-            if name == "pk" {
-                frag_name = "pk_k";
-                aliased_wrap = wrap.to_owned();
-                aliased_wrap.push('c');
-                frag_wrap = aliased_wrap.into();
-            } else if name == "pkh" {
-                frag_name = "pk_h";
-                aliased_wrap = wrap.to_owned();
-                aliased_wrap.push('c');
-                frag_wrap = aliased_wrap.into();
-            } else {
-                frag_name = name;
-                frag_wrap = wrap.into();
-            }
-        }
-        (Some(_), Some(_), Some(_)) => {
-            return Err(Error::MultiColon(full_name.to_owned()));
-        }
-    }
-    Ok((frag_name, frag_wrap))
-}
-
-/// Utility function used when parsing a script from an expression tree.
-///
 /// Once a Miniscript fragment has been parsed into a terminal, apply any
 /// wrappers that were included in its name.
 fn wrap_into_miniscript<Pk, Ctx>(
     term: Terminal<Pk, Ctx>,
-    frag_wrap: Cow<str>,
+    frag_wrap: &str,
 ) -> Result<Miniscript<Pk, Ctx>, Error>
 where
     Pk: MiniscriptKey,

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -874,57 +874,74 @@ impl<Pk: FromStrKey> Policy<Pk> {
                 return Err(Error::MultiColon(top.name.to_owned()));
             }
         }
-        match (frag_name, top.args.len() as u32) {
-            ("UNSATISFIABLE", 0) => Ok(Policy::Unsatisfiable),
-            ("TRIVIAL", 0) => Ok(Policy::Trivial),
-            ("pk", 1) => expression::terminal(&top.args[0], |pk| Pk::from_str(pk).map(Policy::Key)),
-            ("after", 1) => expression::terminal(&top.args[0], |x| {
+        match frag_name {
+            "UNSATISFIABLE" => {
+                top.verify_n_children("UNSATISFIABLE", 0..=0)
+                    .map_err(From::from)
+                    .map_err(Error::Parse)?;
+                Ok(Policy::Unsatisfiable)
+            }
+            "TRIVIAL" => {
+                top.verify_n_children("TRIVIAL", 0..=0)
+                    .map_err(From::from)
+                    .map_err(Error::Parse)?;
+                Ok(Policy::Trivial)
+            }
+            "pk" => top
+                .verify_terminal_parent("pk", "public key")
+                .map(Policy::Key)
+                .map_err(Error::Parse),
+            "after" => expression::terminal(&top.args[0], |x| {
                 expression::parse_num(x)
                     .and_then(|x| AbsLockTime::from_consensus(x).map_err(Error::AbsoluteLockTime))
                     .map(Policy::After)
             }),
-            ("older", 1) => expression::terminal(&top.args[0], |x| {
+            "older" => expression::terminal(&top.args[0], |x| {
                 expression::parse_num(x)
                     .and_then(|x| RelLockTime::from_consensus(x).map_err(Error::RelativeLockTime))
                     .map(Policy::Older)
             }),
-            ("sha256", 1) => expression::terminal(&top.args[0], |x| {
-                <Pk::Sha256 as core::str::FromStr>::from_str(x).map(Policy::Sha256)
-            }),
-            ("hash256", 1) => expression::terminal(&top.args[0], |x| {
-                <Pk::Hash256 as core::str::FromStr>::from_str(x).map(Policy::Hash256)
-            }),
-            ("ripemd160", 1) => expression::terminal(&top.args[0], |x| {
-                <Pk::Ripemd160 as core::str::FromStr>::from_str(x).map(Policy::Ripemd160)
-            }),
-            ("hash160", 1) => expression::terminal(&top.args[0], |x| {
-                <Pk::Hash160 as core::str::FromStr>::from_str(x).map(Policy::Hash160)
-            }),
-            ("and", _) => {
-                if top.args.len() != 2 {
-                    return Err(Error::ConcretePolicy(PolicyError::NonBinaryArgAnd));
-                }
-                let mut subs = Vec::with_capacity(top.args.len());
-                for arg in &top.args {
-                    subs.push(Arc::new(Policy::from_tree(arg)?));
-                }
+            "sha256" => top
+                .verify_terminal_parent("sha256", "hash")
+                .map(Policy::Sha256)
+                .map_err(Error::Parse),
+            "hash256" => top
+                .verify_terminal_parent("hash256", "hash")
+                .map(Policy::Hash256)
+                .map_err(Error::Parse),
+            "ripemd160" => top
+                .verify_terminal_parent("ripemd160", "hash")
+                .map(Policy::Ripemd160)
+                .map_err(Error::Parse),
+            "hash160" => top
+                .verify_terminal_parent("hash160", "hash")
+                .map(Policy::Hash160)
+                .map_err(Error::Parse),
+            "and" => {
+                top.verify_n_children("and", 2..=2)
+                    .map_err(From::from)
+                    .map_err(Error::Parse)?;
+                let subs = top
+                    .args
+                    .iter()
+                    .map(|arg| Self::from_tree(arg).map(Arc::new))
+                    .collect::<Result<_, Error>>()?;
                 Ok(Policy::And(subs))
             }
-            ("or", _) => {
-                if top.args.len() != 2 {
-                    return Err(Error::ConcretePolicy(PolicyError::NonBinaryArgOr));
-                }
-                let mut subs = Vec::with_capacity(top.args.len());
-                for arg in &top.args {
-                    subs.push(Policy::from_tree_prob(arg, true)?);
-                }
-                Ok(Policy::Or(
-                    subs.into_iter()
-                        .map(|(prob, sub)| (prob, Arc::new(sub)))
-                        .collect(),
-                ))
+            "or" => {
+                top.verify_n_children("or", 2..=2)
+                    .map_err(From::from)
+                    .map_err(Error::Parse)?;
+                let subs = top
+                    .args
+                    .iter()
+                    .map(|arg| {
+                        Self::from_tree_prob(arg, true).map(|(prob, sub)| (prob, Arc::new(sub)))
+                    })
+                    .collect::<Result<_, Error>>()?;
+                Ok(Policy::Or(subs))
             }
-            ("thresh", _) => top
+            "thresh" => top
                 .to_null_threshold()
                 .map_err(Error::ParseThreshold)?
                 .translate_by_index(|i| Policy::from_tree(&top.args[1 + i]).map(Arc::new))

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -19,6 +19,8 @@ use {
     core::cmp::Reverse,
 };
 
+#[cfg(feature = "compiler")]
+use crate::errstr;
 use crate::expression::{self, FromTree};
 use crate::iter::{Tree, TreeLike};
 use crate::miniscript::types::extra_props::TimelockInfo;
@@ -27,8 +29,7 @@ use crate::sync::Arc;
 #[cfg(all(doc, not(feature = "compiler")))]
 use crate::Descriptor;
 use crate::{
-    errstr, AbsLockTime, Error, ForEachKey, FromStrKey, MiniscriptKey, RelLockTime, Threshold,
-    Translator,
+    AbsLockTime, Error, ForEachKey, FromStrKey, MiniscriptKey, RelLockTime, Threshold, Translator,
 };
 
 /// Maximum TapLeafs allowed in a compiled TapTree
@@ -940,7 +941,9 @@ impl<Pk: FromStrKey> Policy<Pk> {
                 .map_err(Error::ParseThreshold)?
                 .translate_by_index(|i| Policy::from_tree(&top.args[1 + i]).map(Arc::new))
                 .map(Policy::Thresh),
-            _ => Err(errstr(top.name)),
+            x => Err(Error::Parse(crate::ParseError::Tree(crate::ParseTreeError::UnknownName {
+                name: x.to_owned(),
+            }))),
         }
         .map(|res| (frag_prob, res))
     }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -308,11 +308,11 @@ mod tests {
         );
         assert_eq!(
             ConcretePol::from_str("and(pk())").unwrap_err().to_string(),
-            "And policy fragment must take 2 arguments"
+            "and must have 2 children, but found 1"
         );
         assert_eq!(
             ConcretePol::from_str("or(pk())").unwrap_err().to_string(),
-            "Or policy fragment must take 2 arguments"
+            "or must have 2 children, but found 1"
         );
         // these weird "unexpected" wrapping of errors will go away in a later PR
         // which rewrites the expression parser

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -320,14 +320,14 @@ mod tests {
             ConcretePol::from_str("thresh(3,after(0),pk(),pk())")
                 .unwrap_err()
                 .to_string(),
-            "unexpected «absolute locktimes in Miniscript have a minimum value of 1»",
+            "absolute locktimes in Miniscript have a minimum value of 1",
         );
 
         assert_eq!(
             ConcretePol::from_str("thresh(2,older(2147483650),pk(),pk())")
                 .unwrap_err()
                 .to_string(),
-            "unexpected «locktime value 2147483650 is not a valid BIP68 relative locktime»"
+            "locktime value 2147483650 is not a valid BIP68 relative locktime"
         );
     }
 

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -356,7 +356,9 @@ impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
                     .translate_by_index(|i| Policy::from_tree(&top.args[1 + i]).map(Arc::new))
                     .map(Policy::Thresh)
             }
-            _ => Err(errstr(top.name)),
+            x => Err(Error::Parse(crate::ParseError::Tree(crate::ParseTreeError::UnknownName {
+                name: x.to_owned(),
+            }))),
         }
     }
 }

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -14,8 +14,8 @@ use crate::iter::{Tree, TreeLike};
 use crate::prelude::*;
 use crate::sync::Arc;
 use crate::{
-    errstr, expression, AbsLockTime, Error, ForEachKey, FromStrKey, MiniscriptKey, RelLockTime,
-    Threshold, Translator,
+    expression, AbsLockTime, Error, ForEachKey, FromStrKey, MiniscriptKey, RelLockTime, Threshold,
+    Translator,
 };
 
 /// Abstract policy which corresponds to the semantics of a miniscript and
@@ -346,10 +346,11 @@ impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
                 let thresh = top.to_null_threshold().map_err(Error::ParseThreshold)?;
 
                 // thresh(1) and thresh(n) are disallowed in semantic policies
-                if thresh.is_or() || thresh.is_and() {
-                    return Err(errstr(
-                        "Semantic Policy thresh cannot have k = 1 or k = n, use `and`/`or` instead",
-                    ));
+                if thresh.is_or() {
+                    return Err(Error::ParseThreshold(crate::ParseThresholdError::IllegalOr));
+                }
+                if thresh.is_and() {
+                    return Err(Error::ParseThreshold(crate::ParseThresholdError::IllegalAnd));
                 }
 
                 thresh

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -302,16 +302,8 @@ impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
                 .verify_terminal_parent("pk", "public key")
                 .map(Policy::Key)
                 .map_err(Error::Parse),
-            "after" => expression::terminal(&top.args[0], |x| {
-                expression::parse_num(x)
-                    .and_then(|x| AbsLockTime::from_consensus(x).map_err(Error::AbsoluteLockTime))
-                    .map(Policy::After)
-            }),
-            "older" => expression::terminal(&top.args[0], |x| {
-                expression::parse_num(x)
-                    .and_then(|x| RelLockTime::from_consensus(x).map_err(Error::RelativeLockTime))
-                    .map(Policy::Older)
-            }),
+            "after" => top.verify_after().map_err(Error::Parse).map(Policy::After),
+            "older" => top.verify_older().map_err(Error::Parse).map(Policy::Older),
             "sha256" => top
                 .verify_terminal_parent("sha256", "hash")
                 .map(Policy::Sha256)


### PR DESCRIPTION
This PR is a series of commits which cleans up the expression parsing module. After the last couple PRs, which substantially rewrote the parser and introduce a new parsing-error module, we can get rid of many uses of the `Error::Unexpected` variant and its constructor, the `errstr` function.

This PR should have no visible effects, and does not even change any algorithms. The next one will return to the process of rewriting the expression parser, by replacing the recursive `Tree` type with a non-recursive one.

Will post benchmarks once they are done.