### PR TITLE
Use new corepc-node crate

### DIFF
--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 miniscript = {path = "../"}
-bitcoind = { package = "bitcoind-json-rpc-regtest", version = "0.3.0" }
+bitcoind = { package = "corepc-node", version = "0.4.0", default-features = false }
 actual-rand = { package = "rand", version = "0.8.4"}
 secp256k1 = {version = "0.29.0", features = ["rand-std"]}
 


### PR DESCRIPTION
We just re-named and move the crate/repo from `rust-bitcoind-json` to `corepc`. Use the new name

For context see: https://github.com/rust-bitcoin/rust-bitcoind-json-rpc/pull/51