### PR TITLE
mechanical updates to fuzztests

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -21,6 +21,7 @@ jobs:
 compile_descriptor,
 compile_taproot,
 parse_descriptor,
+parse_descriptor_priv,
 parse_descriptor_secret,
 regression_descriptor_parse,
 roundtrip_concrete,

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -23,8 +23,10 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.56", default-features = false }
-miniscript = { path = "..", features = [ "compiler" ] }
-old_miniscript = { package = "miniscript", git = "https://github.com/apoelstra/rust-miniscript/", rev = "1259375d7b7c91053e09d1cbe3db983612fe301c" }
+# We shouldn't need an explicit version on the next line, but Andrew's tools
+# choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
+miniscript = { path = "..", features = [ "compiler" ], version = "13.0" }
+old_miniscript = { package = "miniscript", version = "12.3" }
 
 regex = "1.0"
 EOF


### PR DESCRIPTION
Our `generate-files.sh` script got out of sync again.

I will try to add a check for this to my local CI.

Fixes #789