### PR TITLE
fuzz: add target for tapscript parsing from script

### DIFF
--- a/.github/workflows/cron-daily-fuzz.yml
+++ b/.github/workflows/cron-daily-fuzz.yml
@@ -27,6 +27,7 @@ regression_descriptor_parse,
 roundtrip_concrete,
 roundtrip_descriptor,
 roundtrip_miniscript_script,
+roundtrip_miniscript_script_tap,
 roundtrip_miniscript_str,
 roundtrip_semantic,
         ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -55,6 +55,10 @@ name = "roundtrip_miniscript_script"
 path = "fuzz_targets/roundtrip_miniscript_script.rs"
 
 [[bin]]
+name = "roundtrip_miniscript_script_tap"
+path = "fuzz_targets/roundtrip_miniscript_script_tap.rs"
+
+[[bin]]
 name = "roundtrip_miniscript_str"
 path = "fuzz_targets/roundtrip_miniscript_str.rs"
 

--- a/fuzz/fuzz_targets/roundtrip_miniscript_script_tap.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_script_tap.rs
@@ -1,0 +1,24 @@
+#![allow(unexpected_cfgs)]
+
+use honggfuzz::fuzz;
+use miniscript::bitcoin::blockdata::script;
+use miniscript::{Miniscript, Tap};
+
+fn do_test(data: &[u8]) {
+    // Try round-tripping as a script
+    let script = script::Script::from_bytes(data);
+
+    if let Ok(pt) = Miniscript::<miniscript::bitcoin::key::XOnlyPublicKey, Tap>::parse(script) {
+        let output = pt.encode();
+        assert_eq!(pt.script_size(), output.len());
+        assert_eq!(&output, script);
+    }
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}


### PR DESCRIPTION
This PR adds a new fuzz target to parse a miniscript from script hex for Tap. We currently have one target that does it for Segwitv0.