### PR TITLE
Refactor: make descriptors::key::DescriptorKeyParseError an enum

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -50,7 +50,7 @@ mod key;
 pub use self::key::{
     ConversionError, DefiniteDescriptorKey, DerivPaths, DescriptorKeyParseError,
     DescriptorMultiXKey, DescriptorPublicKey, DescriptorSecretKey, DescriptorXKey, InnerXKey,
-    SinglePriv, SinglePub, SinglePubKey, Wildcard,
+    MalformedKeyDataKind, SinglePriv, SinglePub, SinglePubKey, Wildcard,
 };
 
 /// Alias type for a map of public key to secret key


### PR DESCRIPTION
This PR has a go at refactoring `DescriptorKeyParseError` into an enum, as suggested in the `FIXME` comment:

https://github.com/rust-bitcoin/rust-miniscript/blob/d0da327417cb177884c5d77edffa0891ba9b6969/src/descriptor/key.rs#L327-L330

I have separated the error variants by different inner parse error types and result types (e.g, public key, private key, etc) where I think it made sense to retain the inner error.

I left a variant that wraps a `&'static str` and its used for the various ad-hoc parsing errors instead of adding the boilerplate for variants only created once and without retained data.

The generic `parse_xkey_deriv` function now takes a parse function as its first parameter to allow specific key parsing errors:

https://github.com/chris-ricketts/rust-miniscript/blob/790b08fcf46f53ce6ee80355a7db8e5108ed860f/src/descriptor/key.rs#L935-L952