### PR TITLE
[Taproot API Project] flatten internal representation of `TapTree`

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -256,7 +256,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
     /// returned value.
     pub fn tap_tree(&self) -> Option<&TapTree<Pk>> {
         if let Descriptor::Tr(ref tr) = self {
-            tr.tap_tree().as_ref()
+            tr.tap_tree()
         } else {
             None
         }
@@ -268,7 +268,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
     /// Taproot descriptor containing only a keyspend, returns an empty iterator.
     pub fn tap_tree_iter(&self) -> tr::TapTreeIter<Pk> {
         if let Descriptor::Tr(ref tr) = self {
-            if let Some(ref tree) = tr.tap_tree() {
+            if let Some(tree) = tr.tap_tree() {
                 return tree.leaves();
             }
         }
@@ -988,7 +988,7 @@ impl<Pk: FromStrKey> FromStr for Descriptor<Pk> {
             // FIXME preserve weird/broken behavior from 12.x.
             // See https://github.com/rust-bitcoin/rust-miniscript/issues/734
             ret.sanity_check()?;
-            for item in inner.iter_scripts() {
+            for item in inner.leaves() {
                 item.miniscript()
                     .ext_check(&crate::miniscript::analyzable::ExtParams::sane())?;
             }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -42,7 +42,7 @@ pub use self::bare::{Bare, Pkh};
 pub use self::segwitv0::{Wpkh, Wsh, WshInner};
 pub use self::sh::{Sh, ShInner};
 pub use self::sortedmulti::SortedMultiVec;
-pub use self::tr::{TapTree, TapTreeIter, TapTreeIterItem, Tr};
+pub use self::tr::{TapTree, TapTreeDepthError, TapTreeIter, TapTreeIterItem, Tr};
 
 pub mod checksum;
 mod key;

--- a/src/descriptor/tr/mod.rs
+++ b/src/descriptor/tr/mod.rs
@@ -456,7 +456,7 @@ impl<Pk: FromStrKey> crate::expression::FromTree for Tr<Pk> {
                     return Err(Error::NonTopLevel(format!("{:?}", script)));
                 };
 
-                tree_stack.push(node.parent().unwrap(), TapTree::Leaf(Arc::new(script)))?;
+                tree_stack.push(node.parent().unwrap(), TapTree::leaf(script))?;
                 tap_tree_iter.skip_descendants();
             }
         }

--- a/src/descriptor/tr/mod.rs
+++ b/src/descriptor/tr/mod.rs
@@ -105,16 +105,7 @@ impl<Pk: MiniscriptKey> Tr<Pk> {
     pub fn internal_key(&self) -> &Pk { &self.internal_key }
 
     /// Obtain the [`TapTree`] of the [`Tr`] descriptor
-    pub fn tap_tree(&self) -> &Option<TapTree<Pk>> { &self.tree }
-
-    /// Obtain the [`TapTree`] of the [`Tr`] descriptor
-    #[deprecated(since = "11.0.0", note = "use tap_tree instead")]
-    pub fn taptree(&self) -> &Option<TapTree<Pk>> { self.tap_tree() }
-
-    /// Iterate over all scripts in merkle tree. If there is no script path, the iterator
-    /// yields [`None`]
-    #[deprecated(since = "TBD", note = "use `leaves` instead")]
-    pub fn iter_scripts(&self) -> TapTreeIter<Pk> { self.leaves() }
+    pub fn tap_tree(&self) -> Option<&TapTree<Pk>> { self.tree.as_ref() }
 
     /// Iterates over all the leaves of the tree in depth-first preorder.
     ///

--- a/src/descriptor/tr/mod.rs
+++ b/src/descriptor/tr/mod.rs
@@ -276,7 +276,7 @@ impl<Pk: MiniscriptKey> Tr<Pk> {
         T: Translator<Pk>,
     {
         let tree = match &self.tree {
-            Some(tree) => Some(tree.translate_helper(translate)?),
+            Some(tree) => Some(tree.translate_pk(translate)?),
             None => None,
         };
         let translate_desc =
@@ -603,12 +603,5 @@ mod tests {
         let tr = Tr::<String>::from_str(&desc).unwrap();
         // Note the last ac12 only has ac and fails the predicate
         assert!(!tr.for_each_key(|k| k.starts_with("acc")));
-    }
-
-    #[test]
-    fn height() {
-        let desc = descriptor();
-        let tr = Tr::<String>::from_str(&desc).unwrap();
-        assert_eq!(tr.tap_tree().as_ref().unwrap().height(), 2);
     }
 }

--- a/src/descriptor/tr/taptree.rs
+++ b/src/descriptor/tr/taptree.rs
@@ -46,6 +46,9 @@ pub enum TapTree<Pk: MiniscriptKey> {
 }
 
 impl<Pk: MiniscriptKey> TapTree<Pk> {
+    /// Creates a `TapTree` leaf from a Miniscript.
+    pub fn leaf<A: Into<Arc<Miniscript<Pk, Tap>>>>(ms: A) -> Self { TapTree::Leaf(ms.into()) }
+
     /// Creates a `TapTree` by combining `left` and `right` tree nodes.
     pub fn combine(left: TapTree<Pk>, right: TapTree<Pk>) -> Result<Self, TapTreeDepthError> {
         let height = 1 + cmp::max(left.height(), right.height());

--- a/src/descriptor/tr/taptree.rs
+++ b/src/descriptor/tr/taptree.rs
@@ -161,6 +161,20 @@ impl<'tr, Pk: MiniscriptKey> Iterator for TapTreeIter<'tr, Pk> {
     }
 }
 
+impl<'tr, Pk: MiniscriptKey> DoubleEndedIterator for TapTreeIter<'tr, Pk> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|&(depth, ref node)| TapTreeIterItem { depth, node })
+    }
+}
+
+impl<'tr, Pk: MiniscriptKey> ExactSizeIterator for TapTreeIter<'tr, Pk> {
+    fn len(&self) -> usize { self.inner.len() }
+}
+
+impl<'tr, Pk: MiniscriptKey> core::iter::FusedIterator for TapTreeIter<'tr, Pk> {}
+
 /// Iterator over all of the leaves of a Taproot tree.
 ///
 /// If there is no tree (i.e. this is a keyspend-only Taproot descriptor)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,6 +450,8 @@ pub enum Error {
     LiftError(policy::LiftError),
     /// Forward script context related errors
     ContextError(miniscript::context::ScriptContextError),
+    /// Tried to construct a Taproot tree which was too deep.
+    TapTreeDepthError(crate::descriptor::TapTreeDepthError),
     /// Recursion depth exceeded when parsing policy/miniscript from string
     MaxRecursiveDepthExceeded,
     /// Anything but c:pk(key) (P2PK), c:pk_h(key) (P2PKH), and thresh_m(k,...)
@@ -509,6 +511,7 @@ impl fmt::Display for Error {
             Error::TypeCheck(ref e) => write!(f, "typecheck: {}", e),
             Error::Secp(ref e) => fmt::Display::fmt(e, f),
             Error::ContextError(ref e) => fmt::Display::fmt(e, f),
+            Error::TapTreeDepthError(ref e) => fmt::Display::fmt(e, f),
             #[cfg(feature = "compiler")]
             Error::CompilerError(ref e) => fmt::Display::fmt(e, f),
             Error::ConcretePolicy(ref e) => fmt::Display::fmt(e, f),
@@ -573,6 +576,7 @@ impl std::error::Error for Error {
             ConcretePolicy(e) => Some(e),
             LiftError(e) => Some(e),
             ContextError(e) => Some(e),
+            TapTreeDepthError(e) => Some(e),
             AnalysisError(e) => Some(e),
             PubKeyCtxError(e, _) => Some(e),
             AbsoluteLockTime(e) => Some(e),
@@ -592,6 +596,11 @@ impl From<miniscript::types::Error> for Error {
 #[doc(hidden)]
 impl From<policy::LiftError> for Error {
     fn from(e: policy::LiftError) -> Error { Error::LiftError(e) }
+}
+
+#[doc(hidden)]
+impl From<crate::descriptor::TapTreeDepthError> for Error {
+    fn from(e: crate::descriptor::TapTreeDepthError) -> Error { Error::TapTreeDepthError(e) }
 }
 
 #[doc(hidden)]

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -589,7 +589,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             .collect()
     }
 
-    /// Gets the number of [TapLeaf](`TapTree::Leaf`)s considering exhaustive root-level [`Policy::Or`]
+    /// Gets the number of [TapLeaf](`TapTree::leaf`)s considering exhaustive root-level [`Policy::Or`]
     /// and [`Policy::Thresh`] disjunctions for the `TapTree`.
     #[cfg(feature = "compiler")]
     fn num_tap_leaves(&self) -> usize { self.tapleaf_probability_iter().count() }
@@ -957,7 +957,7 @@ impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
 fn with_huffman_tree<Pk: MiniscriptKey>(ms: Vec<(OrdF64, Miniscript<Pk, Tap>)>) -> TapTree<Pk> {
     let mut node_weights = BinaryHeap::<(Reverse<OrdF64>, TapTree<Pk>)>::new();
     for (prob, script) in ms {
-        node_weights.push((Reverse(prob), TapTree::Leaf(Arc::new(script))));
+        node_weights.push((Reverse(prob), TapTree::leaf(script)));
     }
     assert_ne!(node_weights.len(), 0, "empty Miniscript compilation");
     while node_weights.len() > 1 {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -965,7 +965,11 @@ fn with_huffman_tree<Pk: MiniscriptKey>(ms: Vec<(OrdF64, Miniscript<Pk, Tap>)>) 
         let (p2, s2) = node_weights.pop().expect("len must at least be two");
 
         let p = (p1.0).0 + (p2.0).0;
-        node_weights.push((Reverse(OrdF64(p)), TapTree::combine(s1, s2)));
+        node_weights.push((
+            Reverse(OrdF64(p)),
+            TapTree::combine(s1, s2)
+                .expect("huffman tree cannot produce depth > 128 given sane weights"),
+        ));
     }
 
     debug_assert!(node_weights.len() == 1);

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -386,10 +386,8 @@ mod tests {
             let policy: Concrete<String> = policy_str!("or(and(pk(A),pk(B)),and(pk(C),pk(D)))");
             let descriptor = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
 
-            let left_ms_compilation: Arc<Miniscript<String, Tap>> =
-                Arc::new(ms_str!("and_v(v:pk(C),pk(D))"));
-            let right_ms_compilation: Arc<Miniscript<String, Tap>> =
-                Arc::new(ms_str!("and_v(v:pk(A),pk(B))"));
+            let left_ms_compilation: Miniscript<String, Tap> = ms_str!("and_v(v:pk(C),pk(D))");
+            let right_ms_compilation: Miniscript<String, Tap> = ms_str!("and_v(v:pk(A),pk(B))");
 
             let left = TapTree::leaf(left_ms_compilation);
             let right = TapTree::leaf(right_ms_compilation);

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -393,7 +393,7 @@ mod tests {
 
             let left = TapTree::Leaf(left_ms_compilation);
             let right = TapTree::Leaf(right_ms_compilation);
-            let tree = TapTree::combine(left, right);
+            let tree = TapTree::combine(left, right).unwrap();
 
             let expected_descriptor =
                 Descriptor::new_tr(unspendable_key.clone(), Some(tree)).unwrap();
@@ -460,18 +460,23 @@ mod tests {
 
             // Arrange leaf compilations (acc. to probabilities) using huffman encoding into a TapTree
             let tree = TapTree::combine(
-                TapTree::combine(node_compilations[4].clone(), node_compilations[5].clone()),
+                TapTree::combine(node_compilations[4].clone(), node_compilations[5].clone())
+                    .unwrap(),
                 TapTree::combine(
                     TapTree::combine(
                         TapTree::combine(
                             node_compilations[0].clone(),
                             node_compilations[1].clone(),
-                        ),
+                        )
+                        .unwrap(),
                         node_compilations[3].clone(),
-                    ),
+                    )
+                    .unwrap(),
                     node_compilations[6].clone(),
-                ),
-            );
+                )
+                .unwrap(),
+            )
+            .unwrap();
 
             let expected_descriptor = Descriptor::new_tr("E".to_string(), Some(tree)).unwrap();
             assert_eq!(descriptor, expected_descriptor);

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -375,7 +375,7 @@ mod tests {
             let descriptor = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
 
             let ms_compilation: Miniscript<String, Tap> = ms_str!("multi_a(2,A,B,C,D)");
-            let tree: TapTree<String> = TapTree::Leaf(Arc::new(ms_compilation));
+            let tree: TapTree<String> = TapTree::leaf(ms_compilation);
             let expected_descriptor =
                 Descriptor::new_tr(unspendable_key.clone(), Some(tree)).unwrap();
             assert_eq!(descriptor, expected_descriptor);
@@ -391,8 +391,8 @@ mod tests {
             let right_ms_compilation: Arc<Miniscript<String, Tap>> =
                 Arc::new(ms_str!("and_v(v:pk(A),pk(B))"));
 
-            let left = TapTree::Leaf(left_ms_compilation);
-            let right = TapTree::Leaf(right_ms_compilation);
+            let left = TapTree::leaf(left_ms_compilation);
+            let right = TapTree::leaf(right_ms_compilation);
             let tree = TapTree::combine(left, right).unwrap();
 
             let expected_descriptor =
@@ -454,7 +454,7 @@ mod tests {
                 .into_iter()
                 .map(|x| {
                     let leaf_policy: Concrete<String> = policy_str!("{}", x);
-                    TapTree::Leaf(Arc::from(leaf_policy.compile::<Tap>().unwrap()))
+                    TapTree::leaf(leaf_policy.compile::<Tap>().unwrap())
                 })
                 .collect::<Vec<_>>();
 


### PR DESCRIPTION
This PR completely rewrites the `TapTree` module to store a taptree as a flat list of leaves and heights. For a non-`ToPublicKey` key this is the only useful information that we ever extract from this, so storing a big recursive structure is wasteful. We also eliminate recursive code from everything `TapTree` related, including the implicit `Drop` impl.

In the next PR we'll introduce a new tree structure that contains control block information -- but `TapTree` can't be this structure because `TapTree` doesn't assume that its keys can be serialized.

Also breaks the `iter_scripts` iterator API in a couple small ways.