### PR TITLE
Backport of #809: fix crash in `Descriptor::parse_desc`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.1"
+version = "12.3.2"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.1"
+version = "12.3.2"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "12.3.1"
+version = "12.3.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-miniscript/"

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -2049,4 +2049,19 @@ pk(03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8))";
         Desc::from_str(&format!("tr({},pk({}))", x_only_key, uncomp_key)).unwrap_err();
         Desc::from_str(&format!("tr({},pk({}))", x_only_key, x_only_key)).unwrap();
     }
+
+    #[test]
+    fn regression_806() {
+        let secp = secp256k1::Secp256k1::signing_only();
+        type Desc = Descriptor<DescriptorPublicKey>;
+        // OK
+        Desc::from_str("pkh(111111111111111111111111111111110000008375319363688624584A111111)")
+            .unwrap_err();
+        // ERR: crashes in translate_pk
+        Desc::parse_descriptor(
+            &secp,
+            "pkh(111111111111111111111111111111110000008375319363688624584A111111)",
+        )
+        .unwrap_err();
+    }
 }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -731,12 +731,9 @@ impl Descriptor<DescriptorPublicKey> {
         }
 
         let descriptor = Descriptor::<String>::from_str(s)?;
-        let descriptor = descriptor.translate_pk(&mut keymap_pk).map_err(|e| {
-            Error::Unexpected(
-                e.expect_translator_err("No Outer context errors")
-                    .to_string(),
-            )
-        })?;
+        let descriptor = descriptor
+            .translate_pk(&mut keymap_pk)
+            .map_err(TranslateErr::flatten)?;
 
         Ok((descriptor, keymap_pk.0))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,10 +350,11 @@ impl<E> TranslateErr<E> {
     ///
     /// This function will panic if the Error is OutError.
     pub fn expect_translator_err(self, msg: &str) -> E {
-        if let Self::TranslatorErr(v) = self {
-            v
-        } else {
-            panic!("{}", msg)
+        match self {
+            Self::TranslatorErr(v) => v,
+            Self::OuterError(ref e) => {
+                panic!("Unexpected Miniscript error when translating: {}\nMessage: {}", e, msg)
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,17 @@ impl<E> TranslateErr<E> {
     }
 }
 
+impl TranslateErr<Error> {
+    /// If we are doing a translation where our "outer error" is the generic
+    /// Miniscript error, eliminate the `TranslateErr` type which is just noise.
+    pub fn flatten(self) -> Error {
+        match self {
+            Self::TranslatorErr(e) => e,
+            Self::OuterError(e) => e,
+        }
+    }
+}
+
 impl<E> From<E> for TranslateErr<E> {
     fn from(v: E) -> Self { Self::TranslatorErr(v) }
 }


### PR DESCRIPTION
Backports #809 and does another patch release.