### PR TITLE
CVE-2025-43707 public disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# # 12.3.1 - April 1, 2025
+
+- Silent fix for CVE-2025-43707 (crash on satisfaction of particularly crafted `thresh` fragments) [#798](https://github.com/rust-bitcoin/rust-miniscript/pull/798)
+
 # # 12.3.0 - August 31, 2024
 
 - Fix incorrect string serialization of `and_b` [#735](https://github.com/rust-bitcoin/rust-miniscript/pull/735)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# # 12.3.0 - August 31, 2024
+
+- Fix incorrect string serialization of `and_b` [#735](https://github.com/rust-bitcoin/rust-miniscript/pull/735)
+
 # # 12.2.0 - July 20, 2024
 
 - Fix panics while decoding large miniscripts from script [#712](https://github.com/rust-bitcoin/rust-miniscript/pull/712)


### PR DESCRIPTION
Add an entry to the CHANGELOG stating #798 was a silent fix for a crash bug which could be triggered by satisfying `thresh(k,subs)` fragments where `k == len(subs)`.