### PR TITLE
Fix typos: correct spelling of "interpreter", "translation" and "resource"

### DIFF
--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -233,7 +233,7 @@ pub(super) fn from_txdata<'txin>(
                             // so it's easy enough to keep track of all uses.
                             //
                             // In particular, this return value will be put into the `script_code` member of
-                            // the `Interpreter` script; the iterpreter logic does the right thing with it.
+                            // the `Interpreter` script; the interpreter logic does the right thing with it.
                             Some(tap_script),
                         ))
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ impl ToPublicKey for bitcoin::secp256k1::XOnlyPublicKey {
 pub trait Translator<P: MiniscriptKey> {
     /// The public key (and associated hash types that this translator converts to.
     type TargetPk: MiniscriptKey;
-    /// An error that may occur during transalation.
+    /// An error that may occur during translation.
     type Error;
 
     /// Translates keys.

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -331,7 +331,7 @@ where
 
     /// Check top level consensus rules.
     // All the previous check_ were applied at each fragment while parsing script
-    // Because if any of sub-miniscripts failed the reource level check, the entire
+    // Because if any of sub-miniscripts failed the resource level check, the entire
     // miniscript would also be invalid. However, there are certain checks like
     // in Bare context, only c:pk(key) (P2PK),
     // c:pk_h(key) (P2PKH), and thresh_m(k,...) up to n=3 are allowed


### PR DESCRIPTION
This PR fixes several typos in comments and documentation:

- "iterpreter" -> "interpreter" in src/interpreter/inner.rs
- "transalation" -> "translation" in src/lib.rs  
- "reource" -> "resource" in src/miniscript/context.rs

These changes only affect comments and do not modify any functional code.