### PR TITLE
Fix typos: occurrence, occurred, restricted

### DIFF
--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -1025,7 +1025,7 @@ fn parse_xkey_deriv<Key>(
                 // BIP389 defines a new step in the derivation path. This step contains two or more
                 // derivation indexes in the form '<1;2;3';4h;5H;6>'.
                 if p.starts_with('<') && p.ends_with('>') {
-                    // There may only be one occurence of this step.
+                    // There may only be one occurrence of this step.
                     if multipath {
                         return Some(Err(DescriptorKeyParseError::MalformedKeyData(
                             MalformedKeyDataKind::MultipleDerivationPathIndexSteps,

--- a/src/expression/error.rs
+++ b/src/expression/error.rs
@@ -159,7 +159,7 @@ impl fmt::Display for ParseTreeError {
             ParseTreeError::MultipleSeparators { separator, pos } => {
                 write!(
                     f,
-                    "separator '{}' occured multiple times (second time at position {})",
+                    "separator '{}' occurred multiple times (second time at position {})",
                     separator, pos
                 )
             }

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -200,7 +200,7 @@ where
     /// 3600 or number of stack elements are more than 100.
     fn check_witness(_witness: &[Vec<u8>]) -> Result<(), ScriptContextError> {
         // Only really need to do this for segwitv0 and legacy
-        // Bare is already restrcited by standardness rules
+        // Bare is already restricted by standardness rules
         // and would reach these limits.
         Ok(())
     }
@@ -895,7 +895,7 @@ impl ScriptContext for NoChecks {
 
     fn check_witness(_witness: &[Vec<u8>]) -> Result<(), ScriptContextError> {
         // Only really need to do this for segwitv0 and legacy
-        // Bare is already restrcited by standardness rules
+        // Bare is already restricted by standardness rules
         // and would reach these limits.
         Ok(())
     }


### PR DESCRIPTION
This PR fixes several typos across the codebase:

- src/descriptor/key.rs: Fix "occurence" -> "occurrence"
- src/expression/error.rs: Fix "occured" -> "occurred" 
- src/miniscript/context.rs: Fix "restrcted" -> "restricted" (in two places)

These are simple spelling corrections that don't affect functionality.