### PR TITLE
various improvements/refactors of the decoder and its errors

### DIFF
--- a/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_script.rs
@@ -8,7 +8,7 @@ fn do_test(data: &[u8]) {
     // Try round-tripping as a script
     let script = script::Script::from_bytes(data);
 
-    if let Ok(pt) = Miniscript::<miniscript::bitcoin::PublicKey, Segwitv0>::parse(script) {
+    if let Ok(pt) = Miniscript::<miniscript::bitcoin::PublicKey, Segwitv0>::decode(script) {
         let output = pt.encode();
         assert_eq!(pt.script_size(), output.len());
         assert_eq!(&output, script);

--- a/fuzz/fuzz_targets/roundtrip_miniscript_script_tap.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_script_tap.rs
@@ -8,7 +8,7 @@ fn do_test(data: &[u8]) {
     // Try round-tripping as a script
     let script = script::Script::from_bytes(data);
 
-    if let Ok(pt) = Miniscript::<miniscript::bitcoin::key::XOnlyPublicKey, Tap>::parse(script) {
+    if let Ok(pt) = Miniscript::<miniscript::bitcoin::key::XOnlyPublicKey, Tap>::decode(script) {
         let output = pt.encode();
         assert_eq!(pt.script_size(), output.len());
         assert_eq!(&output, script);

--- a/src/interpreter/inner.rs
+++ b/src/interpreter/inner.rs
@@ -43,7 +43,7 @@ fn script_from_stack_elem<Ctx: ScriptContext>(
 ) -> Result<Miniscript<Ctx::Key, Ctx>, Error> {
     match *elem {
         stack::Element::Push(sl) => {
-            Miniscript::parse_with_ext(bitcoin::Script::from_bytes(sl), &ExtParams::allow_all())
+            Miniscript::decode_with_ext(bitcoin::Script::from_bytes(sl), &ExtParams::allow_all())
                 .map_err(Error::from)
         }
         stack::Element::Satisfied => Ok(Miniscript::TRUE),
@@ -327,7 +327,7 @@ pub(super) fn from_txdata<'txin>(
     } else {
         if wit_stack.is_empty() {
             // Bare script parsed in BareCtx
-            let miniscript = Miniscript::<bitcoin::PublicKey, BareCtx>::parse_with_ext(
+            let miniscript = Miniscript::<bitcoin::PublicKey, BareCtx>::decode_with_ext(
                 spk,
                 &ExtParams::allow_all(),
             )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,6 @@ mod util;
 use core::{fmt, hash, str};
 
 use bitcoin::hashes::{hash160, ripemd160, sha256, Hash};
-use bitcoin::hex::DisplayHex;
-use bitcoin::{script, Opcode};
 
 pub use crate::blanket_traits::FromStrKey;
 pub use crate::descriptor::{DefiniteDescriptorKey, Descriptor, DescriptorPublicKey};
@@ -436,15 +434,8 @@ pub trait ForEachKey<Pk: MiniscriptKey> {
 
 #[derive(Debug)]
 pub enum Error {
-    /// Opcode appeared which is not part of the script subset
-    InvalidOpcode(Opcode),
-    /// Some opcode occurred followed by `OP_VERIFY` when it had
-    /// a `VERIFY` version that should have been used instead
-    NonMinimalVerify(String),
-    /// Push was illegal in some context
-    InvalidPush(Vec<u8>),
-    /// rust-bitcoin script error
-    Script(script::Error),
+    /// Error when lexing a bitcoin Script.
+    ScriptLexer(crate::miniscript::lex::Error),
     /// rust-bitcoin address error
     AddrError(bitcoin::address::ParseError),
     /// rust-bitcoin p2sh address error
@@ -519,12 +510,7 @@ const MAX_RECURSION_DEPTH: u32 = 402;
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::InvalidOpcode(op) => write!(f, "invalid opcode {}", op),
-            Error::NonMinimalVerify(ref tok) => write!(f, "{} VERIFY", tok),
-            Error::InvalidPush(ref push) => {
-                write!(f, "invalid push {:x}", push.as_hex())
-            },
-            Error::Script(ref e) => fmt::Display::fmt(e, f),
+            Error::ScriptLexer(ref e) => e.fmt(f),
             Error::AddrError(ref e) => fmt::Display::fmt(e, f),
             Error::AddrP2shError(ref e) => fmt::Display::fmt(e, f),
             Error::UnexpectedStart => f.write_str("unexpected start of script"),
@@ -576,10 +562,7 @@ impl std::error::Error for Error {
         use self::Error::*;
 
         match self {
-            InvalidOpcode(_)
-            | NonMinimalVerify(_)
-            | InvalidPush(_)
-            | UnexpectedStart
+            UnexpectedStart
             | Unexpected(_)
             | UnknownWrapper(_)
             | NonTopLevel(_)
@@ -593,7 +576,7 @@ impl std::error::Error for Error {
             | BareDescriptorAddr
             | TrNoScriptCode
             | MultipathDescLenMismatch => None,
-            Script(e) => Some(e),
+            ScriptLexer(e) => Some(e),
             AddrError(e) => Some(e),
             AddrP2shError(e) => Some(e),
             Secp(e) => Some(e),
@@ -612,6 +595,11 @@ impl std::error::Error for Error {
             Parse(e) => Some(e),
         }
     }
+}
+
+#[doc(hidden)]
+impl From<miniscript::lex::Error> for Error {
+    fn from(e: miniscript::lex::Error) -> Error { Error::ScriptLexer(e) }
 }
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,7 +481,7 @@ pub enum Error {
     /// Bare descriptors don't have any addresses
     BareDescriptorAddr,
     /// PubKey invalid under current context
-    PubKeyCtxError(miniscript::decode::KeyParseError, &'static str),
+    PubKeyCtxError(miniscript::decode::KeyError, &'static str),
     /// No script code for Tr descriptors
     TrNoScriptCode,
     /// At least two BIP389 key expressions in the descriptor contain tuples of

--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -13,7 +13,7 @@ use crate::prelude::*;
 use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal};
 
 /// Params for parsing miniscripts that either non-sane or non-specified(experimental) in the spec.
-/// Used as a parameter [`Miniscript::from_str_ext`] and [`Miniscript::parse_with_ext`].
+/// Used as a parameter [`Miniscript::from_str_ext`] and [`Miniscript::decode_with_ext`].
 ///
 /// This allows parsing miniscripts if
 /// 1. It is unsafe(does not require a digital signature to spend it)

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -331,7 +331,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> TerminalStack<Pk, Ctx> {
 
 /// Parse a script fragment into an `Miniscript`
 #[allow(unreachable_patterns)]
-pub fn parse<Ctx: ScriptContext>(
+pub fn decode<Ctx: ScriptContext>(
     tokens: &mut TokenIter,
 ) -> Result<Miniscript<Ctx::Key, Ctx>, Error> {
     let mut non_term = Vec::with_capacity(tokens.len());

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -373,12 +373,12 @@ pub fn parse<Ctx: ScriptContext>(
                     tokens,
                     // pubkey
                     Tk::Bytes33(pk) => {
-                        let ret = Ctx::Key::from_slice(pk)
+                        let ret = Ctx::Key::from_slice(&pk)
                             .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?;
                         term.reduce0(Terminal::PkK(ret))?
                     },
                     Tk::Bytes65(pk) => {
-                        let ret = Ctx::Key::from_slice(pk)
+                        let ret = Ctx::Key::from_slice(&pk)
                             .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?;
                         term.reduce0(Terminal::PkK(ret))?
                     },
@@ -395,7 +395,7 @@ pub fn parse<Ctx: ScriptContext>(
                     // after bytes32 means bytes32 is in a hashlock
                     // Finally for the first case, K being parsed as a solo expression is a Pk type
                     Tk::Bytes32(pk) => {
-                        let ret = Ctx::Key::from_slice(pk).map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?;
+                        let ret = Ctx::Key::from_slice(&pk).map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?;
                         term.reduce0(Terminal::PkK(ret))?
                     },
                     // checksig
@@ -414,20 +414,20 @@ pub fn parse<Ctx: ScriptContext>(
                                     tokens,
                                     Tk::Dup => {
                                         term.reduce0(Terminal::RawPkH(
-                                            hash160::Hash::from_slice(hash).expect("valid size")
+                                            hash160::Hash::from_byte_array(hash)
                                         ))?
                                     },
                                     Tk::Verify, Tk::Equal, Tk::Num(32), Tk::Size => {
                                         non_term.push(NonTerm::Verify);
                                         term.reduce0(Terminal::Hash160(
-                                            hash160::Hash::from_slice(hash).expect("valid size")
+                                            hash160::Hash::from_byte_array(hash)
                                         ))?
                                     },
                                 ),
                                 Tk::Ripemd160, Tk::Verify, Tk::Equal, Tk::Num(32), Tk::Size => {
                                     non_term.push(NonTerm::Verify);
                                     term.reduce0(Terminal::Ripemd160(
-                                        ripemd160::Hash::from_slice(hash).expect("valid size")
+                                        ripemd160::Hash::from_byte_array(hash)
                                     ))?
                                 },
                             ),
@@ -437,13 +437,13 @@ pub fn parse<Ctx: ScriptContext>(
                                 Tk::Sha256, Tk::Verify, Tk::Equal, Tk::Num(32), Tk::Size => {
                                     non_term.push(NonTerm::Verify);
                                     term.reduce0(Terminal::Sha256(
-                                        sha256::Hash::from_slice(hash).expect("valid size")
+                                        sha256::Hash::from_byte_array(hash)
                                     ))?
                                 },
                                 Tk::Hash256, Tk::Verify, Tk::Equal, Tk::Num(32), Tk::Size => {
                                     non_term.push(NonTerm::Verify);
                                     term.reduce0(Terminal::Hash256(
-                                        hash256::Hash::from_slice(hash).expect("valid size")
+                                        hash256::Hash::from_byte_array(hash)
                                     ))?
                                 },
                             ),
@@ -480,14 +480,14 @@ pub fn parse<Ctx: ScriptContext>(
                             Tk::Equal,
                             Tk::Num(32),
                             Tk::Size => term.reduce0(Terminal::Sha256(
-                                sha256::Hash::from_slice(hash).expect("valid size")
+                                sha256::Hash::from_byte_array(hash)
                             ))?,
                             Tk::Hash256,
                             Tk::Verify,
                             Tk::Equal,
                             Tk::Num(32),
                             Tk::Size => term.reduce0(Terminal::Hash256(
-                                hash256::Hash::from_slice(hash).expect("valid size")
+                                hash256::Hash::from_byte_array(hash)
                             ))?,
                         ),
                         Tk::Hash20(hash) => match_token!(
@@ -497,14 +497,14 @@ pub fn parse<Ctx: ScriptContext>(
                             Tk::Equal,
                             Tk::Num(32),
                             Tk::Size => term.reduce0(Terminal::Ripemd160(
-                                ripemd160::Hash::from_slice(hash).expect("valid size")
+                                ripemd160::Hash::from_byte_array(hash)
                             ))?,
                             Tk::Hash160,
                             Tk::Verify,
                             Tk::Equal,
                             Tk::Num(32),
                             Tk::Size => term.reduce0(Terminal::Hash160(
-                                hash160::Hash::from_slice(hash).expect("valid size")
+                                hash160::Hash::from_byte_array(hash)
                             ))?,
                         ),
                         // thresholds
@@ -545,9 +545,9 @@ pub fn parse<Ctx: ScriptContext>(
                         for _ in 0..n {
                             match_token!(
                                 tokens,
-                                Tk::Bytes33(pk) => keys.push(<Ctx::Key>::from_slice(pk)
+                                Tk::Bytes33(pk) => keys.push(<Ctx::Key>::from_slice(&pk)
                                     .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?),
-                                Tk::Bytes65(pk) => keys.push(<Ctx::Key>::from_slice(pk)
+                                Tk::Bytes65(pk) => keys.push(<Ctx::Key>::from_slice(&pk)
                                     .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?),
                             );
                         }
@@ -567,14 +567,14 @@ pub fn parse<Ctx: ScriptContext>(
                         while tokens.peek() == Some(&Tk::CheckSigAdd) {
                             match_token!(
                                 tokens,
-                                Tk::CheckSigAdd, Tk::Bytes32(pk) => keys.push(<Ctx::Key>::from_slice(pk)
+                                Tk::CheckSigAdd, Tk::Bytes32(pk) => keys.push(<Ctx::Key>::from_slice(&pk)
                                     .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?),
                             );
                         }
                         // Last key must be with a CheckSig
                         match_token!(
                             tokens,
-                            Tk::CheckSig, Tk::Bytes32(pk) => keys.push(<Ctx::Key>::from_slice(pk)
+                            Tk::CheckSig, Tk::Bytes32(pk) => keys.push(<Ctx::Key>::from_slice(&pk)
                                 .map_err(|e| Error::PubKeyCtxError(e, Ctx::name_str()))?),
                         );
                         keys.reverse();

--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -8,6 +8,7 @@
 use core::fmt;
 
 use bitcoin::blockdata::{opcodes, script};
+use bitcoin::hex::DisplayHex as _;
 
 use super::Error;
 use crate::prelude::*;
@@ -15,7 +16,7 @@ use crate::prelude::*;
 /// Atom of a tokenized version of a script
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
-pub enum Token<'s> {
+pub enum Token {
     BoolAnd,
     BoolOr,
     Add,
@@ -44,22 +45,20 @@ pub enum Token<'s> {
     Sha256,
     Hash256,
     Num(u32),
-    Hash20(&'s [u8]),
-    Bytes32(&'s [u8]),
-    Bytes33(&'s [u8]),
-    Bytes65(&'s [u8]),
+    Hash20([u8; 20]),
+    Bytes32([u8; 32]),
+    Bytes33([u8; 33]),
+    Bytes65([u8; 65]),
 }
 
-impl fmt::Display for Token<'_> {
+impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Token::Num(n) => write!(f, "#{}", n),
-            Token::Hash20(b) | Token::Bytes33(b) | Token::Bytes32(b) | Token::Bytes65(b) => {
-                for ch in b {
-                    write!(f, "{:02x}", *ch)?;
-                }
-                Ok(())
-            }
+            Token::Hash20(b) => write!(f, "{}", b.as_hex()),
+            Token::Bytes32(b) => write!(f, "{}", b.as_hex()),
+            Token::Bytes33(b) => write!(f, "{}", b.as_hex()),
+            Token::Bytes65(b) => write!(f, "{}", b.as_hex()),
             x => write!(f, "{:?}", x),
         }
     }
@@ -68,18 +67,18 @@ impl fmt::Display for Token<'_> {
 #[derive(Debug, Clone)]
 /// Iterator that goes through a vector of tokens backward (our parser wants to read
 /// backward and this is more efficient anyway since we can use `Vec::pop()`).
-pub struct TokenIter<'s>(Vec<Token<'s>>);
+pub struct TokenIter(Vec<Token>);
 
-impl<'s> TokenIter<'s> {
+impl TokenIter {
     /// Create a new TokenIter
-    pub fn new(v: Vec<Token<'s>>) -> TokenIter<'s> { TokenIter(v) }
+    pub fn new(v: Vec<Token>) -> TokenIter { TokenIter(v) }
 
     /// Look at the top at Iterator
-    pub fn peek(&self) -> Option<&'s Token> { self.0.last() }
+    pub fn peek(&self) -> Option<&Token> { self.0.last() }
 
     /// Push a value to the iterator
     /// This will be first value consumed by popun_
-    pub fn un_next(&mut self, tok: Token<'s>) { self.0.push(tok) }
+    pub fn un_next(&mut self, tok: Token) { self.0.push(tok) }
 
     /// The len of the iterator
     pub fn len(&self) -> usize { self.0.len() }
@@ -88,14 +87,14 @@ impl<'s> TokenIter<'s> {
     pub fn is_empty(&self) -> bool { self.0.is_empty() }
 }
 
-impl<'s> Iterator for TokenIter<'s> {
-    type Item = Token<'s>;
+impl Iterator for TokenIter {
+    type Item = Token;
 
-    fn next(&mut self) -> Option<Token<'s>> { self.0.pop() }
+    fn next(&mut self) -> Option<Token> { self.0.pop() }
 }
 
 /// Tokenize a script
-pub fn lex(script: &'_ script::Script) -> Result<Vec<Token<'_>>, Error> {
+pub fn lex(script: &'_ script::Script) -> Result<Vec<Token>, Error> {
     let mut ret = Vec::with_capacity(script.len());
 
     for ins in script.instructions_minimal() {
@@ -207,20 +206,22 @@ pub fn lex(script: &'_ script::Script) -> Result<Vec<Token<'_>>, Error> {
                 ret.push(Token::Hash256);
             }
             script::Instruction::PushBytes(bytes) => {
-                match bytes.len() {
-                    20 => ret.push(Token::Hash20(bytes.as_bytes())),
-                    32 => ret.push(Token::Bytes32(bytes.as_bytes())),
-                    33 => ret.push(Token::Bytes33(bytes.as_bytes())),
-                    65 => ret.push(Token::Bytes65(bytes.as_bytes())),
-                    _ => {
-                        // check minimality of the number
-                        match script::read_scriptint(bytes.as_bytes()) {
-                            Ok(v) if v >= 0 => {
-                                ret.push(Token::Num(v as u32));
-                            }
-                            Ok(_) => return Err(Error::InvalidPush(bytes.to_owned().into())),
-                            Err(e) => return Err(Error::Script(e)),
+                if let Ok(bytes) = bytes.as_bytes().try_into() {
+                    ret.push(Token::Hash20(bytes));
+                } else if let Ok(bytes) = bytes.as_bytes().try_into() {
+                    ret.push(Token::Bytes32(bytes));
+                } else if let Ok(bytes) = bytes.as_bytes().try_into() {
+                    ret.push(Token::Bytes33(bytes));
+                } else if let Ok(bytes) = bytes.as_bytes().try_into() {
+                    ret.push(Token::Bytes65(bytes));
+                } else {
+                    // check minimality of the number
+                    match script::read_scriptint(bytes.as_bytes()) {
+                        Ok(v) if v >= 0 => {
+                            ret.push(Token::Num(v as u32));
                         }
+                        Ok(_) => return Err(Error::InvalidPush(bytes.to_owned().into())),
+                        Err(e) => return Err(Error::Script(e)),
                     }
                 }
             }

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -71,7 +71,7 @@ fn construct_tap_witness(
                 // We don't know how to satisfy non default version scripts yet
                 continue;
             }
-            let ms = match Miniscript::<XOnlyPublicKey, Tap>::parse_with_ext(
+            let ms = match Miniscript::<XOnlyPublicKey, Tap>::decode_with_ext(
                 script,
                 &ExtParams::allow_all(),
             ) {
@@ -213,7 +213,7 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
                     p2wsh_expected: script_pubkey.clone(),
                 });
             }
-            let ms = Miniscript::<bitcoin::PublicKey, Segwitv0>::parse_with_ext(
+            let ms = Miniscript::<bitcoin::PublicKey, Segwitv0>::decode_with_ext(
                 witness_script,
                 &ExtParams::allow_all(),
             )?;
@@ -240,7 +240,7 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
                                 p2wsh_expected: redeem_script.clone(),
                             });
                         }
-                        let ms = Miniscript::<bitcoin::PublicKey, Segwitv0>::parse_with_ext(
+                        let ms = Miniscript::<bitcoin::PublicKey, Segwitv0>::decode_with_ext(
                             witness_script,
                             &ExtParams::allow_all(),
                         )?;
@@ -272,7 +272,7 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
                         return Err(InputError::NonEmptyWitnessScript);
                     }
                     if let Some(ref redeem_script) = inp.redeem_script {
-                        let ms = Miniscript::<bitcoin::PublicKey, Legacy>::parse_with_ext(
+                        let ms = Miniscript::<bitcoin::PublicKey, Legacy>::decode_with_ext(
                             redeem_script,
                             &ExtParams::allow_all(),
                         )?;
@@ -291,7 +291,7 @@ fn get_descriptor(psbt: &Psbt, index: usize) -> Result<Descriptor<PublicKey>, In
         if inp.redeem_script.is_some() {
             return Err(InputError::NonEmptyRedeemScript);
         }
-        let ms = Miniscript::<bitcoin::PublicKey, BareCtx>::parse_with_ext(
+        let ms = Miniscript::<bitcoin::PublicKey, BareCtx>::decode_with_ext(
             &script_pubkey,
             &ExtParams::allow_all(),
         )?;


### PR DESCRIPTION
The last commit, which renames `parse_with_ext` to `decode_with_ext`, I think we should backport with deprecation to 12.x. This is a pretty uncommonly used function and is unlikely to bother anybody, but the current name is inconsistent with our general use of "parse" for strings and "decode" for scripts.