### PR TITLE
Fix Typos in Comment

### DIFF
--- a/src/miniscript/lex.rs
+++ b/src/miniscript/lex.rs
@@ -288,7 +288,7 @@ pub enum Error {
     InvalidInt {
         /// The bytes of the push that were attempted to be parsed.
         bytes: bitcoin::script::PushBytesBuf,
-        /// The error that occured.
+        /// The error that occurred.
         err: bitcoin::script::Error,
     },
     /// Parsed an opcode outside of the Miniscript language.

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -270,7 +270,7 @@ mod private {
             }
         }
 
-        // non-const because Thresh::n is not becasue Vec::len is not (needs Rust 1.87)
+        // non-const because Thresh::n is not because Vec::len is not (needs Rust 1.87)
         /// The `multi` combinator.
         pub fn multi(thresh: crate::Threshold<Pk, MAX_PUBKEYS_PER_MULTISIG>) -> Self {
             Self {
@@ -281,7 +281,7 @@ mod private {
             }
         }
 
-        // non-const because Thresh::n is not becasue Vec::len is not
+        // non-const because Thresh::n is not because Vec::len is not
         /// The `multi` combinator.
         pub fn multi_a(thresh: crate::Threshold<Pk, MAX_PUBKEYS_IN_CHECKSIGADD>) -> Self {
             Self {


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `occured` → `occurred`
  - `becasue` → `because`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.