### PR TITLE
chore: Fix spelling issues

### DIFF
--- a/fuzz/fuzz_targets/compile_taproot.rs
+++ b/fuzz/fuzz_targets/compile_taproot.rs
@@ -22,7 +22,7 @@ fn do_test(data: &[u8]) {
                 let rtt = desc.to_string();
                 assert_eq!(output.to_lowercase(), rtt.to_lowercase());
             } else {
-                panic!("compiler output something unparseable: {}", output)
+                panic!("compiler output something unparsable: {}", output)
             }
         }
     }

--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -227,7 +227,7 @@ pub struct Formatter<'f, 'a> {
 }
 
 impl<'f, 'a> Formatter<'f, 'a> {
-    /// Contructs a new `Formatter`, wrapping a given `fmt::Formatter`.
+    /// Constructs a new `Formatter`, wrapping a given `fmt::Formatter`.
     pub fn new(f: &'f mut fmt::Formatter<'a>) -> Self { Formatter { fmt: f, eng: Engine::new() } }
 
     /// Writes the checksum into the underlying `fmt::Formatter`.

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -187,7 +187,7 @@ impl<'txin> Interpreter<'txin> {
     /// - the input index is out of range
     /// - Insufficient sighash information is present
     /// - sighash single without corresponding output
-    // TODO: Create a good first isse to change this to error
+    // TODO: Create a good first issue to change this to error
     // TODO: Requires refactor to remove the script_code logic in order to use the new sighash API.
     #[allow(deprecated)] // For segwit_signature_hash
     pub fn verify_sig<C: secp256k1::Verification, T: Borrow<TxOut>>(


### PR DESCRIPTION
### Description

- Corrected misspellings:
  - `unparseable` → `unparsable`
  - `Contructs` → `Constructs`
  - `isse` → `issue`