### PR TITLE
chore: correct typos across files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ See this (link)[https://github.com/rust-bitcoin/rust-miniscript/pull/349/commits
 - Add sortedmulti descriptor
 - Added standardness and other sanity checks
 - Cleaned up `Error` type and return values of most of the API
-- Overhauled `satisfied_constraints` module into a new `Iterpreter` API
+- Overhauled `satisfied_constraints` module into a new `Interpreter` API
 
 # 3.0.0 - Oct 13, 2020
 

--- a/src/miniscript/satisfy.rs
+++ b/src/miniscript/satisfy.rs
@@ -1079,7 +1079,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         }
     }
 
-    // produce a possily malleable satisafaction for thesh frag
+    // produce a possibly malleable satisafaction for thesh frag
     fn thresh_mall<Ctx, Sat, F>(
         thresh: &Threshold<Arc<Miniscript<Pk, Ctx>>, 0>,
         stfr: &Sat,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -520,7 +520,7 @@ pub struct Assets {
 
 // Checks if the `pk` is a "direct child" of the `derivation_path` provided.
 // Direct child means that the key derivation path is either the same as the
-// `derivation_path`, or the same extened by exactly one child number.
+// `derivation_path`, or the same extended by exactly one child number.
 // For example, `pk/0/1/2` is a direct child of `m/0/1` and of `m/0/1/2`,
 // but not of `m/0`.
 fn is_key_direct_child_of(
@@ -690,7 +690,7 @@ impl IntoAssets for Assets {
 }
 
 impl Assets {
-    /// Contruct an empty instance
+    /// Construct an empty instance
     pub fn new() -> Self { Self::default() }
 
     /// Add some assets

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -30,7 +30,7 @@ use crate::{
     AbsLockTime, Error, ForEachKey, FromStrKey, MiniscriptKey, RelLockTime, Threshold, Translator,
 };
 
-/// Maximum TapLeafs allowed in a compiled TapTree
+/// Maximum `TapLeaf`s allowed in a compiled TapTree
 #[cfg(feature = "compiler")]
 const MAX_COMPILATION_LEAVES: usize = 1024;
 


### PR DESCRIPTION
Fixed a few typos — “possily” → “possibly”, “TapLeafs” → " `TapLeaf`s ", “Contruct” → “Construct”, and fixed the misspelled “Interpreter”.