### PR TITLE
Remove link to doc file

### DIFF
--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -346,7 +346,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     ///
     /// It is **not recommended** to use policy as a stable identifier for a miniscript. You should
     /// use the policy compiler once, and then use the miniscript output as a stable identifier. See
-    /// the compiler document in [`doc/compiler.md`] for more details.
+    /// the compiler document in `./doc/compiler.md` for more details.
     #[cfg(feature = "compiler")]
     pub fn compile_to_descriptor<Ctx: ScriptContext>(
         &self,


### PR DESCRIPTION
We cannot link to a file by directory path in rustdocs. Just remove the link.

This is breaking the docs build in #805 and is also mentioned in #872.