### PR TITLE
 Fix typos in comments 

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -156,7 +156,7 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
 
     /// Create a new pk descriptor
     pub fn new_pk(pk: Pk) -> Self {
-        // roundabout way to constuct `c:pk_k(pk)`
+        // roundabout way to construct `c:pk_k(pk)`
         let ms: Miniscript<Pk, BareCtx> = Miniscript::from_ast(Terminal::Check(Arc::new(
             Miniscript::from_ast(Terminal::PkK(pk)).expect("Type check cannot fail"),
         )))

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -783,7 +783,7 @@ impl ScriptContext for BareCtx {
 
 /// "No Checks Ecdsa" Context
 ///
-/// Used by the "satisified constraints" iterator, which is intended to read
+/// Used by the "satisfied constraints" iterator, which is intended to read
 /// scripts off of the blockchain without doing any sanity checks on them.
 /// This context should *NOT* be used unless you know what you are doing.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]


### PR DESCRIPTION
Fixes three typos found in the codebase:

  - `constuct` → `construct` (src/descriptor/mod.rs:159) 
  - `satisified` → `satisfied` (src/miniscript/context.rs:786) 