### PR TITLE
bitcoind_tests: Upgrade corepc-node version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,6 +133,25 @@ jobs:
   Integration:                  # 1 job for each bitcoind version we support.
     name: Integration tests - stable toolchain
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          [
+            "29_0",
+            "28_2",
+            "27_2",
+            "26_2",
+            "25_2",
+            "24_2",
+            "23_2",
+            "22_1",
+            "0_21_2",
+            "0_20_2",
+            "0_19_1",
+            "0_18_1",
+            "0_17_2",
+          ]
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/prepare

--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -9,26 +9,22 @@ publish = false
 
 [dependencies]
 miniscript = {path = "../"}
-bitcoind = { package = "corepc-node", version = "0.4.0", default-features = false }
+bitcoind = { package = "corepc-node", version = "0.10.0", default-features = false }
 actual-rand = { package = "rand", version = "0.8.4"}
 secp256k1 = {version = "0.29.0", features = ["rand-std"]}
 
 [features]
 # Enable the same feature in `bitcoind`.
-"26_0" = ["bitcoind/26_0"]
+"29_0" = ["bitcoind/29_0"]
+"28_2" = ["bitcoind/28_2"]
+"27_2" = ["bitcoind/27_2"]
+"26_2" = ["bitcoind/26_2"]
 "25_2" = ["bitcoind/25_2"]
-"25_1" = ["bitcoind/25_1"]
-"25_0" = ["bitcoind/25_0"]
 "24_2" = ["bitcoind/24_2"]
-"24_1" = ["bitcoind/24_1"]
-"24_0_1" = ["bitcoind/24_0_1"]
 "23_2" = ["bitcoind/23_2"]
-"23_1" = ["bitcoind/23_1"]
-"23_0" = ["bitcoind/23_0"]
 "22_1" = ["bitcoind/22_1"]
-"22_0" = ["bitcoind/22_0"]
 "0_21_2" = ["bitcoind/0_21_2"]
 "0_20_2" = ["bitcoind/0_20_2"]
 "0_19_1" = ["bitcoind/0_19_1"]
 "0_18_1" = ["bitcoind/0_18_1"]
-"0_17_1" = ["bitcoind/0_17_1"]
+"0_17_2" = ["bitcoind/0_17_2"]

--- a/bitcoind-tests/tests/setup/mod.rs
+++ b/bitcoind-tests/tests/setup/mod.rs
@@ -5,7 +5,7 @@ use bitcoind::client::bitcoin;
 pub mod test_util;
 
 // Launch an instance of bitcoind with
-pub fn setup() -> bitcoind::BitcoinD {
+pub fn setup() -> bitcoind::Node {
     // Create env var BITCOIND_EXE_PATH to point to the ../bitcoind/bin/bitcoind binary
     let key = "BITCOIND_EXE";
     if std::env::var(key).is_err() {
@@ -24,7 +24,7 @@ pub fn setup() -> bitcoind::BitcoinD {
     }
 
     let exe_path = bitcoind::exe_path().unwrap();
-    let bitcoind = bitcoind::BitcoinD::new(exe_path).unwrap();
+    let bitcoind = bitcoind::Node::new(exe_path).unwrap();
     let cl = &bitcoind.client;
     // generate to an address by the wallet. And wait for funds to mature
     let addr = cl.new_address().unwrap();


### PR DESCRIPTION
Upgrade to the `v0.10` release of the `corepc` stack.

Only test latest point release of each version of Core. `corepc` supports all point releases for the latest 3 version of Core but I'm not convinced there is any benefit testing all of them here.

Note that `corepc-node` only supports up to Core v29