### PR TITLE
ci: free bloat for MSRV job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,6 +85,12 @@ jobs:
           repository: rust-bitcoin/rust-bitcoin-maintainer-tools
           ref: c3324024ced9bb1eb854397686919c3ff7d97e1e
           path: maintainer-tools
+      - name: "Free disk space"
+        uses: endersonmenezes/free-disk-space@v3
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
       - name: "Select toolchain"
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
The MSRV job is running out of memory in CI due to a recent change to Github's underlying runner. Sounds like this will be resolved at some point in the future, actions/runner-images#13315, but until then remove the extra bloat.

Copying over from rust-bitcoin: https://github.com/rust-bitcoin/rust-bitcoin/pull/5310