### PR TITLE
chore: fix typos in comment

### DIFF
--- a/examples/taptree_of_horror/taptree_of_horror.rs
+++ b/examples/taptree_of_horror/taptree_of_horror.rs
@@ -250,7 +250,7 @@ fn main() {
     // ====== 5. Sign and Create a Spending Transaction ======
 
     // this is how you would sign for an internal key spend
-    //let _res = psbt.sign(&intneral_xpriv.xkey, secp).unwrap();
+    //let _res = psbt.sign(&internal_xpriv.xkey, secp).unwrap();
 
     // how you would sign using the leaf that uses index 0 keys
     let _res = psbt.sign(&a_prvs[0], secp).unwrap();

--- a/fuzz/fuzz_targets/compile_descriptor.rs
+++ b/fuzz/fuzz_targets/compile_descriptor.rs
@@ -22,7 +22,7 @@ fn do_test(data: &[u8]) {
                 let rtt = desc.to_string();
                 assert_eq!(output.to_lowercase(), rtt.to_lowercase());
             } else {
-                panic!("compiler output something unparseable: {}", output)
+                panic!("compiler output something unparsable: {}", output)
             }
         }
     }

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -567,7 +567,7 @@ impl<'a> Tree<'a> {
                     //
                     // From a user point of view, UnmatchedCloseParen would probably be
                     // a clearer error to get, but it complicates the parser to do this,
-                    // and "TralingCharacter" is technically correct, so we leave it for
+                    // and "TrailingCharacter" is technically correct, so we leave it for
                     // now.
                     return Err(ParseTreeError::UnmatchedCloseParen { ch: ch.into(), pos });
                 }


### PR DESCRIPTION
Corrected several spelling errors :
  - `intneral_xpriv` → `internal_xpriv` (examples/taptree_of_horror/taptree_of_horror.rs:253) 
  - `unparseable` → `unparsable` (fuzz/fuzz_targets/compile_descriptor.rs:25) 
  - `TralingCharacter` → `TrailingCharacter` (src/expression/mod.rs:570)