### PR TITLE
[plan] Derive `Clone` for `Assets`

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -494,7 +494,7 @@ impl TaprootAvailableLeaves {
 }
 
 /// The Assets we can use to satisfy a particular spending path
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Assets {
     /// Keys the user can sign for, and how.
     ///


### PR DESCRIPTION
I would like to derive `Clone` for a type in my project which holds some assets but currently cannot since `Assets` itself is not `Clone`. This change implements `Clone` for the `Assets` type, by deriving it. This felt like a straightforward approach but let me know if I've overlooked something.