### PR TITLE
plan: Derive PartialEq, Eq, Hash for Assets

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -494,7 +494,7 @@ impl TaprootAvailableLeaves {
 }
 
 /// The Assets we can use to satisfy a particular spending path
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct Assets {
     /// Keys the user can sign for, and how.
     ///


### PR DESCRIPTION
 Adds `PartialEq`, `Eq`, and `Hash` derives to the `Assets` struct, enabling it to be used as a hashmap key and compared for equality.

  All fields in `Assets` already implement these traits (BTreeSet, Option, etc.), and similar structs in the same module like `CanSign` and `TaprootCanSign` already derive them. This makes the API more consistent and useful for testing and practical applications where comparing or storing `Assets` instances is needed.