### PR TITLE
Add compile_tr_native() for Taptree-native policy compilation

### DIFF
--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -64,6 +64,11 @@ pub enum CompilerError {
         /// Maximum allowed number of Tapleaves.
         max: usize,
     },
+    /// Native Taproot compilation produced a leaf containing OP_IF/NOTIF.
+    IfFragmentInNativeLeaf {
+        /// Index of the leaf that contains branching fragments.
+        leaf_index: usize,
+    },
     ///Policy related errors
     PolicyError(policy::concrete::PolicyError),
 }
@@ -92,6 +97,14 @@ impl fmt::Display for CompilerError {
             CompilerError::TooManyTapleaves { n, max } => {
                 write!(f, "Policy had too many Tapleaves (found {}, maximum {})", n, max)
             }
+            CompilerError::IfFragmentInNativeLeaf { leaf_index } => {
+                write!(
+                    f,
+                    "native Taproot compilation produced a leaf with OP_IF/NOTIF at leaf index {}; \
+                     try increasing max_leaves",
+                    leaf_index
+                )
+            }
             CompilerError::PolicyError(ref e) => fmt::Display::fmt(e, f),
         }
     }
@@ -109,7 +122,8 @@ impl error::Error for CompilerError {
             | ImpossibleNonMalleableCompilation
             | LimitsExceeded
             | NoInternalKey
-            | TooManyTapleaves { .. } => None,
+            | TooManyTapleaves { .. }
+            | IfFragmentInNativeLeaf { .. } => None,
             PolicyError(e) => Some(e),
         }
     }

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -424,6 +424,21 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// enumerated sub-policies whose disjunction is isomorphic to initial policy (*invariant*).
     #[cfg(feature = "compiler")]
     fn enumerate_policy_tree(self, prob: f64) -> Vec<(f64, Arc<Self>)> {
+        self.enumerate_leaves(prob, MAX_COMPILATION_LEAVES, Self::enumerate_pol)
+    }
+
+    /// Fixed-point leaf enumeration parameterized by the expansion function and leaf limit.
+    ///
+    /// Iteratively expands policies using `expand_fn` until no further splits are possible
+    /// or the number of leaves exceeds `max_leaves`.
+    #[cfg(feature = "compiler")]
+    #[allow(clippy::type_complexity)]
+    fn enumerate_leaves(
+        self,
+        prob: f64,
+        max_leaves: usize,
+        expand_fn: fn(&Self, f64) -> Vec<(f64, Arc<Self>)>,
+    ) -> Vec<(f64, Arc<Self>)> {
         let mut tapleaf_prob_vec = BTreeSet::<(Reverse<OrdF64>, Arc<Self>)>::new();
         // Store probability corresponding to policy in the enumerated tree. This is required since
         // owing to the current [policy element enumeration algorithm][`Policy::enumerate_pol`],
@@ -457,7 +472,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             // from the ordered set.
             let mut to_del: Vec<(f64, Arc<Self>)> = vec![];
             'inner: for (i, (p, pol)) in tapleaf_prob_vec.iter().enumerate() {
-                curr_pol_replace_vec = pol.enumerate_pol(p.0 .0);
+                curr_pol_replace_vec = expand_fn(pol, p.0 .0);
                 enum_len += curr_pol_replace_vec.len() - 1; // A disjunctive node should have separated this into more nodes
                 assert!(prev_len <= enum_len);
 
@@ -479,7 +494,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
             }
 
             // --- Sanity Checks ---
-            if enum_len > MAX_COMPILATION_LEAVES || no_more_enum {
+            if enum_len > max_leaves || no_more_enum {
                 for (p, pol) in tapleaf_prob_vec.into_iter() {
                     ret.push((p.0 .0, pol));
                 }

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -278,12 +278,12 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
 
     /// Compiles the [`Policy`] into a [`Descriptor::Tr`] using Taptree-native branching.
     ///
-    /// Unlike [`compile_tr`], this method decomposes all `Or` and `Thresh` branches
+    /// Unlike [`Self::compile_tr`], this method decomposes all `Or` and `Thresh` branches
     /// (including those nested inside `And` nodes) into separate TapTree leaves.
     /// Each leaf contains only non-branching Miniscript fragments (no OP_IF/NOTIF).
     ///
     /// `max_leaves` caps the number of TapTree leaves to prevent combinatorial explosion.
-    /// Clamped to [`MAX_COMPILATION_LEAVES`] (1024).
+    /// Clamped to 1024.
     #[cfg(feature = "compiler")]
     pub fn compile_tr_native(
         &self,

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -16,6 +16,7 @@ use {
     crate::Descriptor,
     crate::Miniscript,
     crate::Tap,
+    crate::Terminal,
     core::cmp::Reverse,
 };
 
@@ -275,6 +276,70 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         }
     }
 
+    /// Compiles the [`Policy`] into a [`Descriptor::Tr`] using Taptree-native branching.
+    ///
+    /// Unlike [`compile_tr`], this method decomposes all `Or` and `Thresh` branches
+    /// (including those nested inside `And` nodes) into separate TapTree leaves.
+    /// Each leaf contains only non-branching Miniscript fragments (no OP_IF/NOTIF).
+    ///
+    /// `max_leaves` caps the number of TapTree leaves to prevent combinatorial explosion.
+    /// Clamped to [`MAX_COMPILATION_LEAVES`] (1024).
+    #[cfg(feature = "compiler")]
+    pub fn compile_tr_native(
+        &self,
+        unspendable_key: Option<Pk>,
+        max_leaves: usize,
+    ) -> Result<Descriptor<Pk>, CompilerError> {
+        if max_leaves == 0 {
+            return Err(CompilerError::TooManyTapleaves { n: 1, max: 0 });
+        }
+        let max_leaves = max_leaves.min(MAX_COMPILATION_LEAVES);
+        self.is_valid().map_err(CompilerError::PolicyError)?;
+        self.check_binary_ops()?;
+        match self.is_safe_nonmalleable() {
+            (false, _) => Err(CompilerError::TopLevelNonSafe),
+            (_, false) => Err(CompilerError::ImpossibleNonMalleableCompilation),
+            _ => {
+                let (internal_key, policy) = self.clone().extract_key(unspendable_key)?;
+                let tap_tree = match policy {
+                    Policy::Trivial => None,
+                    policy => {
+                        let leaves =
+                            policy.enumerate_leaves(1.0, max_leaves, Self::enumerate_pol_native);
+                        let n = leaves.len();
+                        if n > max_leaves {
+                            return Err(CompilerError::TooManyTapleaves { n, max: max_leaves });
+                        }
+                        let mut leaf_compilations: Vec<(OrdF64, Miniscript<Pk, Tap>)> = vec![];
+                        for (leaf_idx, (prob, pol)) in leaves.iter().enumerate() {
+                            if **pol == Policy::Unsatisfiable {
+                                continue;
+                            }
+                            let compilation = compiler::best_compilation::<Pk, Tap>(pol.as_ref())?;
+                            compilation
+                                .sanity_check()
+                                .expect("compiler produces sane output");
+                            if has_if_fragment(&compilation) {
+                                return Err(CompilerError::IfFragmentInNativeLeaf {
+                                    leaf_index: leaf_idx,
+                                });
+                            }
+                            leaf_compilations.push((OrdF64(*prob), compilation));
+                        }
+                        if !leaf_compilations.is_empty() {
+                            Some(with_huffman_tree::<Pk>(leaf_compilations))
+                        } else {
+                            None
+                        }
+                    }
+                };
+                let tree = Descriptor::new_tr(internal_key, tap_tree)
+                    .expect("compiler produces sane output");
+                Ok(tree)
+            }
+        }
+    }
+
     /// Compiles the [`Policy`] into a [`Descriptor::Tr`].
     ///
     /// ### TapTree compilation
@@ -412,6 +477,53 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                     .collect::<Vec<_>>()
             }
             Policy::Thresh(ref thresh) if !thresh.is_and() => generate_combination(thresh, prob),
+            pol => vec![(prob, Arc::new(pol.clone()))],
+        }
+    }
+
+    /// Like [`enumerate_pol`] but also distributes `And` over `Or`/`Thresh` children.
+    ///
+    /// This ensures nested `Or` branches inside `And` nodes are decomposed into
+    /// separate sub-policies, producing IF-free leaves for Taptree-native compilation.
+    #[cfg(feature = "compiler")]
+    fn enumerate_pol_native(&self, prob: f64) -> Vec<(f64, Arc<Self>)> {
+        match self {
+            Policy::Or(subs) => {
+                let total_odds = subs.iter().fold(0, |acc, x| acc + x.0);
+                subs.iter()
+                    .map(|(odds, pol)| (prob * *odds as f64 / total_odds as f64, pol.clone()))
+                    .collect::<Vec<_>>()
+            }
+            Policy::Thresh(ref thresh) if thresh.is_or() => {
+                let total_odds = thresh.n();
+                thresh
+                    .iter()
+                    .map(|pol| (prob / total_odds as f64, pol.clone()))
+                    .collect::<Vec<_>>()
+            }
+            Policy::Thresh(ref thresh) if !thresh.is_and() => generate_combination(thresh, prob),
+            Policy::And(subs) => {
+                for (i, sub) in subs.iter().enumerate() {
+                    let child_expanded = sub.enumerate_pol_native(1.0);
+                    if child_expanded.len() > 1 {
+                        let other: Vec<_> = subs
+                            .iter()
+                            .enumerate()
+                            .filter(|(j, _)| *j != i)
+                            .map(|(_, s)| s.clone())
+                            .collect();
+                        return child_expanded
+                            .into_iter()
+                            .map(|(child_prob, child_pol)| {
+                                let mut new_subs = other.clone();
+                                new_subs.insert(i, child_pol);
+                                (prob * child_prob, Arc::new(Policy::And(new_subs)))
+                            })
+                            .collect();
+                    }
+                }
+                vec![(prob, Arc::new(self.clone()))]
+            }
             pol => vec![(prob, Arc::new(pol.clone()))],
         }
     }
@@ -963,6 +1075,25 @@ impl<Pk: FromStrKey> expression::FromTree for Policy<Pk> {
         assert_eq!(stack.len(), 1);
         Ok(Arc::try_unwrap(stack.pop().unwrap().1).unwrap())
     }
+}
+
+/// Checks if a compiled Tapscript contains any OP_IF/NOTIF fragments.
+///
+/// `OrB` is intentionally excluded: it uses `OP_BOOLOR` (not `OP_IF`/`OP_NOTIF`),
+/// so both branches are always evaluated and no execution-path branching occurs.
+#[cfg(feature = "compiler")]
+fn has_if_fragment<Pk: MiniscriptKey>(ms: &Miniscript<Pk, Tap>) -> bool {
+    ms.pre_order_iter().any(|node| {
+        matches!(
+            node.node,
+            Terminal::DupIf(_)
+                | Terminal::NonZero(_)
+                | Terminal::AndOr(..)
+                | Terminal::OrD(..)
+                | Terminal::OrC(..)
+                | Terminal::OrI(..)
+        )
+    })
 }
 
 /// Creates a Huffman Tree from compiled [`Miniscript`] nodes.

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -573,9 +573,7 @@ mod tests {
                 }
                 _ => panic!("expected Tr descriptor"),
             }
-            let standard = policy
-                .compile_tr(Some(unspendable_key.clone()))
-                .unwrap();
+            let standard = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
             let lifted_native = desc.lift().unwrap();
             let lifted_standard = standard.lift().unwrap();
             assert_eq!(
@@ -603,25 +601,16 @@ mod tests {
                 }
                 _ => panic!("expected Tr descriptor"),
             }
-            let standard = policy
-                .compile_tr(Some(unspendable_key.clone()))
-                .unwrap();
+            let standard = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
             let lifted_native = desc.lift().unwrap();
             let lifted_standard = standard.lift().unwrap();
-            assert_eq!(
-                lifted_native.clone().entails(lifted_standard.clone()),
-                Some(true),
-            );
-            assert_eq!(
-                lifted_standard.entails(lifted_native),
-                Some(true),
-            );
+            assert_eq!(lifted_native.clone().entails(lifted_standard.clone()), Some(true),);
+            assert_eq!(lifted_standard.entails(lifted_native), Some(true),);
         }
 
         // max_leaves caps the enumeration
         {
-            let policy: Concrete<String> =
-                policy_str!("thresh(2,pk(A),pk(B),pk(C),pk(D),pk(E))");
+            let policy: Concrete<String> = policy_str!("thresh(2,pk(A),pk(B),pk(C),pk(D),pk(E))");
             let result = policy.compile_tr_native(Some(unspendable_key.clone()), 1024);
             assert!(result.is_ok());
         }
@@ -630,17 +619,13 @@ mod tests {
         {
             let policy: Concrete<String> = policy_str!("or(pk(A),pk(B))");
             let result = policy.compile_tr_native(Some(unspendable_key.clone()), 0);
-            assert!(matches!(
-                result,
-                Err(super::compiler::CompilerError::TooManyTapleaves { .. })
-            ));
+            assert!(matches!(result, Err(super::compiler::CompilerError::TooManyTapleaves { .. })));
         }
 
         // max_leaves too small: returns TooManyTapleaves or IfFragmentInNativeLeaf
         // (the latter when enumeration stops early, leaving unexpanded branches)
         {
-            let policy: Concrete<String> =
-                policy_str!("and(or(pk(A),pk(B)),or(pk(C),pk(D)))");
+            let policy: Concrete<String> = policy_str!("and(or(pk(A),pk(B)),or(pk(C),pk(D)))");
             let result = policy.compile_tr_native(Some(unspendable_key.clone()), 2);
             assert!(
                 matches!(
@@ -651,6 +636,46 @@ mod tests {
                 "expected TooManyTapleaves or IfFragmentInNativeLeaf, got: {:?}",
                 result
             );
+        }
+
+        // and(or(A,B),or(C,D)) -> 4 leaves via cross-product; verify semantic equivalence
+        {
+            let policy: Concrete<String> = policy_str!("and(or(pk(A),pk(B)),or(pk(C),pk(D)))");
+            let desc = policy
+                .compile_tr_native(Some(unspendable_key.clone()), 128)
+                .unwrap();
+            match &desc {
+                Descriptor::Tr(tr) => {
+                    let leaves: Vec<_> = tr.tap_tree().unwrap().leaves().collect();
+                    assert_eq!(leaves.len(), 4, "expected 4 leaves from and(or(A,B),or(C,D))");
+                }
+                _ => panic!("expected Tr descriptor"),
+            }
+            let standard = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
+            let lifted_native = desc.lift().unwrap();
+            let lifted_standard = standard.lift().unwrap();
+            assert_eq!(lifted_native.clone().entails(lifted_standard.clone()), Some(true));
+            assert_eq!(lifted_standard.entails(lifted_native), Some(true));
+        }
+
+        // thresh(3,pk(A),pk(B),pk(C),pk(D),pk(E)) -> 10 leaves (C(5,3)=10), all distinct
+        {
+            let policy: Concrete<String> = policy_str!("thresh(3,pk(A),pk(B),pk(C),pk(D),pk(E))");
+            let desc = policy
+                .compile_tr_native(Some(unspendable_key.clone()), 128)
+                .unwrap();
+            match &desc {
+                Descriptor::Tr(tr) => {
+                    let leaves: Vec<_> = tr.tap_tree().unwrap().leaves().collect();
+                    assert_eq!(leaves.len(), 10, "expected 10 leaves from thresh(3,5)");
+                    let mut leaf_scripts: Vec<_> =
+                        leaves.iter().map(|l| l.miniscript().to_string()).collect();
+                    leaf_scripts.sort();
+                    leaf_scripts.dedup();
+                    assert_eq!(leaf_scripts.len(), 10, "all 10 leaves should be distinct");
+                }
+                _ => panic!("expected Tr descriptor"),
+            }
         }
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -541,4 +541,116 @@ mod tests {
             assert_eq!(desc, expected_desc);
         }
     }
+
+    #[test]
+    #[cfg(feature = "compiler")]
+    fn native_taproot_compile() {
+        use super::Liftable;
+
+        let unspendable_key = "UNSPEND".to_string();
+
+        // Simple or: one key becomes internal key, other is single leaf
+        {
+            let policy: Concrete<String> = policy_str!("or(pk(A),pk(B))");
+            let desc = policy
+                .compile_tr_native(Some(unspendable_key.clone()), 128)
+                .unwrap();
+            let standard = policy.compile_tr(Some(unspendable_key.clone())).unwrap();
+            assert_eq!(desc, standard);
+        }
+
+        // And(Or(A,B), C) -> 2 leaves via cross-product; verify semantic equivalence
+        // (compile_tr_native and compile_tr should produce same semantic policy when lifted)
+        {
+            let policy: Concrete<String> = policy_str!("and(or(pk(A),pk(B)),pk(C))");
+            let desc = policy
+                .compile_tr_native(Some(unspendable_key.clone()), 128)
+                .unwrap();
+            match &desc {
+                Descriptor::Tr(tr) => {
+                    let leaves: Vec<_> = tr.tap_tree().unwrap().leaves().collect();
+                    assert_eq!(leaves.len(), 2, "expected 2 leaves from and(or(A,B),C)");
+                }
+                _ => panic!("expected Tr descriptor"),
+            }
+            let standard = policy
+                .compile_tr(Some(unspendable_key.clone()))
+                .unwrap();
+            let lifted_native = desc.lift().unwrap();
+            let lifted_standard = standard.lift().unwrap();
+            assert_eq!(
+                lifted_native.clone().entails(lifted_standard.clone()),
+                Some(true),
+                "native should entail standard"
+            );
+            assert_eq!(
+                lifted_standard.entails(lifted_native),
+                Some(true),
+                "standard should entail native"
+            );
+        }
+
+        // Or of Ands: 2 leaves (same as compile_tr); verify semantic equivalence
+        {
+            let policy: Concrete<String> = policy_str!("or(and(pk(A),pk(B)),and(pk(C),pk(D)))");
+            let desc = policy
+                .compile_tr_native(Some(unspendable_key.clone()), 128)
+                .unwrap();
+            match &desc {
+                Descriptor::Tr(tr) => {
+                    let leaves: Vec<_> = tr.tap_tree().unwrap().leaves().collect();
+                    assert_eq!(leaves.len(), 2);
+                }
+                _ => panic!("expected Tr descriptor"),
+            }
+            let standard = policy
+                .compile_tr(Some(unspendable_key.clone()))
+                .unwrap();
+            let lifted_native = desc.lift().unwrap();
+            let lifted_standard = standard.lift().unwrap();
+            assert_eq!(
+                lifted_native.clone().entails(lifted_standard.clone()),
+                Some(true),
+            );
+            assert_eq!(
+                lifted_standard.entails(lifted_native),
+                Some(true),
+            );
+        }
+
+        // max_leaves caps the enumeration
+        {
+            let policy: Concrete<String> =
+                policy_str!("thresh(2,pk(A),pk(B),pk(C),pk(D),pk(E))");
+            let result = policy.compile_tr_native(Some(unspendable_key.clone()), 1024);
+            assert!(result.is_ok());
+        }
+
+        // max_leaves=0 returns error
+        {
+            let policy: Concrete<String> = policy_str!("or(pk(A),pk(B))");
+            let result = policy.compile_tr_native(Some(unspendable_key.clone()), 0);
+            assert!(matches!(
+                result,
+                Err(super::compiler::CompilerError::TooManyTapleaves { .. })
+            ));
+        }
+
+        // max_leaves too small: returns TooManyTapleaves or IfFragmentInNativeLeaf
+        // (the latter when enumeration stops early, leaving unexpanded branches)
+        {
+            let policy: Concrete<String> =
+                policy_str!("and(or(pk(A),pk(B)),or(pk(C),pk(D)))");
+            let result = policy.compile_tr_native(Some(unspendable_key.clone()), 2);
+            assert!(
+                matches!(
+                    result,
+                    Err(super::compiler::CompilerError::TooManyTapleaves { .. })
+                        | Err(super::compiler::CompilerError::IfFragmentInNativeLeaf { .. })
+                ),
+                "expected TooManyTapleaves or IfFragmentInNativeLeaf, got: {:?}",
+                result
+            );
+        }
+    }
 }


### PR DESCRIPTION
Closes #905

Adds `compile_tr_native()` which decomposes all `Or` and `Thresh` branches into separate TapTree leaves instead of using `OP_IF`/`OP_NOTIF` within a single leaf. Each leaf is compiled to branch-free Tapscript and assembled into a Huffman-weighted TapTree.

Also refactors `enumerate_policy_tree` into a shared `enumerate_leaves` helper to avoid duplication.