### PR TITLE
refactor: remove *SortedMulti variants from DescriptorType

### DIFF
--- a/bitcoind-tests/tests/test_desc.rs
+++ b/bitcoind-tests/tests/test_desc.rs
@@ -501,10 +501,7 @@ fn test_plan_satisfy(
     let sighash_type = sighash::EcdsaSighashType::All;
     let desc_type = derived_desc.desc_type();
     let sighash_msg = match desc_type {
-        DescriptorType::Wsh
-        | DescriptorType::WshSortedMulti
-        | DescriptorType::ShWsh
-        | DescriptorType::ShWshSortedMulti => {
+        DescriptorType::Wsh | DescriptorType::ShWsh => {
             let script_code = derived_desc.script_code().expect("has script_code");
             sighash_cache
                 .p2wsh_signature_hash(0, &script_code, witness_utxo.value, sighash_type)

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -125,12 +125,6 @@ pub enum DescriptorType {
     ShWsh,
     /// Sh wrapped Wpkh
     ShWpkh,
-    /// Sh Sorted Multi
-    ShSortedMulti,
-    /// Wsh Sorted Multi
-    WshSortedMulti,
-    /// Sh Wsh Sorted Multi
-    ShWshSortedMulti,
     /// Tr Descriptor
     Tr,
 }
@@ -143,10 +137,8 @@ impl DescriptorType {
         use self::DescriptorType::*;
         match self {
             Tr => Some(WitnessVersion::V1),
-            Wpkh | ShWpkh | Wsh | ShWsh | ShWshSortedMulti | WshSortedMulti => {
-                Some(WitnessVersion::V0)
-            }
-            Bare | Sh | Pkh | ShSortedMulti => None,
+            Wpkh | ShWpkh | Wsh | ShWsh => Some(WitnessVersion::V0),
+            Bare | Sh | Pkh => None,
         }
     }
 }
@@ -300,34 +292,16 @@ impl<Pk: MiniscriptKey> Descriptor<Pk> {
     /// Get the [DescriptorType] of [Descriptor]
     pub fn desc_type(&self) -> DescriptorType {
         match *self {
-            Descriptor::Bare(ref _bare) => DescriptorType::Bare,
-            Descriptor::Pkh(ref _pkh) => DescriptorType::Pkh,
-            Descriptor::Wpkh(ref _wpkh) => DescriptorType::Wpkh,
+            Descriptor::Bare(..) => DescriptorType::Bare,
+            Descriptor::Pkh(..) => DescriptorType::Pkh,
+            Descriptor::Wpkh(..) => DescriptorType::Wpkh,
             Descriptor::Sh(ref sh) => match sh.as_inner() {
-                ShInner::Wsh(ref wsh) => {
-                    if let Terminal::SortedMulti(..) = wsh.as_inner().node {
-                        DescriptorType::ShWshSortedMulti
-                    } else {
-                        DescriptorType::ShWsh
-                    }
-                }
+                ShInner::Wsh(..) => DescriptorType::ShWsh,
                 ShInner::Wpkh(ref _wpkh) => DescriptorType::ShWpkh,
-                ShInner::Ms(ref ms) => {
-                    if let Terminal::SortedMulti(..) = ms.node {
-                        DescriptorType::ShSortedMulti
-                    } else {
-                        DescriptorType::Sh
-                    }
-                }
+                ShInner::Ms(..) => DescriptorType::Sh,
             },
-            Descriptor::Wsh(ref wsh) => {
-                if let Terminal::SortedMulti(..) = wsh.as_inner().node {
-                    DescriptorType::WshSortedMulti
-                } else {
-                    DescriptorType::Wsh
-                }
-            }
-            Descriptor::Tr(ref _tr) => DescriptorType::Tr,
+            Descriptor::Wsh(..) => DescriptorType::Wsh,
+            Descriptor::Tr(..) => DescriptorType::Tr,
         }
     }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -245,7 +245,7 @@ impl Plan {
             // scriptSig len (1) + OP_0 (1) + OP_PUSHBYTES_20 (1) + <pk hash> (20)
             (_, DescriptorType::ShWpkh) => 1 + 1 + 1 + 20,
             // scriptSig len (1) + OP_0 (1) + OP_PUSHBYTES_32 (1) + <script hash> (32)
-            (_, DescriptorType::ShWsh) | (_, DescriptorType::ShWshSortedMulti) => 1 + 1 + 1 + 32,
+            (_, DescriptorType::ShWsh) => 1 + 1 + 1 + 32,
             // Native Segwit v0 (scriptSig len (1))
             _ => 1,
         }
@@ -278,10 +278,7 @@ impl Plan {
             .ok_or(Error::CouldNotSatisfy)?;
 
         Ok(match self.descriptor.desc_type() {
-            DescriptorType::Bare
-            | DescriptorType::Sh
-            | DescriptorType::Pkh
-            | DescriptorType::ShSortedMulti => (
+            DescriptorType::Bare | DescriptorType::Sh | DescriptorType::Pkh => (
                 vec![],
                 stack
                     .into_iter()
@@ -294,10 +291,7 @@ impl Plan {
             ),
             DescriptorType::Wpkh | DescriptorType::Tr => (stack, ScriptBuf::new()),
             DescriptorType::ShWpkh => (stack, self.descriptor.unsigned_script_sig()),
-            DescriptorType::Wsh
-            | DescriptorType::WshSortedMulti
-            | DescriptorType::ShWsh
-            | DescriptorType::ShWshSortedMulti => {
+            DescriptorType::Wsh | DescriptorType::ShWsh => {
                 let mut stack = stack;
                 let witness_script = self
                     .descriptor


### PR DESCRIPTION
After 01d25c1, these variants no longer serve a purpose since descriptors
containing sortedmulti are not handled as a distinct type, but as an underlying
Miniscript.

Closes #919