### PR TITLE
refactor: make `Descriptor` plan API available for generic `Pk`

### DIFF
--- a/bitcoind-tests/tests/test_desc.rs
+++ b/bitcoind-tests/tests/test_desc.rs
@@ -475,7 +475,7 @@ fn test_plan_satisfy(
 
     let plan = definite_desc
         .clone()
-        .plan(&assets)
+        .into_plan(&assets)
         .expect("plan creation failed");
 
     let mut unsigned_tx = Transaction {

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -12,7 +12,7 @@ use core::fmt;
 use bitcoin::script::{self, PushBytes};
 use bitcoin::{Address, Network, ScriptBuf, Weight};
 
-use crate::descriptor::{write_descriptor, DefiniteDescriptorKey};
+use crate::descriptor::write_descriptor;
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::{ScriptContext, ScriptContextError};
 use crate::miniscript::satisfy::{Placeholder, Satisfaction, Witness};
@@ -138,25 +138,19 @@ impl<Pk: MiniscriptKey + ToPublicKey> Bare<Pk> {
     }
 }
 
-impl Bare<DefiniteDescriptorKey> {
+impl<Pk: MiniscriptKey + ToPublicKey> Bare<Pk> {
     /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
-    pub fn plan_satisfaction<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         self.ms.build_template(provider)
     }
 
     /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
-    pub fn plan_satisfaction_mall<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction_mall<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         self.ms.build_template_mall(provider)
     }
@@ -316,16 +310,11 @@ impl<Pk: MiniscriptKey + ToPublicKey> Pkh<Pk> {
     {
         self.get_satisfaction(satisfier)
     }
-}
 
-impl Pkh<DefiniteDescriptorKey> {
     /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
-    pub fn plan_satisfaction<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         let stack = if provider.provider_lookup_ecdsa_sig(&self.pk) {
             let stack = vec![
@@ -341,12 +330,9 @@ impl Pkh<DefiniteDescriptorKey> {
     }
 
     /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
-    pub fn plan_satisfaction_mall<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction_mall<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         self.plan_satisfaction(provider)
     }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -556,8 +556,20 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
     /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
     ///
     /// If the assets aren't sufficient for generating a Plan, the descriptor is returned
+    #[deprecated(since = "TBD", note = "use into_plan instead")]
     #[allow(clippy::result_large_err)] // our "error type" is the original descriptor
     pub fn plan<P>(self, provider: &P) -> Result<Plan<Pk>, Self>
+    where
+        P: AssetProvider<Pk>,
+    {
+        self.into_plan(provider)
+    }
+
+    /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
+    ///
+    /// If the assets aren't sufficient for generating a Plan, the descriptor is returned
+    #[allow(clippy::result_large_err)] // our "error type" is the original descriptor
+    pub fn into_plan<P>(self, provider: &P) -> Result<Plan<Pk>, Self>
     where
         P: AssetProvider<Pk>,
     {
@@ -585,8 +597,20 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
     /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
     ///
     /// If the assets aren't sufficient for generating a Plan, the descriptor is returned
+    #[deprecated(since = "TBD", note = "use into_plan_mall instead")]
     #[allow(clippy::result_large_err)] // our "error type" is the original descriptor
     pub fn plan_mall<P>(self, provider: &P) -> Result<Plan<Pk>, Self>
+    where
+        P: AssetProvider<Pk>,
+    {
+        self.into_plan_mall(provider)
+    }
+
+    /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
+    ///
+    /// If the assets aren't sufficient for generating a Plan, the descriptor is returned
+    #[allow(clippy::result_large_err)] // our "error type" is the original descriptor
+    pub fn into_plan_mall<P>(self, provider: &P) -> Result<Plan<Pk>, Self>
     where
         P: AssetProvider<Pk>,
     {

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -552,14 +552,14 @@ impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
     }
 }
 
-impl Descriptor<DefiniteDescriptorKey> {
+impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk> {
     /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
     ///
     /// If the assets aren't sufficient for generating a Plan, the descriptor is returned
     #[allow(clippy::result_large_err)] // our "error type" is the original descriptor
-    pub fn plan<P>(self, provider: &P) -> Result<Plan, Self>
+    pub fn plan<P>(self, provider: &P) -> Result<Plan<Pk>, Self>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         let satisfaction = match self {
             Descriptor::Bare(ref bare) => bare.plan_satisfaction(provider),
@@ -586,9 +586,9 @@ impl Descriptor<DefiniteDescriptorKey> {
     ///
     /// If the assets aren't sufficient for generating a Plan, the descriptor is returned
     #[allow(clippy::result_large_err)] // our "error type" is the original descriptor
-    pub fn plan_mall<P>(self, provider: &P) -> Result<Plan, Self>
+    pub fn plan_mall<P>(self, provider: &P) -> Result<Plan<Pk>, Self>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         let satisfaction = match self {
             Descriptor::Bare(ref bare) => bare.plan_satisfaction_mall(provider),

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -10,7 +10,7 @@ use core::fmt;
 
 use bitcoin::{Address, Network, ScriptBuf, Weight};
 
-use crate::descriptor::{write_descriptor, DefiniteDescriptorKey};
+use crate::descriptor::write_descriptor;
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::{ScriptContext, ScriptContextError};
 use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
@@ -159,27 +159,19 @@ impl<Pk: MiniscriptKey + ToPublicKey> Wsh<Pk> {
         let script_sig = ScriptBuf::new();
         Ok((witness, script_sig))
     }
-}
 
-impl Wsh<DefiniteDescriptorKey> {
     /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
-    pub fn plan_satisfaction<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         self.ms.build_template(provider)
     }
 
     /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
-    pub fn plan_satisfaction_mall<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction_mall<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         if let Terminal::SortedMulti(..) = self.ms.node {
             self.ms.build_template(provider)
@@ -363,16 +355,11 @@ impl<Pk: MiniscriptKey + ToPublicKey> Wpkh<Pk> {
     {
         self.get_satisfaction(satisfier)
     }
-}
 
-impl Wpkh<DefiniteDescriptorKey> {
     /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
-    pub fn plan_satisfaction<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         let stack = if provider.provider_lookup_ecdsa_sig(&self.pk) {
             let stack = vec![
@@ -388,12 +375,9 @@ impl Wpkh<DefiniteDescriptorKey> {
     }
 
     /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
-    pub fn plan_satisfaction_mall<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction_mall<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         self.plan_satisfaction(provider)
     }

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -14,7 +14,7 @@ use bitcoin::script::PushBytes;
 use bitcoin::{script, Address, Network, ScriptBuf, Weight};
 
 use super::{Wpkh, Wsh};
-use crate::descriptor::{write_descriptor, DefiniteDescriptorKey};
+use crate::descriptor::write_descriptor;
 use crate::expression::{self, FromTree};
 use crate::miniscript::context::ScriptContext;
 use crate::miniscript::limits::MAX_PUBKEYS_PER_MULTISIG;
@@ -377,16 +377,11 @@ impl<Pk: MiniscriptKey + ToPublicKey> Sh<Pk> {
             _ => self.get_satisfaction(satisfier),
         }
     }
-}
 
-impl Sh<DefiniteDescriptorKey> {
     /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
-    pub fn plan_satisfaction<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         match &self.inner {
             ShInner::Wsh(ref wsh) => wsh.plan_satisfaction(provider),
@@ -396,12 +391,9 @@ impl Sh<DefiniteDescriptorKey> {
     }
 
     /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
-    pub fn plan_satisfaction_mall<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction_mall<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         match &self.inner {
             ShInner::Wsh(ref wsh) => wsh.plan_satisfaction_mall(provider),

--- a/src/descriptor/tr/mod.rs
+++ b/src/descriptor/tr/mod.rs
@@ -7,7 +7,6 @@ use bitcoin::{opcodes, Address, Network, ScriptBuf, Weight};
 use sync::Arc;
 
 use super::checksum;
-use crate::descriptor::DefiniteDescriptorKey;
 use crate::expression::{self, FromTree};
 use crate::miniscript::satisfy::{Placeholder, Satisfaction, SchnorrSigType, Witness};
 use crate::miniscript::Miniscript;
@@ -318,27 +317,19 @@ impl<Pk: MiniscriptKey + ToPublicKey> Tr<Pk> {
             Err(Error::CouldNotSatisfy)
         }
     }
-}
 
-impl Tr<DefiniteDescriptorKey> {
     /// Returns a plan if the provided assets are sufficient to produce a non-malleable satisfaction
-    pub fn plan_satisfaction<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         best_tap_spend(self, provider, false /* allow_mall */)
     }
 
     /// Returns a plan if the provided assets are sufficient to produce a malleable satisfaction
-    pub fn plan_satisfaction_mall<P>(
-        &self,
-        provider: &P,
-    ) -> Satisfaction<Placeholder<DefiniteDescriptorKey>>
+    pub fn plan_satisfaction_mall<P>(&self, provider: &P) -> Satisfaction<Placeholder<Pk>>
     where
-        P: AssetProvider<DefiniteDescriptorKey>,
+        P: AssetProvider<Pk>,
     {
         best_tap_spend(self, provider, true /* allow_mall */)
     }

--- a/src/miniscript/satisfy/mod.rs
+++ b/src/miniscript/satisfy/mod.rs
@@ -621,7 +621,7 @@ mod tests {
         let descriptor =
             Descriptor::<crate::DefiniteDescriptorKey>::from_str(&descriptor_str).unwrap();
         // Compute plan and confirm the timelock is correct.
-        let plan = descriptor.plan(&satisfier).unwrap();
+        let plan = descriptor.into_plan(&satisfier).unwrap();
         assert_eq!(plan.absolute_timelock, Some(absolute::LockTime::from_height(144).unwrap()),);
 
         // Same descriptor as above, except that now we use a time-based timelock rather than a
@@ -642,7 +642,7 @@ mod tests {
         let descriptor =
             Descriptor::<crate::DefiniteDescriptorKey>::from_str(&descriptor_str).unwrap();
 
-        let plan = descriptor.plan(&satisfier).unwrap();
+        let plan = descriptor.into_plan(&satisfier).unwrap();
         assert_eq!(
             plan.absolute_timelock,
             Some(absolute::LockTime::from_time(1000000000).unwrap()),

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -210,20 +210,20 @@ where
 /// Calling `plan` on a Descriptor will return this structure,
 /// containing the cheapest spending path possible (considering the `Assets` given)
 #[derive(Debug, Clone)]
-pub struct Plan {
+pub struct Plan<Pk: MiniscriptKey> {
     /// This plan's witness template
-    pub(crate) template: Vec<Placeholder<DefiniteDescriptorKey>>,
+    pub(crate) template: Vec<Placeholder<Pk>>,
     /// The absolute timelock this plan uses
     pub absolute_timelock: Option<absolute::LockTime>,
     /// The relative timelock this plan uses
     pub relative_timelock: Option<relative::LockTime>,
 
-    pub(crate) descriptor: Descriptor<DefiniteDescriptorKey>,
+    pub(crate) descriptor: Descriptor<Pk>,
 }
 
-impl Plan {
+impl<Pk: MiniscriptKey + ToPublicKey> Plan<Pk> {
     /// Returns the witness template
-    pub fn witness_template(&self) -> &Vec<Placeholder<DefiniteDescriptorKey>> { &self.template }
+    pub fn witness_template(&self) -> &Vec<Placeholder<Pk>> { &self.template }
 
     /// Returns the witness version
     pub fn witness_version(&self) -> Option<WitnessVersion> {
@@ -264,7 +264,7 @@ impl Plan {
     }
 
     /// Try creating the final script_sig and witness using a [`Satisfier`]
-    pub fn satisfy<Sat: Satisfier<DefiniteDescriptorKey>>(
+    pub fn satisfy<Sat: Satisfier<Pk>>(
         &self,
         stfr: &Sat,
     ) -> Result<(Vec<Vec<u8>>, ScriptBuf), Error> {
@@ -302,7 +302,9 @@ impl Plan {
             }
         })
     }
+}
 
+impl Plan<DefiniteDescriptorKey> {
     /// Update a PSBT input with the metadata required to complete this plan
     ///
     /// This will only add the metadata for items required to complete this plan. For example, if

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -766,7 +766,7 @@ mod test {
                 assets = assets.add(hashes[hi]);
             }
 
-            let result = desc.clone().plan(&assets);
+            let result = desc.clone().into_plan(&assets);
             assert_eq!(
                 result.as_ref().ok().map(|plan| plan.satisfaction_weight()),
                 expected,
@@ -1105,7 +1105,7 @@ mod test {
         let mut psbt_input = bitcoin::psbt::Input::default();
         let assets = Assets::new().add(internal_key);
         desc.clone()
-            .plan(&assets)
+            .into_plan(&assets)
             .unwrap()
             .update_psbt_input(&mut psbt_input);
         assert!(psbt_input.tap_internal_key.is_some(), "Internal key is missing");
@@ -1116,7 +1116,7 @@ mod test {
         let mut psbt_input = bitcoin::psbt::Input::default();
         let assets = Assets::new().add(first_branch);
         desc.clone()
-            .plan(&assets)
+            .into_plan(&assets)
             .unwrap()
             .update_psbt_input(&mut psbt_input);
         assert!(psbt_input.tap_internal_key.is_none(), "Internal key is present");
@@ -1126,7 +1126,7 @@ mod test {
 
         let mut psbt_input = bitcoin::psbt::Input::default();
         let assets = Assets::new().add(second_branch);
-        desc.plan(&assets)
+        desc.into_plan(&assets)
             .unwrap()
             .update_psbt_input(&mut psbt_input);
         assert!(psbt_input.tap_internal_key.is_none(), "Internal key is present");
@@ -1149,7 +1149,7 @@ mod test {
 
         let mut psbt_input = bitcoin::psbt::Input::default();
         let assets = Assets::new().add(asset_key);
-        desc.plan(&assets)
+        desc.into_plan(&assets)
             .unwrap()
             .update_psbt_input(&mut psbt_input);
         assert!(psbt_input.witness_script.is_some(), "Witness script missing");
@@ -1202,7 +1202,7 @@ mod test {
             assets = assets.add(DescriptorPublicKey::from_str(&pk.to_string()).unwrap());
         }
 
-        let plan = desc.plan(&assets).expect("plan should succeed");
+        let plan = desc.into_plan(&assets).expect("plan should succeed");
 
         let (witness, script_sig) = plan.satisfy(&satisfier).expect("satisfy should succeed");
         assert_eq!(witness.last().unwrap(), &exp_witness_script.into_bytes());


### PR DESCRIPTION
- Migrate `plan` and `plan_mall` methods from `DefiniteDescriptorKey` to generic
`Pk: MiniscriptKey + ToPublicKey`.

- Made the `Plan` struct generic over `Pk` (excluding `update_psbt_input` since
it needs descriptor key data).

Adding this to same PR in a separate commit since it's trivial:

- Rename `plan` and `plan_mall` to have `into_` prefix

Closes #927 and #928