### PR TITLE
Followup to #895: rename `dissat_sat` function and use struct rather than tuple for return values

### DIFF
--- a/src/miniscript/satisfy/mod.rs
+++ b/src/miniscript/satisfy/mod.rs
@@ -1026,7 +1026,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         Ctx: ScriptContext,
         P: AssetProvider<Pk>,
     {
-        Self::dissat_sat(node, provider, false, root_has_sig, leaf_hash).sat
+        Self::sat_dissat(node, provider, false, root_has_sig, leaf_hash).sat
     }
 
     pub(crate) fn build_template_mall<P, Ctx>(
@@ -1039,7 +1039,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         Ctx: ScriptContext,
         P: AssetProvider<Pk>,
     {
-        Self::dissat_sat(node, provider, true, root_has_sig, leaf_hash).sat
+        Self::sat_dissat(node, provider, true, root_has_sig, leaf_hash).sat
     }
 
     // produce a non-malleable satisafaction for thesh frag

--- a/src/miniscript/satisfy/mod.rs
+++ b/src/miniscript/satisfy/mod.rs
@@ -1026,7 +1026,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         Ctx: ScriptContext,
         P: AssetProvider<Pk>,
     {
-        Self::dissat_sat(node, provider, false, root_has_sig, leaf_hash).1
+        Self::dissat_sat(node, provider, false, root_has_sig, leaf_hash).sat
     }
 
     pub(crate) fn build_template_mall<P, Ctx>(
@@ -1039,7 +1039,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         Ctx: ScriptContext,
         P: AssetProvider<Pk>,
     {
-        Self::dissat_sat(node, provider, true, root_has_sig, leaf_hash).1
+        Self::dissat_sat(node, provider, true, root_has_sig, leaf_hash).sat
     }
 
     // produce a non-malleable satisafaction for thesh frag

--- a/src/miniscript/satisfy/sat_dissat.rs
+++ b/src/miniscript/satisfy/sat_dissat.rs
@@ -15,6 +15,11 @@ use crate::{
     ToPublicKey,
 };
 
+pub(super) struct SatDissat<Pk: MiniscriptKey> {
+    dissat: Satisfaction<Placeholder<Pk>>,
+    pub sat: Satisfaction<Placeholder<Pk>>,
+}
+
 impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
     const IMPOSSIBLE: Self = Self {
         stack: Witness::Impossible,
@@ -33,38 +38,38 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
     /// Constant that can't be `const` due to Rust limitations
     fn push_0() -> Self { Self { stack: Witness::push_0(), ..Self::TRIVIAL } }
 
-    /// The (dissatisfaction, satisfaction) pair for a `pk_k` fragment.
-    fn pk_k<S, Ctx>(stfr: &S, pk: &Pk, leaf_hash: &TapLeafHash) -> (Self, Self)
+    /// The satisfaction and dissatisfaction for a `pk_k` fragment.
+    fn pk_k<S, Ctx>(stfr: &S, pk: &Pk, leaf_hash: &TapLeafHash) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
         Ctx: ScriptContext,
     {
-        (
-            Self::push_0(),
-            Self {
+        SatDissat {
+            dissat: Self::push_0(),
+            sat: Self {
                 stack: Witness::signature::<_, Ctx>(stfr, pk, leaf_hash),
                 has_sig: true,
                 ..Self::TRIVIAL
             },
-        )
+        }
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `pk_h` fragment.
-    fn pk_h<S, Ctx>(stfr: &S, pk: &Pk, leaf_hash: &TapLeafHash) -> (Self, Self)
+    fn pk_h<S, Ctx>(stfr: &S, pk: &Pk, leaf_hash: &TapLeafHash) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
         Ctx: ScriptContext,
     {
         let wit = Witness::signature::<_, Ctx>(stfr, pk, leaf_hash);
-        (
-            Self {
+        SatDissat {
+            dissat: Self {
                 stack: Witness::combine(
                     Witness::push_0(),
                     Witness::Stack(vec![Placeholder::Pubkey(pk.clone(), Ctx::pk_len(pk))]),
                 ),
                 ..Self::TRIVIAL
             },
-            Self {
+            sat: Self {
                 stack: Witness::combine(
                     wit,
                     Witness::Stack(vec![Placeholder::Pubkey(pk.clone(), Ctx::pk_len(pk))]),
@@ -72,29 +77,29 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                 has_sig: true,
                 ..Self::TRIVIAL
             },
-        )
+        }
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `pk_h` fragment.
-    fn raw_pk_h<S, Ctx>(stfr: &S, pkh: &hash160::Hash, leaf_hash: &TapLeafHash) -> (Self, Self)
+    fn raw_pk_h<S, Ctx>(stfr: &S, pkh: &hash160::Hash, leaf_hash: &TapLeafHash) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
         Ctx: ScriptContext,
     {
-        (
-            Self {
+        SatDissat {
+            dissat: Self {
                 stack: Witness::combine(
                     Witness::push_0(),
                     Witness::pkh_public_key::<_, Ctx>(stfr, pkh),
                 ),
                 ..Self::TRIVIAL
             },
-            Self {
+            sat: Self {
                 stack: Witness::pkh_signature::<_, Ctx>(stfr, pkh, leaf_hash),
                 has_sig: true,
                 ..Self::TRIVIAL
             },
-        )
+        }
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `multi` fragment.
@@ -102,7 +107,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         stfr: &S,
         thresh: &Threshold<Pk, MAX_PUBKEYS_PER_MULTISIG>,
         leaf_hash: &TapLeafHash,
-    ) -> (Self, Self)
+    ) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
         Ctx: ScriptContext,
@@ -129,7 +134,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         }
 
         if sig_count < thresh.k() {
-            (dissat, Self::IMPOSSIBLE)
+            SatDissat { dissat, sat: Self::IMPOSSIBLE }
         } else {
             // Throw away the most expensive ones
             for _ in 0..sig_count - thresh.k() {
@@ -142,16 +147,16 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                 sigs[max_idx] = vec![];
             }
 
-            (
+            SatDissat {
                 dissat,
-                Self {
+                sat: Self {
                     stack: sigs.into_iter().fold(Witness::push_0(), |acc, sig| {
                         Witness::combine(acc, Witness::Stack(sig))
                     }),
                     has_sig: true,
                     ..Self::TRIVIAL
                 },
-            )
+            }
         }
     }
 
@@ -160,7 +165,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         stfr: &S,
         thresh: &Threshold<Pk, MAX_PUBKEYS_IN_CHECKSIGADD>,
         leaf_hash: &TapLeafHash,
-    ) -> (Self, Self)
+    ) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
         Ctx: ScriptContext,
@@ -194,23 +199,23 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         }
 
         if sig_count < thresh.k() {
-            (dissat, Self::IMPOSSIBLE)
+            SatDissat { dissat, sat: Self::IMPOSSIBLE }
         } else {
-            (
+            SatDissat {
                 dissat,
-                Self {
+                sat: Self {
                     stack: sigs.into_iter().fold(Witness::empty(), |acc, sig| {
                         Witness::combine(acc, Witness::Stack(sig))
                     }),
                     has_sig: true,
                     ..Self::TRIVIAL
                 },
-            )
+            }
         }
     }
 
     /// The (dissatisfaction, satisfaction) pair for an `after` fragment.
-    fn after<S>(stfr: &S, t: AbsLockTime, root_has_sig: bool) -> (Self, Self)
+    fn after<S>(stfr: &S, t: AbsLockTime, root_has_sig: bool) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
     {
@@ -226,14 +231,14 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         } else {
             (Witness::Unavailable, None)
         };
-        (
-            Self::IMPOSSIBLE,
-            Self { stack, has_sig: false, relative_timelock: None, absolute_timelock },
-        )
+        SatDissat {
+            dissat: Self::IMPOSSIBLE,
+            sat: Self { stack, has_sig: false, relative_timelock: None, absolute_timelock },
+        }
     }
 
     /// The (dissatisfaction, satisfaction) pair for an `older` fragment.
-    fn older<S>(stfr: &S, t: RelLockTime, root_has_sig: bool) -> (Self, Self)
+    fn older<S>(stfr: &S, t: RelLockTime, root_has_sig: bool) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
     {
@@ -249,54 +254,54 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         } else {
             (Witness::Unavailable, None)
         };
-        (
-            Self::IMPOSSIBLE,
-            Self { stack, has_sig: false, relative_timelock, absolute_timelock: None },
-        )
+        SatDissat {
+            dissat: Self::IMPOSSIBLE,
+            sat: Self { stack, has_sig: false, relative_timelock, absolute_timelock: None },
+        }
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `ripemd160` fragment.
-    fn ripemd160<S>(stfr: &S, h: &Pk::Ripemd160) -> (Self, Self)
+    fn ripemd160<S>(stfr: &S, h: &Pk::Ripemd160) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
     {
-        (
-            Self { stack: Witness::hash_dissatisfaction(), ..Self::TRIVIAL },
-            Self { stack: Witness::ripemd160_preimage(stfr, h), ..Self::TRIVIAL },
-        )
+        SatDissat {
+            dissat: Self { stack: Witness::hash_dissatisfaction(), ..Self::TRIVIAL },
+            sat: Self { stack: Witness::ripemd160_preimage(stfr, h), ..Self::TRIVIAL },
+        }
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `hash160` fragment.
-    fn hash160<S>(stfr: &S, h: &Pk::Hash160) -> (Self, Self)
+    fn hash160<S>(stfr: &S, h: &Pk::Hash160) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
     {
-        (
-            Self { stack: Witness::hash_dissatisfaction(), ..Self::TRIVIAL },
-            Self { stack: Witness::hash160_preimage(stfr, h), ..Self::TRIVIAL },
-        )
+        SatDissat {
+            dissat: Self { stack: Witness::hash_dissatisfaction(), ..Self::TRIVIAL },
+            sat: Self { stack: Witness::hash160_preimage(stfr, h), ..Self::TRIVIAL },
+        }
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `sha256` fragment.
-    fn sha256<S>(stfr: &S, h: &Pk::Sha256) -> (Self, Self)
+    fn sha256<S>(stfr: &S, h: &Pk::Sha256) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
     {
-        (
-            Self { stack: Witness::hash_dissatisfaction(), ..Self::TRIVIAL },
-            Self { stack: Witness::sha256_preimage(stfr, h), ..Self::TRIVIAL },
-        )
+        SatDissat {
+            dissat: Self { stack: Witness::hash_dissatisfaction(), ..Self::TRIVIAL },
+            sat: Self { stack: Witness::sha256_preimage(stfr, h), ..Self::TRIVIAL },
+        }
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `hash256` fragment.
-    fn hash256<S>(stfr: &S, h: &Pk::Hash256) -> (Self, Self)
+    fn hash256<S>(stfr: &S, h: &Pk::Hash256) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
     {
-        (
-            Self { stack: Witness::hash_dissatisfaction(), ..Self::TRIVIAL },
-            Self { stack: Witness::hash256_preimage(stfr, h), ..Self::TRIVIAL },
-        )
+        SatDissat {
+            dissat: Self { stack: Witness::hash_dissatisfaction(), ..Self::TRIVIAL },
+            sat: Self { stack: Witness::hash256_preimage(stfr, h), ..Self::TRIVIAL },
+        }
     }
 
     /// Compute the dissatisfaction and the satisfaction for the given node, by querying
@@ -311,7 +316,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         malleable: bool,
         root_has_sig: bool,
         leaf_hash: &TapLeafHash,
-    ) -> (Self, Self)
+    ) -> SatDissat<Pk>
     where
         Ctx: ScriptContext,
         Sat: AssetProvider<Pk>,
@@ -332,8 +337,8 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         let mut stack = Vec::with_capacity(128);
         for item in node.post_order_iter() {
             let new_dissat_sat = match *item.node.as_inner() {
-                Terminal::False => (Self::TRIVIAL, Self::IMPOSSIBLE),
-                Terminal::True => (Self::IMPOSSIBLE, Self::TRIVIAL),
+                Terminal::False => SatDissat { dissat: Self::TRIVIAL, sat: Self::IMPOSSIBLE },
+                Terminal::True => SatDissat { dissat: Self::IMPOSSIBLE, sat: Self::TRIVIAL },
                 Terminal::PkK(ref pk) => Self::pk_k::<_, Ctx>(stfr, pk, leaf_hash),
                 Terminal::PkH(ref pk) => Self::pk_h::<_, Ctx>(stfr, pk, leaf_hash),
                 Terminal::RawPkH(ref pkh) => Self::raw_pk_h::<_, Ctx>(stfr, pkh, leaf_hash),
@@ -359,75 +364,84 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                 | Terminal::Check(_)
                 | Terminal::ZeroNotEqual(_) => stack.pop().unwrap(),
                 Terminal::DupIf(_) => {
-                    let (_, sub) = stack.pop().unwrap();
-                    (
-                        Self::push_0(),
-                        Self { stack: Witness::combine(sub.stack, Witness::push_1()), ..sub },
-                    )
+                    let SatDissat { sat: sub, .. } = stack.pop().unwrap();
+                    SatDissat {
+                        dissat: Self::push_0(),
+                        sat: Self { stack: Witness::combine(sub.stack, Witness::push_1()), ..sub },
+                    }
                 }
                 Terminal::Verify(_) => {
-                    let (_, sub) = stack.pop().unwrap();
-                    (Self::IMPOSSIBLE, sub)
+                    let SatDissat { sat: sub, .. } = stack.pop().unwrap();
+                    SatDissat { dissat: Self::IMPOSSIBLE, sat: sub }
                 }
                 Terminal::NonZero(_) => {
-                    let (_, sub) = stack.pop().unwrap();
-                    (Self::IMPOSSIBLE, sub)
+                    let SatDissat { sat: sub, .. } = stack.pop().unwrap();
+                    SatDissat { dissat: Self::IMPOSSIBLE, sat: sub }
                 }
                 Terminal::AndB(_, _) => {
-                    let (r_dis, r_sat) = stack.pop().unwrap();
-                    let (l_dis, l_sat) = stack.pop().unwrap();
-                    (l_dis.concatenate_rev(r_dis), l_sat.concatenate_rev(r_sat))
+                    let SatDissat { dissat: r_dis, sat: r_sat } = stack.pop().unwrap();
+                    let SatDissat { dissat: l_dis, sat: l_sat } = stack.pop().unwrap();
+                    SatDissat {
+                        dissat: l_dis.concatenate_rev(r_dis),
+                        sat: l_sat.concatenate_rev(r_sat),
+                    }
                 }
                 Terminal::AndV(_, _) => {
-                    let (r_dis, r_sat) = stack.pop().unwrap();
-                    let (_, l_sat) = stack.pop().unwrap();
+                    let SatDissat { dissat: r_dis, sat: r_sat } = stack.pop().unwrap();
+                    let SatDissat { sat: l_sat, .. } = stack.pop().unwrap();
                     // Left child is a `v` and must be satisfied for both sat and dissat.
-                    (l_sat.clone().concatenate_rev(r_dis), l_sat.concatenate_rev(r_sat))
+                    SatDissat {
+                        dissat: l_sat.clone().concatenate_rev(r_dis),
+                        sat: l_sat.concatenate_rev(r_sat),
+                    }
                 }
                 Terminal::AndOr(_, _, _) => {
-                    let (c_dis, c_sat) = stack.pop().unwrap();
-                    let (_, b_sat) = stack.pop().unwrap();
-                    let (a_dis, a_sat) = stack.pop().unwrap();
+                    let SatDissat { dissat: c_dis, sat: c_sat } = stack.pop().unwrap();
+                    let SatDissat { sat: b_sat, .. } = stack.pop().unwrap();
+                    let SatDissat { dissat: a_dis, sat: a_sat } = stack.pop().unwrap();
 
-                    (
-                        a_dis.clone().concatenate_rev(c_dis),
-                        min_fn(a_sat.concatenate_rev(b_sat), a_dis.concatenate_rev(c_sat)),
-                    )
+                    SatDissat {
+                        dissat: a_dis.clone().concatenate_rev(c_dis),
+                        sat: min_fn(a_sat.concatenate_rev(b_sat), a_dis.concatenate_rev(c_sat)),
+                    }
                 }
                 Terminal::OrB(_, _) => {
-                    let (r_dis, r_sat) = stack.pop().unwrap();
-                    let (l_dis, l_sat) = stack.pop().unwrap();
+                    let SatDissat { dissat: r_dis, sat: r_sat } = stack.pop().unwrap();
+                    let SatDissat { dissat: l_dis, sat: l_sat } = stack.pop().unwrap();
                     assert!(!l_dis.has_sig);
                     assert!(!r_dis.has_sig);
 
-                    (
-                        l_dis.clone().concatenate_rev(r_dis.clone()),
-                        min_fn(
+                    SatDissat {
+                        dissat: l_dis.clone().concatenate_rev(r_dis.clone()),
+                        sat: min_fn(
                             Self::concatenate_rev(l_dis, r_sat),
                             Self::concatenate_rev(l_sat, r_dis),
                         ),
-                    )
+                    }
                 }
                 Terminal::OrC(_, _) => {
-                    let (_, r_sat) = stack.pop().unwrap();
-                    let (l_dis, l_sat) = stack.pop().unwrap();
+                    let SatDissat { sat: r_sat, .. } = stack.pop().unwrap();
+                    let SatDissat { dissat: l_dis, sat: l_sat } = stack.pop().unwrap();
                     assert!(!l_dis.has_sig);
 
-                    (Self::IMPOSSIBLE, min_fn(l_sat, Self::concatenate_rev(l_dis, r_sat)))
+                    SatDissat {
+                        dissat: Self::IMPOSSIBLE,
+                        sat: min_fn(l_sat, Self::concatenate_rev(l_dis, r_sat)),
+                    }
                 }
                 Terminal::OrD(_, _) => {
-                    let (r_dis, r_sat) = stack.pop().unwrap();
-                    let (l_dis, l_sat) = stack.pop().unwrap();
+                    let SatDissat { dissat: r_dis, sat: r_sat } = stack.pop().unwrap();
+                    let SatDissat { dissat: l_dis, sat: l_sat } = stack.pop().unwrap();
                     assert!(!l_dis.has_sig);
 
-                    (
-                        l_dis.clone().concatenate_rev(r_dis),
-                        min_fn(l_sat, Self::concatenate_rev(l_dis, r_sat)),
-                    )
+                    SatDissat {
+                        dissat: l_dis.clone().concatenate_rev(r_dis),
+                        sat: min_fn(l_sat, Self::concatenate_rev(l_dis, r_sat)),
+                    }
                 }
                 Terminal::OrI(_, _) => {
-                    let (r_dis, r_sat) = stack.pop().unwrap();
-                    let (l_dis, l_sat) = stack.pop().unwrap();
+                    let SatDissat { dissat: r_dis, sat: r_sat } = stack.pop().unwrap();
+                    let SatDissat { dissat: l_dis, sat: l_sat } = stack.pop().unwrap();
                     // Regarding use of `minimum_mall` for dissatisfactions: this is correct, because
                     // dissatisfactions for individual fragments are not required to be unique. (We
                     // track this property using the `ty.malleability.dissat` field.)
@@ -438,8 +452,8 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                     // the `or_c` or `or_b` fragments which use dissatisfactions as part of their
                     // satisfactions, we set `ty.malleability.non_malleable` appropriately (and
                     // potentially reject the whole script at creation time).
-                    (
-                        Self::minimum_mall(
+                    SatDissat {
+                        dissat: Self::minimum_mall(
                             Self {
                                 stack: Witness::combine(l_dis.stack, Witness::push_1()),
                                 ..l_dis
@@ -449,7 +463,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                                 ..r_dis
                             },
                         ),
-                        min_fn(
+                        sat: min_fn(
                             Self {
                                 stack: Witness::combine(l_sat.stack, Witness::push_1()),
                                 ..l_sat
@@ -459,11 +473,17 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                                 ..r_sat
                             },
                         ),
-                    )
+                    }
                 }
                 Terminal::Thresh(ref thresh) => {
-                    let (dissats, sats): (Vec<_>, Vec<_>) =
-                        stack.drain(stack.len() - thresh.n()..).unzip();
+                    // The `thresh_fn`s mix satisfaction and dissatisfactions in a way that
+                    // basically require us to unzip the SatDissat struct into two separate
+                    // vectors, so for this section we need to be a bit careful about the
+                    // order of our tuple.
+                    let (dissats, sats): (Vec<_>, Vec<_>) = stack
+                        .drain(stack.len() - thresh.n()..)
+                        .map(|SatDissat { dissat, sat }| (dissat, sat))
+                        .unzip();
 
                     // Dissatisfaction of a threshold is just the dissatisfaction of its children.
                     let dissat = dissats
@@ -479,7 +499,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                         thresh_fn(thresh.k(), thresh.n(), dissats, sats)
                     };
 
-                    (dissat, sat)
+                    SatDissat { dissat, sat }
                 }
             };
 

--- a/src/miniscript/satisfy/sat_dissat.rs
+++ b/src/miniscript/satisfy/sat_dissat.rs
@@ -310,7 +310,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
     /// If the `malleable` flag is set to true, more efficient satisfactions may be found,
     /// but which a 3rd party may be able to replace with less efficient versions. (This
     /// flag does not affect dissatisfactions.)
-    pub(super) fn dissat_sat<Ctx, Sat>(
+    pub(super) fn sat_dissat<Ctx, Sat>(
         node: &Miniscript<Pk, Ctx>,
         stfr: &Sat,
         malleable: bool,


### PR DESCRIPTION
Makes naming more consistent and reduces confusion caused by having a tuple with two entries of the same type.