### PR TITLE
miniscript: change `tap_leaf_internal` to return an `Option` in the satisfier

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1222,7 +1222,7 @@ mod tests {
 
         let mut checksum_eng = checksum::Engine::new();
         checksum_eng.input(&normalize_aliases).unwrap();
-        assert_eq!(format!("{}#{}", &normalize_aliases, checksum_eng.checksum()), output);
+        assert_eq!(format!("{}#{}", normalize_aliases, checksum_eng.checksum()), output);
     }
 
     #[test]

--- a/src/miniscript/context.rs
+++ b/src/miniscript/context.rs
@@ -167,7 +167,7 @@ impl fmt::Display for ScriptContextError {
 /// context under which the script is used.
 /// For example, disallowing uncompressed keys in Segwit context
 pub trait ScriptContext:
-    fmt::Debug + Clone + Ord + PartialOrd + Eq + PartialEq + hash::Hash + private::Sealed
+    fmt::Debug + Clone + Ord + PartialOrd + Eq + PartialEq + hash::Hash + private::Sealed + 'static
 where
     Self::Key: MiniscriptKey<Sha256 = sha256::Hash>,
     Self::Key: MiniscriptKey<Hash256 = hash256::Hash>,

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -448,12 +448,29 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         Ctx::max_satisfaction_size(self).ok_or(Error::ImpossibleSatisfaction)
     }
 
+    #[allow(unsafe_code)]
+    fn downcast<NarrowedCtx: ScriptContext>(&self) -> Option<&Miniscript<Pk, NarrowedCtx>> {
+        use core::any::TypeId;
+        if TypeId::of::<Ctx>() == TypeId::of::<NarrowedCtx>() {
+            // SAFETY: this pointer cast is a no-op, as guaranteed by the if guard
+            // In Rust 1.76 we can use core::ptr::from_ref in place of this cast.
+            Some(unsafe { &*(self as *const Self).cast() }) // cast needed til Rust 1.76
+        } else {
+            None
+        }
+    }
+
     /// Helper function to produce Taproot leaf hashes
     fn leaf_hash_internal(&self) -> TapLeafHash
     where
         Pk: ToPublicKey,
     {
-        TapLeafHash::from_script(&self.encode(), LeafVersion::TapScript)
+        if let Some(tapms) = self.downcast::<Tap>() {
+            tapms.leaf_hash()
+        } else {
+            use bitcoin::hashes::Hash as _;
+            TapLeafHash::from_byte_array([0; 32])
+        }
     }
 
     /// Attempt to produce non-malleable satisfying witness for the
@@ -535,11 +552,13 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     }
 }
 
-impl Miniscript<<Tap as ScriptContext>::Key, Tap> {
+impl<Pk: ToPublicKey> Miniscript<Pk, Tap> {
     /// Returns the leaf hash used within a Taproot signature for this script.
     ///
     /// Note that this method is only implemented for Taproot Miniscripts.
-    pub fn leaf_hash(&self) -> TapLeafHash { self.leaf_hash_internal() }
+    pub fn leaf_hash(&self) -> TapLeafHash {
+        TapLeafHash::from_script(&self.encode(), LeafVersion::TapScript)
+    }
 }
 
 impl<Ctx: ScriptContext> Miniscript<Ctx::Key, Ctx> {

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -461,16 +461,11 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     }
 
     /// Helper function to produce Taproot leaf hashes
-    fn leaf_hash_internal(&self) -> TapLeafHash
+    fn leaf_hash_internal(&self) -> Option<TapLeafHash>
     where
         Pk: ToPublicKey,
     {
-        if let Some(tapms) = self.downcast::<Tap>() {
-            tapms.leaf_hash()
-        } else {
-            use bitcoin::hashes::Hash as _;
-            TapLeafHash::from_byte_array([0; 32])
-        }
+        self.downcast::<Tap>().map(Miniscript::<Pk, Tap>::leaf_hash)
     }
 
     /// Attempt to produce non-malleable satisfying witness for the
@@ -484,7 +479,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
             self,
             &satisfier,
             self.ty.mall.safe,
-            &self.leaf_hash_internal(),
+            self.leaf_hash_internal(),
         );
         self._satisfy(satisfaction)
     }
@@ -502,7 +497,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
             self,
             &satisfier,
             self.ty.mall.safe,
-            &self.leaf_hash_internal(),
+            self.leaf_hash_internal(),
         );
         self._satisfy(satisfaction)
     }
@@ -531,7 +526,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
             self,
             provider,
             self.ty.mall.safe,
-            &self.leaf_hash_internal(),
+            self.leaf_hash_internal(),
         )
     }
 
@@ -547,7 +542,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
             self,
             provider,
             self.ty.mall.safe,
-            &self.leaf_hash_internal(),
+            self.leaf_hash_internal(),
         )
     }
 }

--- a/src/miniscript/satisfy/mod.rs
+++ b/src/miniscript/satisfy/mod.rs
@@ -833,30 +833,23 @@ impl<Pk: MiniscriptKey> Ord for Witness<Placeholder<Pk>> {
 
 impl<Pk: MiniscriptKey + ToPublicKey> Witness<Placeholder<Pk>> {
     /// Turn a signature into (part of) a satisfaction
-    fn signature<S: AssetProvider<Pk>, Ctx: ScriptContext>(
-        sat: &S,
-        pk: &Pk,
-        leaf_hash: &TapLeafHash,
-    ) -> Self {
-        match Ctx::sig_type() {
-            super::context::SigType::Ecdsa => {
-                if sat.provider_lookup_ecdsa_sig(pk) {
-                    Witness::Stack(vec![Placeholder::EcdsaSigPk(pk.clone())])
-                } else {
-                    // Signatures cannot be forged
-                    Witness::Impossible
-                }
+    fn signature<S: AssetProvider<Pk>>(sat: &S, pk: &Pk, leaf_hash: Option<TapLeafHash>) -> Self {
+        if let Some(leaf_hash) = leaf_hash {
+            match sat.provider_lookup_tap_leaf_script_sig(pk, &leaf_hash) {
+                Some(size) => Witness::Stack(vec![Placeholder::SchnorrSigPk(
+                    pk.clone(),
+                    SchnorrSigType::ScriptSpend { leaf_hash },
+                    size,
+                )]),
+                // Signatures cannot be forged
+                None => Witness::Impossible,
             }
-            super::context::SigType::Schnorr => {
-                match sat.provider_lookup_tap_leaf_script_sig(pk, leaf_hash) {
-                    Some(size) => Witness::Stack(vec![Placeholder::SchnorrSigPk(
-                        pk.clone(),
-                        SchnorrSigType::ScriptSpend { leaf_hash: *leaf_hash },
-                        size,
-                    )]),
-                    // Signatures cannot be forged
-                    None => Witness::Impossible,
-                }
+        } else {
+            if sat.provider_lookup_ecdsa_sig(pk) {
+                Witness::Stack(vec![Placeholder::EcdsaSigPk(pk.clone())])
+            } else {
+                // Signatures cannot be forged
+                Witness::Impossible
             }
         }
     }
@@ -884,24 +877,23 @@ impl<Pk: MiniscriptKey + ToPublicKey> Witness<Placeholder<Pk>> {
     fn pkh_signature<S: AssetProvider<Pk>, Ctx: ScriptContext>(
         sat: &S,
         pkh: &hash160::Hash,
-        leaf_hash: &TapLeafHash,
+        leaf_hash: Option<TapLeafHash>,
     ) -> Self {
-        match Ctx::sig_type() {
-            SigType::Ecdsa => match sat.provider_lookup_raw_pkh_ecdsa_sig(pkh) {
+        if let Some(leaf_hash) = leaf_hash {
+            match sat.provider_lookup_raw_pkh_tap_leaf_script_sig(&(*pkh, leaf_hash)) {
+                Some((pk, size)) => Witness::Stack(vec![
+                    Placeholder::SchnorrSigPkHash(*pkh, leaf_hash, size),
+                    Placeholder::PubkeyHash(*pkh, Ctx::pk_len(&pk)),
+                ]),
+                None => Witness::Impossible,
+            }
+        } else {
+            match sat.provider_lookup_raw_pkh_ecdsa_sig(pkh) {
                 Some(pk) => Witness::Stack(vec![
                     Placeholder::EcdsaSigPkHash(*pkh),
                     Placeholder::PubkeyHash(*pkh, Ctx::pk_len(&pk)),
                 ]),
                 None => Witness::Impossible,
-            },
-            SigType::Schnorr => {
-                match sat.provider_lookup_raw_pkh_tap_leaf_script_sig(&(*pkh, *leaf_hash)) {
-                    Some((pk, size)) => Witness::Stack(vec![
-                        Placeholder::SchnorrSigPkHash(*pkh, *leaf_hash, size),
-                        Placeholder::PubkeyHash(*pkh, Ctx::pk_len(&pk)),
-                    ]),
-                    None => Witness::Impossible,
-                }
             }
         }
     }
@@ -1020,7 +1012,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         node: &Miniscript<Pk, Ctx>,
         provider: &P,
         root_has_sig: bool,
-        leaf_hash: &TapLeafHash,
+        leaf_hash: Option<TapLeafHash>,
     ) -> Self
     where
         Ctx: ScriptContext,
@@ -1033,7 +1025,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         node: &Miniscript<Pk, Ctx>,
         provider: &P,
         root_has_sig: bool,
-        leaf_hash: &TapLeafHash,
+        leaf_hash: Option<TapLeafHash>,
     ) -> Self
     where
         Ctx: ScriptContext,
@@ -1256,7 +1248,7 @@ impl Satisfaction<Vec<u8>> {
         node: &Miniscript<Pk, Ctx>,
         stfr: &Sat,
         root_has_sig: bool,
-        leaf_hash: &TapLeafHash,
+        leaf_hash: Option<TapLeafHash>,
     ) -> Self
     where
         Ctx: ScriptContext,
@@ -1273,7 +1265,7 @@ impl Satisfaction<Vec<u8>> {
         node: &Miniscript<Pk, Ctx>,
         stfr: &Sat,
         root_has_sig: bool,
-        leaf_hash: &TapLeafHash,
+        leaf_hash: Option<TapLeafHash>,
     ) -> Self
     where
         Ctx: ScriptContext,

--- a/src/miniscript/satisfy/sat_dissat.rs
+++ b/src/miniscript/satisfy/sat_dissat.rs
@@ -39,15 +39,14 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
     fn push_0() -> Self { Self { stack: Witness::push_0(), ..Self::TRIVIAL } }
 
     /// The satisfaction and dissatisfaction for a `pk_k` fragment.
-    fn pk_k<S, Ctx>(stfr: &S, pk: &Pk, leaf_hash: &TapLeafHash) -> SatDissat<Pk>
+    fn pk_k<S>(stfr: &S, pk: &Pk, leaf_hash: Option<TapLeafHash>) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
-        Ctx: ScriptContext,
     {
         SatDissat {
             dissat: Self::push_0(),
             sat: Self {
-                stack: Witness::signature::<_, Ctx>(stfr, pk, leaf_hash),
+                stack: Witness::signature(stfr, pk, leaf_hash),
                 has_sig: true,
                 ..Self::TRIVIAL
             },
@@ -55,12 +54,12 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `pk_h` fragment.
-    fn pk_h<S, Ctx>(stfr: &S, pk: &Pk, leaf_hash: &TapLeafHash) -> SatDissat<Pk>
+    fn pk_h<S, Ctx>(stfr: &S, pk: &Pk, leaf_hash: Option<TapLeafHash>) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
         Ctx: ScriptContext,
     {
-        let wit = Witness::signature::<_, Ctx>(stfr, pk, leaf_hash);
+        let wit = Witness::signature(stfr, pk, leaf_hash);
         SatDissat {
             dissat: Self {
                 stack: Witness::combine(
@@ -81,7 +80,11 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `pk_h` fragment.
-    fn raw_pk_h<S, Ctx>(stfr: &S, pkh: &hash160::Hash, leaf_hash: &TapLeafHash) -> SatDissat<Pk>
+    fn raw_pk_h<S, Ctx>(
+        stfr: &S,
+        pkh: &hash160::Hash,
+        leaf_hash: Option<TapLeafHash>,
+    ) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
         Ctx: ScriptContext,
@@ -103,14 +106,9 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `multi` fragment.
-    fn multi<S, Ctx>(
-        stfr: &S,
-        thresh: &Threshold<Pk, MAX_PUBKEYS_PER_MULTISIG>,
-        leaf_hash: &TapLeafHash,
-    ) -> SatDissat<Pk>
+    fn multi<S>(stfr: &S, thresh: &Threshold<Pk, MAX_PUBKEYS_PER_MULTISIG>) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
-        Ctx: ScriptContext,
     {
         let dissat = Self {
             stack: Witness::Stack(vec![Placeholder::PushZero; thresh.k() + 1]),
@@ -121,7 +119,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         let mut sig_count = 0;
         let mut sigs = Vec::with_capacity(thresh.k());
         for pk in thresh.data() {
-            match Witness::signature::<_, Ctx>(stfr, pk, leaf_hash) {
+            match Witness::signature(stfr, pk, None) {
                 Witness::Stack(sig) => {
                     sigs.push(sig);
                     sig_count += 1;
@@ -161,14 +159,13 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
     }
 
     /// The (dissatisfaction, satisfaction) pair for a `multi_a` fragment.
-    fn multi_a<S, Ctx>(
+    fn multi_a<S>(
         stfr: &S,
         thresh: &Threshold<Pk, MAX_PUBKEYS_IN_CHECKSIGADD>,
-        leaf_hash: &TapLeafHash,
+        leaf_hash: TapLeafHash,
     ) -> SatDissat<Pk>
     where
         S: AssetProvider<Pk>,
-        Ctx: ScriptContext,
     {
         let dissat = Self {
             stack: Witness::Stack(vec![Placeholder::PushZero; thresh.n()]),
@@ -179,7 +176,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         let mut sig_count = 0;
         let mut sigs = vec![vec![Placeholder::PushZero]; thresh.n()];
         for (i, pk) in thresh.iter().rev().enumerate() {
-            match Witness::signature::<_, Ctx>(stfr, pk, leaf_hash) {
+            match Witness::signature(stfr, pk, Some(leaf_hash)) {
                 Witness::Stack(sig) => {
                     sigs[i] = sig;
                     sig_count += 1;
@@ -315,7 +312,7 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
         stfr: &Sat,
         malleable: bool,
         root_has_sig: bool,
-        leaf_hash: &TapLeafHash,
+        leaf_hash: Option<TapLeafHash>,
     ) -> SatDissat<Pk>
     where
         Ctx: ScriptContext,
@@ -339,18 +336,18 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
             let new_dissat_sat = match *item.node.as_inner() {
                 Terminal::False => SatDissat { dissat: Self::TRIVIAL, sat: Self::IMPOSSIBLE },
                 Terminal::True => SatDissat { dissat: Self::IMPOSSIBLE, sat: Self::TRIVIAL },
-                Terminal::PkK(ref pk) => Self::pk_k::<_, Ctx>(stfr, pk, leaf_hash),
+                Terminal::PkK(ref pk) => Self::pk_k(stfr, pk, leaf_hash),
                 Terminal::PkH(ref pk) => Self::pk_h::<_, Ctx>(stfr, pk, leaf_hash),
                 Terminal::RawPkH(ref pkh) => Self::raw_pk_h::<_, Ctx>(stfr, pkh, leaf_hash),
-                Terminal::Multi(ref thresh) => Self::multi::<_, Ctx>(stfr, thresh, leaf_hash),
+                Terminal::Multi(ref thresh) => Self::multi(stfr, thresh),
                 Terminal::SortedMulti(ref thresh) => {
                     let thresh = thresh.clone().into_sorted_bip67();
-                    Self::multi::<_, Ctx>(stfr, &thresh, leaf_hash)
+                    Self::multi(stfr, &thresh)
                 }
-                Terminal::MultiA(ref thresh) => Self::multi_a::<_, Ctx>(stfr, thresh, leaf_hash),
+                Terminal::MultiA(ref thresh) => Self::multi_a(stfr, thresh, leaf_hash.expect("leaf_hash is present when Ctx = Tap, which must be true if multi_a is present")),
                 Terminal::SortedMultiA(ref thresh) => {
                     let thresh = thresh.clone().into_sorted_bip67_xonly();
-                    Self::multi_a::<_, Ctx>(stfr, &thresh, leaf_hash)
+                    Self::multi_a(stfr, &thresh, leaf_hash.expect("leaf_hash is present when Ctx = Tap, which must be true if multi_a is present"))
                 }
                 Terminal::After(t) => Self::after(stfr, t, root_has_sig),
                 Terminal::Older(t) => Self::older(stfr, t, root_has_sig),
@@ -367,7 +364,10 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfaction<Placeholder<Pk>> {
                     let SatDissat { sat: sub, .. } = stack.pop().unwrap();
                     SatDissat {
                         dissat: Self::push_0(),
-                        sat: Self { stack: Witness::combine(sub.stack, Witness::push_1()), ..sub },
+                        sat: Self {
+                            stack: Witness::combine(sub.stack, Witness::push_1()),
+                            ..sub
+                        },
                     }
                 }
                 Terminal::Verify(_) => {

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1453,7 +1453,7 @@ mod tests {
         .unwrap();
         let first_leaf_hash = {
             let ms =
-                Miniscript::<XOnlyPublicKey, Tap>::from_str(&format!("pkh({})", &key_0_1)).unwrap();
+                Miniscript::<XOnlyPublicKey, Tap>::from_str(&format!("pkh({})", key_0_1)).unwrap();
             let first_script = ms.encode();
             assert!(psbt_input
                 .tap_scripts


### PR DESCRIPTION
Now that we have #895 and #930 we have room to change the API for helpers to the satisfaction functions.

Change the method `tap_leaf_internal`, which currently computes the "tapleaf hash" for an arbitrary Miniscript, even non-Taproot ones, to detect whether this is a Taproot script and only compute the tapleaf hash for Taproot scripts.

Once we are returning an `Option` from `tap_leaf_internal`, we can change a bunch of satisfaction code that currently takes a `Ctx` paramater and introspects it to determine whether we are in Taproot mode or not, and have it simply use the `Option` to decide.

Aside from speeding up and simplifying the code, this removes several instances of the `Ctx` parameter, which we want to eventually eliminate.