### PR TITLE
just: Use cargo rbmt in lint task

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,8 @@ required-features = ["compiler"]
 [workspace]
 members = ["fuzz"]
 exclude = ["embedded", "bitcoind-tests"]
+
+[package.metadata.rbmt.lint]
+allowed_duplicates = [
+    "hex-conservative",
+]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -81,3 +81,9 @@ path = "fuzz_targets/roundtrip_miniscript_str.rs"
 [[bin]]
 name = "roundtrip_semantic"
 path = "fuzz_targets/roundtrip_semantic.rs"
+
+[package.metadata.rbmt.lint]
+allowed_duplicates = [
+    "miniscript",        # We explicitly depend on old miniscript here
+    "hex-conservative",  # From old miniscript.
+]

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ check:
 
 # Lint everything.
 lint:
-  cargo +nightly clippy --all-targets --all-features -- --deny warnings
+  RUSTUP_TOOLCHAIN=$(cat ./nightly-version) cargo rbmt lint
 
 # Run the formatter.
 fmt:


### PR DESCRIPTION
We have `cargo rbmt` in CI but not in the justfile. Use it for the lint job because currently `just lint` is failing, did not investigate why.

At the same time make the command pass. I do not know why the lint job in CI is working but not the patched `just lint`?

The fixes are just allow `hex` duplicate dep in `minisicript` and in `fuzz` allow duplicates of `miniscript` and `hex`.