### PR TITLE
plan: add Plan::tap_sighash_default accessor

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -234,6 +234,44 @@ impl<Pk: MiniscriptKey + ToPublicKey> Plan<Pk> {
     /// the script sig weight and the witness weight)
     pub fn satisfaction_weight(&self) -> usize { self.witness_size() + self.scriptsig_size() * 4 }
 
+    /// Returns whether the witness was sized assuming `SIGHASH_DEFAULT` — the 64-byte
+    /// Taproot signature encoding.
+    ///
+    /// * `Some(true)` — every Schnorr placeholder in this plan is sized for a 64-byte
+    ///   signature; the witness assumes `SIGHASH_DEFAULT`.
+    /// * `Some(false)` — every Schnorr placeholder is sized for a 65-byte signature;
+    ///   the witness assumes any non-Default Taproot sighash flag.
+    /// * `None` — this plan has no Schnorr placeholders (e.g. non-Taproot plans, where
+    ///   signature size is invariant under the sighash flag), or its Schnorr placeholders
+    ///   have differing sizes — a mixed plan that cannot be expressed by a single uniform
+    ///   sighash policy per BIP-174.
+    ///
+    /// This mirrors the `sighash_default` flag recorded on each
+    /// [`TaprootCanSign`] when the plan was built. Callers constructing a PSBT
+    /// can use this to populate `PSBT_IN_SIGHASH_TYPE` consistently with the
+    /// witness-size assumption baked into [`Plan::satisfaction_weight`].
+    pub fn tap_sighash_default(&self) -> Option<bool> {
+        let mut acc: Option<bool> = None;
+        for placeholder in &self.template {
+            let size = match placeholder {
+                Placeholder::SchnorrSigPk(_, _, size) => *size,
+                Placeholder::SchnorrSigPkHash(_, _, size) => *size,
+                _ => continue,
+            };
+            let is_default = match size {
+                64 => true,
+                65 => false,
+                _ => return None,
+            };
+            match acc {
+                None => acc = Some(is_default),
+                Some(prev) if prev != is_default => return None,
+                _ => {}
+            }
+        }
+        acc
+    }
+
     /// The size in bytes of the script sig that satisfies this plan, including the size of the
     /// var-int prefix.
     pub fn scriptsig_size(&self) -> usize {
@@ -1244,5 +1282,53 @@ mod test {
                 4
             )
         );
+    }
+
+    /// Build an [`Assets`] containing a single key with a custom `sighash_default` flag.
+    fn assets_with_sighash_default(pk: &DescriptorPublicKey, sighash_default: bool) -> Assets {
+        let mut keys = BTreeSet::new();
+        for deriv_path in pk.full_derivation_paths() {
+            keys.insert((
+                (pk.master_fingerprint(), deriv_path),
+                CanSign {
+                    ecdsa: true,
+                    taproot: TaprootCanSign {
+                        key_spend: true,
+                        script_spend: TaprootAvailableLeaves::Any,
+                        sighash_default,
+                    },
+                },
+            ));
+        }
+        Assets { keys, ..Default::default() }
+    }
+
+    #[test]
+    fn test_tap_sighash_default() {
+        let pk = DescriptorPublicKey::from_str(
+            "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
+        )
+        .unwrap();
+
+        // Taproot key-path plan built with the default `sighash_default: true`
+        // assumes a 64-byte signature.
+        let tr_desc =
+            Descriptor::<DefiniteDescriptorKey>::from_str(&format!("tr({})", pk)).unwrap();
+        let plan = tr_desc
+            .clone()
+            .into_plan(&Assets::new().add(pk.clone()))
+            .unwrap();
+        assert_eq!(plan.tap_sighash_default(), Some(true));
+
+        // The same descriptor planned with `sighash_default: false` assumes 65-byte sigs.
+        let assets = assets_with_sighash_default(&pk, false);
+        let plan = tr_desc.into_plan(&assets).unwrap();
+        assert_eq!(plan.tap_sighash_default(), Some(false));
+
+        // Non-Taproot plans have no Schnorr placeholders, so the assumption is moot.
+        let wsh_desc =
+            Descriptor::<DefiniteDescriptorKey>::from_str(&format!("wsh(pk({}))", pk)).unwrap();
+        let plan = wsh_desc.into_plan(&Assets::new().add(pk)).unwrap();
+        assert_eq!(plan.tap_sighash_default(), None);
     }
 }


### PR DESCRIPTION
## Summary

Adds a public accessor on `Plan` that exposes the existing per-Schnorr-placeholder size assumption — recorded when the plan was built from `TaprootCanSign::sighash_default` — as a single `Option<bool>`.

```rust
impl<Pk: MiniscriptKey + ToPublicKey> Plan<Pk> {
    /// Returns whether the witness was sized assuming `SIGHASH_DEFAULT` (the
    /// 64-byte Taproot signature encoding).
    pub fn tap_sighash_default(&self) -> Option<bool>;
}
```

- `Some(true)` — every Schnorr placeholder is sized for a 64-byte signature (the `SIGHASH_DEFAULT` encoding).
- `Some(false)` — every Schnorr placeholder is sized for a 65-byte signature (any non-Default Taproot sighash flag).
- `None` — non-Taproot plans (signature size is invariant under the sighash flag for ECDSA), or mixed plans whose Schnorr placeholders have differing sizes — these cannot be expressed by a single uniform sighash policy per BIP-174.

## Motivation

Callers building a PSBT from a `Plan` need to populate `PSBT_IN_SIGHASH_TYPE` consistently with the plan's witness-size assumption — otherwise weight estimates drift from reality. The information already lives inside the plan (on every Schnorr placeholder's `size` field); this just surfaces it as a single readable answer.

Concretely: `bdk-tx` is reworking per-input sighash handling and needs to derive the PSBT sighash policy from the plan rather than carrying separate state on its `Input` type (see bitcoindevkit/bdk-tx#69 for the full design). Without this accessor it would have to walk `Plan::witness_template()` and infer the bool from placeholder sizes, which leaks internals.

A 12.x backport is up at #950.
A 13.x backport is up at #952.

## Test plan

- [x] `cargo test --lib tap_sighash_default` — new test covers Default-Taproot, non-Default-Taproot, and non-Taproot (wsh) plans.
- [x] `cargo test --lib` — full suite still passes (157 / 0 / 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)