### PR TITLE
ci: enable workspace lint rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,11 +70,17 @@ name = "taptree_of_horror"
 path = "examples/taptree_of_horror/taptree_of_horror.rs"
 required-features = ["compiler"]
 
-[workspace]
-members = ["fuzz"]
-exclude = ["embedded", "bitcoind-tests"]
-
 [package.metadata.rbmt.lint]
 allowed_duplicates = [
     "hex-conservative",
 ]
+
+[lints]
+workspace = true
+
+[workspace]
+members = ["fuzz"]
+exclude = ["embedded", "bitcoind-tests"]
+
+[workspace.lints.clippy]
+use_self = "warn"


### PR DESCRIPTION
First patch defines the workspace lint rules and enables them in the root package. While I believe the rules could just be defined in the root package directly, might be nice to share them with the fuzz package (and any future packages)?

Closes #959 