### PR TITLE
13.x: Preserve finalized PSBT inputs

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -112,7 +112,7 @@ version = "0.0.1"
 dependencies = [
  "honggfuzz",
  "miniscript 12.3.0",
- "miniscript 13.0.0",
+ "miniscript 13.0.1",
  "regex",
 ]
 
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -112,7 +112,7 @@ version = "0.0.1"
 dependencies = [
  "honggfuzz",
  "miniscript 12.3.0",
- "miniscript 13.0.0",
+ "miniscript 13.0.1",
  "regex",
 ]
 
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "13.0.0"
+version = "13.0.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-miniscript/"

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -346,7 +346,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     ///
     /// It is **not recommended** to use policy as a stable identifier for a miniscript. You should
     /// use the policy compiler once, and then use the miniscript output as a stable identifier. See
-    /// the compiler document in [`doc/compiler.md`] for more details.
+    /// the compiler document in `./doc/compiler.md` for more details.
     #[cfg(feature = "compiler")]
     pub fn compile_to_descriptor<Ctx: ScriptContext>(
         &self,

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -431,6 +431,13 @@ pub(super) fn finalize_input<C: secp256k1::Verification>(
     secp: &Secp256k1<C>,
     allow_mall: bool,
 ) -> Result<(), super::Error> {
+    // Preserve previously finalized inputs
+    if psbt.inputs[index].final_script_sig.is_some()
+        || psbt.inputs[index].final_script_witness.is_some()
+    {
+        return Ok(());
+    }
+
     let (witness, script_sig) = finalize_input_helper(psbt, index, secp, allow_mall)?;
 
     // Now mutate the psbt input. Note that we cannot error after this point.
@@ -457,6 +464,7 @@ pub(super) fn finalize_input<C: secp256k1::Verification>(
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::{absolute, transaction, Transaction, TxIn};
     use hex;
 
     use super::*;
@@ -471,5 +479,24 @@ mod tests {
 
         let expected = Psbt::deserialize(&hex::decode_to_vec("70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000107da00473044022074018ad4180097b873323c0015720b3684cc8123891048e7dbcd9b55ad679c99022073d369b740e3eb53dcefa33823c8070514ca55a7dd9544f157c167913261118c01483045022100f61038b308dc1da865a34852746f015772934208c6d24454393cd99bdf2217770220056e675a675a6d0a02b85b14e5e29074d8a25a9b5760bea2816f661910a006ea01475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae0001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e8870107232200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b20289030108da0400473044022062eb7a556107a7c73f45ac4ab5a1dddf6f7075fb1275969a7f383efff784bcb202200c05dbb7470dbf2f08557dd356c7325c1ed30913e996cd3840945db12228da5f01473044022065f45ba5998b59a27ffe1a7bed016af1f1f90d54b3aa8f7450aa5f56a25103bd02207f724703ad1edb96680b284b56d4ffcb88f7fb759eabbe08aa30f29b851383d20147522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae00220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000").unwrap()).unwrap();
         assert_eq!(psbt, expected);
+    }
+
+    #[test]
+    fn finalize_skips_already_finalized_input() {
+        let tx = Transaction {
+            version: transaction::Version::ONE,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(tx).unwrap();
+        psbt.inputs[0].final_script_witness = Some(Witness::from_slice(&[vec![1]]));
+
+        let expected_input = psbt.inputs[0].clone();
+        let secp = Secp256k1::verification_only();
+
+        psbt.finalize_mut(&secp).unwrap();
+
+        assert_eq!(psbt.inputs[0], expected_input);
     }
 }


### PR DESCRIPTION
Backport of #960 and #873 to the 13.x branch.

This preserves PSBT inputs that already have `final_script_sig` or `final_script_witness`, avoiding re-finalization failures when finalized inputs no longer contain fields such as `witness_script` or `partial_sigs`.

Also bumps the 13.x branch version to 13.0.1 for a new patch release.