### PR TITLE
Remove `--features` flag from `sane` just recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ docsrs:
 
 # Quick and dirty CI useful for pre-push checks.
 sane: fmt-check lint
-  cargo test --quiet --all-targets --no-default-features --features > /dev/null || exit 1
+  cargo test --quiet --all-targets --no-default-features > /dev/null || exit 1
   cargo test --quiet --all-targets > /dev/null || exit 1
   cargo test --quiet --all-targets --all-features > /dev/null || exit 1
 


### PR DESCRIPTION
While executing `just sane` I received the following error message:

```bash
cargo test --quiet --all-targets --no-default-features --features > /dev/null || exit 1
error: a value is required for '--features <FEATURES>' but none was supplied

For more information, try '--help'.
error: Recipe `sane` failed on line 34 with exit code 1
```

I removed the flag because if fixes the issue and the flag is not receiving a feature list.
