### PR TITLE
Prepare `Plan::update_psbt_input` for migration to `rust-psbt`

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -363,8 +363,6 @@ impl Plan<DefiniteDescriptorKey> {
                     data
                 });
 
-            // TODO: TapTree. we need to re-traverse the tree to build it, sigh
-
             let leaf_hash = match data.spend_type {
                 Some(SpendType::KeySpend { internal_key }) => {
                     input.tap_internal_key = Some(internal_key);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -217,8 +217,8 @@ pub struct Plan<Pk: MiniscriptKey> {
     pub absolute_timelock: Option<absolute::LockTime>,
     /// The relative timelock this plan uses
     pub relative_timelock: Option<relative::LockTime>,
-
-    pub(crate) descriptor: Descriptor<Pk>,
+    /// The target descriptor for this plan
+    pub descriptor: Descriptor<Pk>,
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Plan<Pk> {


### PR DESCRIPTION
This is the simplest way I found to use the public `Plan` API in the `Plan::update_psbt_input` method so It can later be migrated to the `rust-psbt` project.

**Notes to the reviewers**:
- There is any reason to not expose the `descriptor` and `template` fields directly?
- There is a **TODO** in the code, but I'm lacking the context of it. It is something that should be fixed or a leftover?