### PR TITLE
Backport rust-bitcoin/rust-miniscript#974 to `rust-miniscript@13.x`

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -360,8 +360,6 @@ impl Plan {
                     data
                 });
 
-            // TODO: TapTree. we need to re-traverse the tree to build it, sigh
-
             let leaf_hash = match data.spend_type {
                 Some(SpendType::KeySpend { internal_key }) => {
                     input.tap_internal_key = Some(internal_key);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -217,8 +217,8 @@ pub struct Plan {
     pub absolute_timelock: Option<absolute::LockTime>,
     /// The relative timelock this plan uses
     pub relative_timelock: Option<relative::LockTime>,
-
-    pub(crate) descriptor: Descriptor<DefiniteDescriptorKey>,
+    /// The target descriptor for this plan
+    pub descriptor: Descriptor<DefiniteDescriptorKey>,
 }
 
 impl Plan {


### PR DESCRIPTION
Getting the changes from #974 into `rust-miniscript@13.x` is easier and faster than waiting for the next major release.

This is a back port of #974.