### PR TITLE
refactor: rename safe to signed in the type checker

### DIFF
--- a/src/miniscript/analyzable.rs
+++ b/src/miniscript/analyzable.rs
@@ -10,7 +10,7 @@ use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal};
 
 impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Whether all spend paths of miniscript require a signature
-    pub fn requires_sig(&self) -> bool { self.ty.mall.safe }
+    pub fn requires_sig(&self) -> bool { self.ty.mall.signed }
 
     /// Whether the miniscript is malleable
     pub fn is_non_malleable(&self) -> bool { self.ty.mall.non_malleable }

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -646,7 +646,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         let satisfaction = satisfy::Satisfaction::satisfy(
             self,
             &satisfier,
-            self.ty.mall.safe,
+            self.ty.mall.signed,
             self.leaf_hash_internal(),
         );
         self._satisfy(satisfaction)
@@ -664,7 +664,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         let satisfaction = satisfy::Satisfaction::satisfy_mall(
             self,
             &satisfier,
-            self.ty.mall.safe,
+            self.ty.mall.signed,
             self.leaf_hash_internal(),
         );
         self._satisfy(satisfaction)
@@ -693,7 +693,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         satisfy::Satisfaction::build_template(
             self,
             provider,
-            self.ty.mall.safe,
+            self.ty.mall.signed,
             self.leaf_hash_internal(),
         )
     }
@@ -709,7 +709,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         satisfy::Satisfaction::build_template_mall(
             self,
             provider,
-            self.ty.mall.safe,
+            self.ty.mall.signed,
             self.leaf_hash_internal(),
         )
     }
@@ -1379,7 +1379,7 @@ mod tests {
             (Ok(ms), true) => {
                 assert_eq!(format!("{:x}", ms.encode()), expected_hex);
                 assert_eq!(ms.ty.mall.non_malleable, non_mal);
-                assert_eq!(ms.ty.mall.safe, need_sig);
+                assert_eq!(ms.ty.mall.signed, need_sig);
                 assert_eq!(ms.ext.static_ops + ms.ext.sat_data.unwrap().max_exec_op_count, ops);
             }
             (Err(_), false) => {}

--- a/src/miniscript/ms_tests.rs
+++ b/src/miniscript/ms_tests.rs
@@ -40,7 +40,7 @@ mod tests {
                 types::Dissat::Unique => "e",
                 types::Dissat::Unknown => "",
             })?;
-            if self.0.mall.safe {
+            if self.0.mall.signed {
                 fmt::Write::write_char(f, 's')?;
             }
             if self.0.mall.non_malleable {

--- a/src/miniscript/types/malleability.rs
+++ b/src/miniscript/types/malleability.rs
@@ -57,12 +57,11 @@ impl Dissat {
 pub struct Malleability {
     /// Properties of dissatisfying inputs
     pub dissat: Dissat,
-    /// `true` if satisfactions cannot be created by any 3rd party
-    /// who has not yet seen a satisfaction.
-    ///
-    /// Hash preimages and signature checks are safe; timelocks are not. Affects
-    /// malleability.
-    pub safe: bool,
+    /// `true` if every satisfaction, if one exists, requires a
+    /// signature. `false` for hash preimages and timelocks, since
+    /// they can be satisfied without a signature.
+    /// Affects malleability.
+    pub signed: bool,
     /// Whether a non-malleable satisfaction is guaranteed to exist for
     /// the fragment
     pub non_malleable: bool,
@@ -70,10 +69,10 @@ pub struct Malleability {
 
 impl Malleability {
     /// Malleability data for the `1` combinator
-    pub const TRUE: Self = Self { dissat: Dissat::None, safe: false, non_malleable: true };
+    pub const TRUE: Self = Self { dissat: Dissat::None, signed: false, non_malleable: true };
 
     /// Malleability data for the `0` combinator
-    pub const FALSE: Self = Self { dissat: Dissat::Unique, safe: true, non_malleable: true };
+    pub const FALSE: Self = Self { dissat: Dissat::Unique, signed: true, non_malleable: true };
 
     /// Check whether the `self` is a subtype of `other` argument.
     ///
@@ -82,45 +81,51 @@ impl Malleability {
     /// `a.is_subtype(a)` is `true`.
     pub const fn is_subtype(&self, other: Self) -> bool {
         self.dissat.is_subtype(other.dissat)
-            && self.safe >= other.safe
+            && self.signed >= other.signed
             && self.non_malleable >= other.non_malleable
     }
 }
 
 impl Malleability {
     /// Constructor for the malleabilitiy properties of the `pk_k` fragment.
-    pub const fn pk_k() -> Self { Self { dissat: Dissat::Unique, safe: true, non_malleable: true } }
+    pub const fn pk_k() -> Self {
+        Self { dissat: Dissat::Unique, signed: true, non_malleable: true }
+    }
 
     /// Constructor for the malleabilitiy properties of the `pk_h` fragment.
-    pub const fn pk_h() -> Self { Self { dissat: Dissat::Unique, safe: true, non_malleable: true } }
+    pub const fn pk_h() -> Self {
+        Self { dissat: Dissat::Unique, signed: true, non_malleable: true }
+    }
 
     /// Constructor for the malleabilitiy properties of the `multi` fragment.
     pub const fn multi() -> Self {
-        Self { dissat: Dissat::Unique, safe: true, non_malleable: true }
+        Self { dissat: Dissat::Unique, signed: true, non_malleable: true }
     }
 
     /// Constructor for the malleabilitiy properties of the `sortedmulti` fragment.
     pub const fn sortedmulti() -> Self {
-        Self { dissat: Dissat::Unique, safe: true, non_malleable: true }
+        Self { dissat: Dissat::Unique, signed: true, non_malleable: true }
     }
 
     /// Constructor for the malleabilitiy properties of the `multi_a` fragment.
     pub const fn multi_a() -> Self {
-        Self { dissat: Dissat::Unique, safe: true, non_malleable: true }
+        Self { dissat: Dissat::Unique, signed: true, non_malleable: true }
     }
 
     /// Constructor for the malleabilitiy properties of the `sortedmulti_a` fragment.
     pub const fn sortedmulti_a() -> Self {
-        Self { dissat: Dissat::Unique, safe: true, non_malleable: true }
+        Self { dissat: Dissat::Unique, signed: true, non_malleable: true }
     }
 
     /// Constructor for the malleabilitiy properties of any of the hash fragments.
     pub const fn hash() -> Self {
-        Self { dissat: Dissat::Unknown, safe: false, non_malleable: true }
+        Self { dissat: Dissat::Unknown, signed: false, non_malleable: true }
     }
 
     /// Constructor for the malleabilitiy properties of either `after` or `older`.
-    pub const fn time() -> Self { Self { dissat: Dissat::None, safe: false, non_malleable: true } }
+    pub const fn time() -> Self {
+        Self { dissat: Dissat::None, signed: false, non_malleable: true }
+    }
 
     /// Constructor for the malleabilitiy properties of the `a:` fragment.
     pub const fn cast_alt(self) -> Self { self }
@@ -139,14 +144,14 @@ impl Malleability {
             } else {
                 Dissat::Unknown
             },
-            safe: self.safe,
+            signed: self.signed,
             non_malleable: self.non_malleable,
         }
     }
 
     /// Constructor for the malleabilitiy properties of the `v:` fragment.
     pub const fn cast_verify(self) -> Self {
-        Self { dissat: Dissat::None, safe: self.safe, non_malleable: self.non_malleable }
+        Self { dissat: Dissat::None, signed: self.signed, non_malleable: self.non_malleable }
     }
 
     /// Constructor for the malleabilitiy properties of the `j:` fragment.
@@ -157,7 +162,7 @@ impl Malleability {
             } else {
                 Dissat::Unknown
             },
-            safe: self.safe,
+            signed: self.signed,
             non_malleable: self.non_malleable,
         }
     }
@@ -167,7 +172,7 @@ impl Malleability {
 
     /// Constructor for the malleabilitiy properties of the `t:` fragment.
     pub const fn cast_true(self) -> Self {
-        Self { dissat: Dissat::None, safe: self.safe, non_malleable: self.non_malleable }
+        Self { dissat: Dissat::None, signed: self.signed, non_malleable: self.non_malleable }
     }
 
     /// Constructor for the malleabilitiy properties of the `l:` or `u:` fragments.
@@ -178,7 +183,7 @@ impl Malleability {
             } else {
                 Dissat::Unknown
             },
-            safe: self.safe,
+            signed: self.signed,
             non_malleable: self.non_malleable,
         }
     }
@@ -188,10 +193,10 @@ impl Malleability {
         Self {
             dissat: match (left.dissat, right.dissat) {
                 (Dissat::None, Dissat::None) => Dissat::None,
-                (Dissat::None, _) if left.safe => Dissat::None,
-                (_, Dissat::None) if right.safe => Dissat::None,
+                (Dissat::None, _) if left.signed => Dissat::None,
+                (_, Dissat::None) if right.signed => Dissat::None,
                 (Dissat::Unique, Dissat::Unique) => {
-                    if left.safe && right.safe {
+                    if left.signed && right.signed {
                         Dissat::Unique
                     } else {
                         Dissat::Unknown
@@ -199,7 +204,7 @@ impl Malleability {
                 }
                 _ => Dissat::Unknown,
             },
-            safe: left.safe || right.safe,
+            signed: left.signed || right.signed,
             non_malleable: left.non_malleable && right.non_malleable,
         }
     }
@@ -207,12 +212,12 @@ impl Malleability {
     /// Constructor for the malleabilitiy properties of the `and_v` fragment.
     pub const fn and_v(left: Self, right: Self) -> Self {
         Self {
-            dissat: match (left.safe, right.dissat) {
+            dissat: match (left.signed, right.dissat) {
                 (_, Dissat::None) => Dissat::None, // fy
                 (true, _) => Dissat::None,         // sx
                 _ => Dissat::Unknown,
             },
-            safe: left.safe || right.safe,
+            signed: left.signed || right.signed,
             non_malleable: left.non_malleable && right.non_malleable,
         }
     }
@@ -221,12 +226,12 @@ impl Malleability {
     pub const fn or_b(left: Self, right: Self) -> Self {
         Self {
             dissat: Dissat::Unique,
-            safe: left.safe && right.safe,
+            signed: left.signed && right.signed,
             non_malleable: left.non_malleable
                 && left.dissat.constfn_eq(Dissat::Unique)
                 && right.non_malleable
                 && right.dissat.constfn_eq(Dissat::Unique)
-                && (left.safe || right.safe),
+                && (left.signed || right.signed),
         }
     }
 
@@ -234,11 +239,11 @@ impl Malleability {
     pub const fn or_d(left: Self, right: Self) -> Self {
         Self {
             dissat: right.dissat,
-            safe: left.safe && right.safe,
+            signed: left.signed && right.signed,
             non_malleable: left.non_malleable
                 && left.dissat.constfn_eq(Dissat::Unique)
                 && right.non_malleable
-                && (left.safe || right.safe),
+                && (left.signed || right.signed),
         }
     }
 
@@ -246,11 +251,11 @@ impl Malleability {
     pub const fn or_c(left: Self, right: Self) -> Self {
         Self {
             dissat: Dissat::None,
-            safe: left.safe && right.safe,
+            signed: left.signed && right.signed,
             non_malleable: left.non_malleable
                 && left.dissat.constfn_eq(Dissat::Unique)
                 && right.non_malleable
-                && (left.safe || right.safe),
+                && (left.signed || right.signed),
         }
     }
 
@@ -263,27 +268,29 @@ impl Malleability {
                 (Dissat::None, Dissat::Unique) => Dissat::Unique,
                 _ => Dissat::Unknown,
             },
-            safe: left.safe && right.safe,
-            non_malleable: left.non_malleable && right.non_malleable && (left.safe || right.safe),
+            signed: left.signed && right.signed,
+            non_malleable: left.non_malleable
+                && right.non_malleable
+                && (left.signed || right.signed),
         }
     }
 
     /// Constructor for the malleabilitiy properties of the `andor` fragment.
     pub const fn and_or(a: Self, b: Self, c: Self) -> Self {
         Self {
-            dissat: match (a.safe, b.dissat, c.dissat) {
+            dissat: match (a.signed, b.dissat, c.dissat) {
                 (_, Dissat::None, Dissat::Unique) => Dissat::Unique, //E: ez fy
                 (true, _, Dissat::Unique) => Dissat::Unique,         // E: ez sx
                 (_, Dissat::None, Dissat::None) => Dissat::None,     // F: fy && fz
                 (true, _, Dissat::None) => Dissat::None,             // F: sx && fz
                 _ => Dissat::Unknown,
             },
-            safe: (a.safe || b.safe) && c.safe,
+            signed: (a.signed || b.signed) && c.signed,
             non_malleable: a.non_malleable
                 && c.non_malleable
                 && a.dissat.constfn_eq(Dissat::Unique)
                 && b.non_malleable
-                && (a.safe || b.safe || c.safe),
+                && (a.signed || b.signed || c.signed),
         }
     }
 
@@ -294,23 +301,23 @@ impl Malleability {
         I: ExactSizeIterator<Item = &'a Self>,
     {
         let n = subs.len();
-        let mut safe_count = 0;
+        let mut signed_count = 0;
         let mut all_are_dissat_unique = true;
         let mut all_are_non_malleable = true;
         for subtype in subs {
-            safe_count += usize::from(subtype.safe);
+            signed_count += usize::from(subtype.signed);
             all_are_dissat_unique &= subtype.dissat == Dissat::Unique;
             all_are_non_malleable &= subtype.non_malleable;
         }
 
         Self {
-            dissat: if all_are_dissat_unique && safe_count == n {
+            dissat: if all_are_dissat_unique && signed_count == n {
                 Dissat::Unique
             } else {
                 Dissat::Unknown
             },
-            safe: safe_count > n - k,
-            non_malleable: all_are_non_malleable && safe_count >= n - k && all_are_dissat_unique,
+            signed: signed_count > n - k,
+            non_malleable: all_are_non_malleable && signed_count >= n - k && all_are_dissat_unique,
         }
     }
 }

--- a/src/miniscript/types/mod.rs
+++ b/src/miniscript/types/mod.rs
@@ -185,7 +185,7 @@ impl fmt::Display for Type {
             Dissat::Unique => "e",
             Dissat::Unknown => "",
         })?;
-        if self.mall.safe {
+        if self.mall.signed {
             f.write_str("s")?;
         }
         if self.mall.non_malleable {
@@ -214,7 +214,7 @@ impl Type {
     fn sanity_checks(&self) {
         debug_assert!(!self.corr.dissatisfiable || self.mall.dissat != Dissat::None);
         debug_assert!(self.mall.dissat == Dissat::None || self.corr.base != Base::V);
-        debug_assert!(self.mall.safe || self.corr.base != Base::K);
+        debug_assert!(self.mall.signed || self.corr.base != Base::K);
         debug_assert!(self.mall.non_malleable || self.corr.input != Input::Zero);
         self.corr.sanity_checks();
     }

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1154,7 +1154,7 @@ pub fn best_compilation<Pk: MiniscriptKey, Ctx: ScriptContext>(
 ) -> Result<Miniscript<Pk, Ctx>, CompilerError> {
     let mut policy_cache = PolicyCache::<Pk, Ctx>::new();
     let x = &*best_t(&mut policy_cache, policy, 1.0, None)?.ms;
-    if !x.ty.mall.safe {
+    if !x.ty.mall.signed {
         Err(CompilerError::TopLevelNonSafe)
     } else if !x.ty.mall.non_malleable {
         Err(CompilerError::ImpossibleNonMalleableCompilation)

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -45,8 +45,8 @@ pub enum CompilerError {
     NonBinaryArgAnd,
     /// `Or` fragments only support two args.
     NonBinaryArgOr,
-    /// Compiler has non-safe input policy.
-    TopLevelNonSafe,
+    /// Compiler has a top-level spend path that does not require a signature.
+    TopLevelSigless,
     /// Non-Malleable compilation  does exists for the given sub-policy.
     ImpossibleNonMalleableCompilation,
     /// At least one satisfaction path in the optimal Miniscript has exceeded
@@ -78,7 +78,9 @@ impl fmt::Display for CompilerError {
         match *self {
             Self::NonBinaryArgAnd => f.write_str("And policy fragment must take 2 arguments"),
             Self::NonBinaryArgOr => f.write_str("Or policy fragment must take 2 arguments"),
-            Self::TopLevelNonSafe => f.write_str("Top Level script is not safe on some spendpath"),
+            Self::TopLevelSigless => {
+                f.write_str("top-level script has a spend path without signatures")
+            }
             Self::ImpossibleNonMalleableCompilation => {
                 f.write_str("The compiler could not find any non-malleable compilation")
             }
@@ -110,7 +112,7 @@ impl error::Error for CompilerError {
         match self {
             NonBinaryArgAnd
             | NonBinaryArgOr
-            | TopLevelNonSafe
+            | TopLevelSigless
             | ImpossibleNonMalleableCompilation
             | LimitsExceeded
             | NoInternalKey
@@ -1155,7 +1157,7 @@ pub fn best_compilation<Pk: MiniscriptKey, Ctx: ScriptContext>(
     let mut policy_cache = PolicyCache::<Pk, Ctx>::new();
     let x = &*best_t(&mut policy_cache, policy, 1.0, None)?.ms;
     if !x.ty.mall.signed {
-        Err(CompilerError::TopLevelNonSafe)
+        Err(CompilerError::TopLevelSigless)
     } else if !x.ty.mall.non_malleable {
         Err(CompilerError::ImpossibleNonMalleableCompilation)
     } else {
@@ -1280,13 +1282,13 @@ mod tests {
     #[test]
     fn compile_basic() {
         assert!(policy_compile_lift_check("pk(A)").is_ok());
-        assert_eq!(policy_compile_lift_check("after(9)"), Err(CompilerError::TopLevelNonSafe));
-        assert_eq!(policy_compile_lift_check("older(1)"), Err(CompilerError::TopLevelNonSafe));
+        assert_eq!(policy_compile_lift_check("after(9)"), Err(CompilerError::TopLevelSigless));
+        assert_eq!(policy_compile_lift_check("older(1)"), Err(CompilerError::TopLevelSigless));
         assert_eq!(
             policy_compile_lift_check(
                 "sha256(1111111111111111111111111111111111111111111111111111111111111111)"
             ),
-            Err(CompilerError::TopLevelNonSafe)
+            Err(CompilerError::TopLevelSigless)
         );
         assert!(policy_compile_lift_check("and(pk(A),pk(B))").is_ok());
         assert!(policy_compile_lift_check("or(pk(A),pk(B))").is_ok());
@@ -1295,7 +1297,7 @@ mod tests {
 
         assert_eq!(
             policy_compile_lift_check("thresh(2,after(9),after(9),pk(A))"),
-            Err(CompilerError::TopLevelNonSafe)
+            Err(CompilerError::TopLevelSigless)
         );
 
         assert_eq!(

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -825,12 +825,12 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     }
 
     /// Checks if any possible compilation of the policy could be compiled
-    /// as non-malleable and safe.
+    /// as non-malleable and requiring signatures.
     ///
     /// # Returns
     ///
-    /// Returns a tuple `(safe, non-malleable)` to avoid the fact that
-    /// non-malleability depends on safety and we would like to cache results.
+    /// Returns a tuple `(signed, non-malleable)` to avoid the fact that
+    /// non-malleability depends on signatures and we would like to cache results.
     pub fn is_safe_nonmalleable(&self) -> (bool, bool) {
         use Policy::*;
 
@@ -842,28 +842,28 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                     (false, true)
                 }
                 And(ref subs) => {
-                    let (atleast_one_safe, all_non_mall) = (0..subs.len())
+                    let (atleast_one_signed, all_non_mall) = (0..subs.len())
                         .map(|_| acc.pop().unwrap())
                         .fold((false, true), |acc, x: (bool, bool)| (acc.0 || x.0, acc.1 && x.1));
-                    (atleast_one_safe, all_non_mall)
+                    (atleast_one_signed, all_non_mall)
                 }
                 Or(ref subs) => {
-                    let (all_safe, atleast_one_safe, all_non_mall) = (0..subs.len())
+                    let (all_signed, atleast_one_signed, all_non_mall) = (0..subs.len())
                         .map(|_| acc.pop().unwrap())
                         .fold((true, false, true), |acc, x| {
                             (acc.0 && x.0, acc.1 || x.0, acc.2 && x.1)
                         });
-                    (all_safe, atleast_one_safe && all_non_mall)
+                    (all_signed, atleast_one_signed && all_non_mall)
                 }
                 Thresh(ref thresh) => {
-                    let (safe_count, non_mall_count) = (0..thresh.n())
+                    let (signed_count, non_mall_count) = (0..thresh.n())
                         .map(|_| acc.pop().unwrap())
-                        .fold((0, 0), |(safe_count, non_mall_count), (safe, non_mall)| {
-                            (safe_count + safe as usize, non_mall_count + non_mall as usize)
+                        .fold((0, 0), |(signed_count, non_mall_count), (signed, non_mall)| {
+                            (signed_count + signed as usize, non_mall_count + non_mall as usize)
                         });
                     (
-                        safe_count >= (thresh.n() - thresh.k() + 1),
-                        non_mall_count == thresh.n() && safe_count >= (thresh.n() - thresh.k()),
+                        signed_count >= (thresh.n() - thresh.k() + 1),
+                        non_mall_count == thresh.n() && signed_count >= (thresh.n() - thresh.k()),
                     )
                 }
             };

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -234,7 +234,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         self.is_valid().map_err(CompilerError::PolicyError)?;
         self.check_binary_ops()?;
         match self.is_safe_nonmalleable() {
-            (false, _) => Err(CompilerError::TopLevelNonSafe),
+            (false, _) => Err(CompilerError::TopLevelSigless),
             (_, false) => Err(CompilerError::ImpossibleNonMalleableCompilation),
             _ => {
                 let (internal_key, policy) = self.clone().extract_key(unspendable_key)?;
@@ -290,7 +290,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         self.is_valid().map_err(CompilerError::PolicyError)?;
         self.check_binary_ops()?;
         match self.is_safe_nonmalleable() {
-            (false, _) => Err(CompilerError::TopLevelNonSafe),
+            (false, _) => Err(CompilerError::TopLevelSigless),
             (_, false) => Err(CompilerError::ImpossibleNonMalleableCompilation),
             _ => {
                 let (internal_key, policy) = self.clone().extract_key(unspendable_key)?;
@@ -356,7 +356,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         self.is_valid().map_err(Error::ConcretePolicy)?;
         self.check_binary_ops()?;
         match self.is_safe_nonmalleable() {
-            (false, _) => Err(Error::from(CompilerError::TopLevelNonSafe)),
+            (false, _) => Err(Error::from(CompilerError::TopLevelSigless)),
             (_, false) => Err(Error::from(CompilerError::ImpossibleNonMalleableCompilation)),
             _ => {
                 let (internal_key, policy) = self.clone().extract_key(unspendable_key)?;
@@ -410,7 +410,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         self.is_valid().map_err(Error::ConcretePolicy)?;
         self.check_binary_ops()?;
         match self.is_safe_nonmalleable() {
-            (false, _) => Err(Error::from(CompilerError::TopLevelNonSafe)),
+            (false, _) => Err(Error::from(CompilerError::TopLevelSigless)),
             (_, false) => Err(Error::from(CompilerError::ImpossibleNonMalleableCompilation)),
             _ => match desc_ctx {
                 DescriptorCtx::Bare => Descriptor::new_bare(compiler::best_compilation(self)?),
@@ -436,7 +436,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         self.is_valid()?;
         self.check_binary_ops()?;
         match self.is_safe_nonmalleable() {
-            (false, _) => Err(CompilerError::TopLevelNonSafe),
+            (false, _) => Err(CompilerError::TopLevelSigless),
             (_, false) => Err(CompilerError::ImpossibleNonMalleableCompilation),
             _ => compiler::best_compilation(self),
         }


### PR DESCRIPTION
- simple find and replace, plus doc comment fixes
- changed CompilerError::TopLevelNonSafe to TopLevelSigless to coincide with the
  rename above

Fixes #977