### PR TITLE
Manual weekly update to rustc (to nightly-2026-06-14)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ members = ["fuzz"]
 exclude = ["embedded", "bitcoind-tests"]
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-05-22"
+nightly = "nightly-2026-06-14"
 stable = "1.95.0"
 
 [workspace.lints.clippy]

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1671,7 +1671,7 @@ mod tests {
     #[test]
     fn tr_roundtrip_key() {
         let script = Tr::<String>::from_str("tr()").unwrap().to_string();
-        assert_eq!(script, format!("tr()#x4ml3kxd"))
+        assert_eq!(script, "tr()#x4ml3kxd");
     }
 
     #[test]


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-miniscript/pull/971

Fix lint by removing unnecessary format call.