### PR TITLE
Release 13.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 13.1.0 - June 9, 2026
+
+- plan: make `Plan`'s `descriptor` field public.
+  [#978](https://github.com/rust-bitcoin/rust-miniscript/pull/978)
+
 # 13.0.0 - October 22, 2025
 
 This release is a pretty big one and includes several significant refactors:

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -112,7 +112,7 @@ version = "0.0.1"
 dependencies = [
  "honggfuzz",
  "miniscript 12.3.0",
- "miniscript 13.0.1",
+ "miniscript 13.1.0",
  "regex",
 ]
 
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "13.0.1"
+version = "13.1.0"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -112,7 +112,7 @@ version = "0.0.1"
 dependencies = [
  "honggfuzz",
  "miniscript 12.3.0",
- "miniscript 13.0.1",
+ "miniscript 13.1.0",
  "regex",
 ]
 
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "13.0.1"
+version = "13.1.0"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "13.0.1"
+version = "13.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-miniscript/"


### PR DESCRIPTION
Bumps the `release-13.x` branch version to 13.1.0 for a new release.

The only included change is the exposure in the public API of the `descriptor` field from `Plan`.