### PR TITLE
fix(manifest): correct serde feature configuration for no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.63.0"
 
 [features]
 default = ["std"]
-std = ["bitcoin/std", "bitcoin/secp-recovery", "bech32/std"]
+std = ["bitcoin/std", "bitcoin/secp-recovery", "bech32/std", "serde?/std"]
 compiler = []
 trace = []
 
@@ -26,7 +26,7 @@ bech32 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 bitcoin = { version = "0.32.6", default-features = false }
 hex = { package = "hex-conservative", default-features = false, features = ["alloc"], version = "1.0.0" }
 
-serde = { version = "1.0.103", optional = true }
+serde = { version = "1.0.103", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.147"


### PR DESCRIPTION
### Description

This PR fixes a bug where the optional serde dependency implicitly leaks the standard library into no-std builds.

Previously, serde was missing `default-features = false` in the `[dependencies]` block. When downstream crates attempted to compile miniscript for bare-metal targets (e.g., thumbv7m-none-eabi) using minimal-version dependency resolution, Cargo would resolve serde with its default "std" feature enabled, causing immediate compilation failures.

### Notes to the reviewers

I encountered this feature leakage while working on integrating cargo-rbmt CI checks over in bdk_wallet (specifically in this PR: https://github.com/bitcoindevkit/bdk_wallet/pull/494).

When the rbmt matrix runs its minimal dependency sweep on no-std bare-metal targets, it exposes this missing feature configuration. Applying this fix locally allowed the embedded target compilation to pass cleanly.

### Changelog notice

- Added default-features = false to the optional serde dependency.
- Explicitly opted into the alloc feature for serde.
- Updated the std feature array to use the weak dependency activation syntax (`"serde?/std"`)