### PR TITLE
Drop obsolete unused-import workaround

### DIFF
--- a/examples/psbt_sign_finalize.rs
+++ b/examples/psbt_sign_finalize.rs
@@ -6,10 +6,9 @@ use std::str::FromStr;
 use miniscript::bitcoin::consensus::encode::deserialize_hex;
 use miniscript::bitcoin::psbt::{self, Psbt};
 use miniscript::bitcoin::sighash::SighashCache;
-//use miniscript::bitcoin::secp256k1; // https://github.com/rust-lang/rust/issues/121684
 use miniscript::bitcoin::{
-    transaction, Address, Amount, Network, OutPoint, PrivateKey, Script, Sequence, Transaction,
-    TxIn, TxOut,
+    secp256k1, transaction, Address, Amount, Network, OutPoint, PrivateKey, Script, Sequence,
+    Transaction, TxIn, TxOut,
 };
 use miniscript::psbt::{PsbtExt, PsbtInputExt};
 use miniscript::Descriptor;

--- a/src/interpreter/error.rs
+++ b/src/interpreter/error.rs
@@ -7,9 +7,7 @@ use std::error;
 
 use bitcoin::hashes::hash160;
 use bitcoin::hex::DisplayHex;
-#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
-use bitcoin::secp256k1;
-use bitcoin::{absolute, relative, taproot};
+use bitcoin::{absolute, relative, secp256k1, taproot};
 
 use super::BitcoinKey;
 use crate::prelude::*;

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -13,12 +13,10 @@ use core::mem;
 
 use bitcoin::hashes::hash160;
 use bitcoin::key::XOnlyPublicKey;
-#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
-use bitcoin::secp256k1;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::Prevouts;
 use bitcoin::taproot::LeafVersion;
-use bitcoin::{PublicKey, Script, ScriptBuf, TxOut, Witness};
+use bitcoin::{secp256k1, PublicKey, Script, ScriptBuf, TxOut, Witness};
 
 use super::{sanity_check, Error, InputError, Psbt, PsbtInputSatisfier};
 use crate::prelude::*;

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -14,12 +14,10 @@ use std::error;
 
 use bitcoin::hashes::{hash160, sha256d, Hash};
 use bitcoin::psbt::{self, Psbt};
-#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
-use bitcoin::secp256k1;
 use bitcoin::secp256k1::{Secp256k1, VerifyOnly};
 use bitcoin::sighash::{self, SighashCache};
 use bitcoin::taproot::{self, ControlBlock, LeafVersion, TapLeafHash};
-use bitcoin::{absolute, bip32, relative, transaction, Script, ScriptBuf};
+use bitcoin::{absolute, bip32, relative, secp256k1, transaction, Script, ScriptBuf};
 
 use crate::miniscript::context::SigType;
 use crate::prelude::*;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -8,7 +8,6 @@ use std::str::FromStr;
 
 use bitcoin::hashes::{hash160, ripemd160, sha256};
 use bitcoin::key::XOnlyPublicKey;
-#[cfg(not(test))] // https://github.com/rust-lang/rust/issues/121684
 use bitcoin::secp256k1;
 
 use crate::miniscript::context::SigType;


### PR DESCRIPTION
The `#[cfg(not(test))]` guard on the secp256k1 imports worked around an `unused_imports` warning tracked in rust-lang/rust#121684 (2024). That bug is fixed, so the guard is no longer needed.

Built with `cargo +nightly-2026-06-26 build --all-targets`, a recent nightly version, and had no warning.

This is not a priority at all, but I caught it during a codebase read.