### PR TITLE
Backports BIP-388 `WalletPolicy` support to `release-13.x`

### DIFF
--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -201,6 +201,16 @@ pub enum Wildcard {
     Hardened,
 }
 
+impl fmt::Display for Wildcard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Wildcard::None => write!(f, ""),
+            Wildcard::Unhardened => write!(f, "/*"),
+            Wildcard::Hardened => write!(f, "/*h"),
+        }
+    }
+}
+
 impl SinglePriv {
     /// Returns the public key of this key.
     fn to_public<C: Signing>(&self, secp: &Secp256k1<C>) -> SinglePub {
@@ -502,22 +512,14 @@ impl fmt::Display for DescriptorPublicKey {
                 maybe_fmt_master_id(f, &xpub.origin)?;
                 xpub.xkey.fmt(f)?;
                 fmt_derivation_path(f, &xpub.derivation_path)?;
-                match xpub.wildcard {
-                    Wildcard::None => {}
-                    Wildcard::Unhardened => write!(f, "/*")?,
-                    Wildcard::Hardened => write!(f, "/*h")?,
-                }
+                xpub.wildcard.fmt(f)?;
                 Ok(())
             }
             Self::MultiXPub(ref xpub) => {
                 maybe_fmt_master_id(f, &xpub.origin)?;
                 xpub.xkey.fmt(f)?;
                 fmt_derivation_paths(f, xpub.derivation_paths.paths())?;
-                match xpub.wildcard {
-                    Wildcard::None => {}
-                    Wildcard::Unhardened => write!(f, "/*")?,
-                    Wildcard::Hardened => write!(f, "/*h")?,
-                }
+                xpub.wildcard.fmt(f)?;
                 Ok(())
             }
         }

--- a/src/descriptor/key.rs
+++ b/src/descriptor/key.rs
@@ -12,6 +12,7 @@ use bitcoin::key::{PublicKey, XOnlyPublicKey};
 use bitcoin::secp256k1::{Secp256k1, Signing, Verification};
 use bitcoin::NetworkKind;
 
+use super::WalletPolicyError;
 use crate::prelude::*;
 #[cfg(feature = "serde")]
 use crate::serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -497,6 +498,7 @@ impl error::Error for DescriptorKeyParseError {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum XKeyParseError {
     Bip32(bip32::Error),
+    Bip388(WalletPolicyError),
 }
 
 #[cfg(feature = "std")]
@@ -504,6 +506,7 @@ impl error::Error for XKeyParseError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::Bip32(err) => Some(err),
+            Self::Bip388(err) => Some(err),
         }
     }
 }
@@ -512,6 +515,7 @@ impl fmt::Display for XKeyParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Bip32(err) => err.fmt(f),
+            Self::Bip388(err) => err.fmt(f),
         }
     }
 }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -53,6 +53,7 @@ pub use self::tr::{
 pub mod checksum;
 mod key;
 mod key_map;
+mod wallet_policy;
 
 pub use self::key::{
     DefiniteDescriptorKey, DerivPaths, DescriptorKeyParseError, DescriptorMultiXKey,
@@ -60,6 +61,7 @@ pub use self::key::{
     NonDefiniteKeyError, SinglePriv, SinglePub, SinglePubKey, Wildcard, XKeyNetwork,
 };
 pub use self::key_map::KeyMap;
+pub use self::wallet_policy::{WalletPolicy, WalletPolicyError};
 
 /// Script descriptor
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/descriptor/wallet_policy/key_expression.rs
+++ b/src/descriptor/wallet_policy/key_expression.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt::{self, Display, Write};
+use core::str::FromStr;
+
+use super::{DerivPaths, DescriptorKeyParseError, Wildcard};
+use crate::descriptor::key::{fmt_derivation_paths, parse_xkey_deriv};
+use crate::descriptor::WalletPolicyError;
+use crate::{BTreeSet, MiniscriptKey, String};
+
+const RECEIVE_CHANGE_SHORTHAND: &str = "**";
+const RECEIVE_CHANGE_PATH: &str = "<0;1>/*";
+
+/// A key expression type based off of the description of KEY and KP in BIP-388.
+/// Used as a `Pk` in `Descriptor<Pk>`
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct KeyExpression {
+    /// The numeric part of key index (KI)
+    pub index: KeyIndex,
+    /// The derivation paths of this key
+    pub derivation_paths: DerivPaths,
+    /// The wildcard value
+    pub wildcard: Wildcard,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct KeyIndex(pub u32);
+
+impl KeyExpression {
+    pub fn is_disjoint(&self, other: &KeyExpression) -> bool {
+        let lhs: BTreeSet<_> = self
+            .derivation_paths
+            .paths()
+            .iter()
+            .flat_map(|p| p.into_iter().copied())
+            .collect();
+
+        !other
+            .derivation_paths
+            .paths()
+            .iter()
+            .flat_map(|p| p.into_iter())
+            .any(|cn| lhs.contains(cn))
+    }
+}
+
+impl TryFrom<&str> for KeyExpression {
+    type Error = DescriptorKeyParseError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        let path = match s.split_once('/') {
+            Some((_placeholder, path)) => path,
+            None => return Err(WalletPolicyError::KeyExpressionParseMustHaveDerivPath.into()),
+        };
+        if path != RECEIVE_CHANGE_SHORTHAND && !valid_unhardened_derivation_path(path) {
+            return Err(WalletPolicyError::KeyExpressionParseInvalidDerivPath.into());
+        }
+        let (ki, derivation_paths, wildcard) =
+            parse_xkey_deriv(&s.replace(RECEIVE_CHANGE_SHORTHAND, RECEIVE_CHANGE_PATH))?;
+        Ok(KeyExpression {
+            index: ki,
+            derivation_paths: DerivPaths::new(derivation_paths)
+                .ok_or(WalletPolicyError::KeyExpressionParseMustHaveDerivPath)?,
+            wildcard,
+        })
+    }
+}
+
+// Returns true if `path` is a string of the form /<NUM;NUM>/*, for two distinct
+// decimal numbers NUM representing unhardened derivations
+// NOTE: the prefix '/' should be stripped in the caller
+fn valid_unhardened_derivation_path(path: &str) -> bool {
+    let (left, right) = match path.split_once(';') {
+        Some(pair) => pair,
+        None => return false,
+    };
+    let left_num = match left.strip_prefix("<") {
+        Some(num) => num,
+        None => return false,
+    };
+    let right_num = match right.strip_suffix(">/*") {
+        Some(num) => num,
+        None => return false,
+    };
+    matches!(
+        (left_num.parse::<u32>(), right_num.parse::<u32>()),
+        (Ok(a), Ok(b)) if a < b
+    )
+}
+
+impl FromStr for KeyExpression {
+    type Err = DescriptorKeyParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> { s.try_into() }
+}
+
+impl Display for KeyExpression {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.index.fmt(f)?;
+        let mut path = String::new();
+        fmt_derivation_paths(&mut path, self.derivation_paths.paths())?;
+        write!(&mut path, "{}", self.wildcard)?;
+        write!(f, "{}", path.replace(RECEIVE_CHANGE_PATH, RECEIVE_CHANGE_SHORTHAND))
+    }
+}
+
+impl MiniscriptKey for KeyExpression {
+    type Sha256 = String;
+    type Hash256 = String;
+    type Ripemd160 = String;
+    type Hash160 = String;
+
+    fn is_x_only_key(&self) -> bool { false }
+    fn num_der_paths(&self) -> usize { self.derivation_paths.paths().len() }
+}
+
+impl FromStr for KeyIndex {
+    type Err = WalletPolicyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut chars = s.chars();
+        match chars.next() {
+            Some('@') => {
+                let index_str = chars.take_while(char::is_ascii_digit).collect::<String>();
+                let index = index_str
+                    .parse()
+                    .map_err(|_| WalletPolicyError::KeyIndexParseInvalidIndex(index_str))?;
+                Ok(KeyIndex(index))
+            }
+            Some(ch) => Err(WalletPolicyError::KeyIndexParseExpectedAtSign(ch)),
+            None => Err(WalletPolicyError::KeyIndexParseInvalidIndex(s.into())),
+        }
+    }
+}
+
+impl Display for KeyIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "@{}", self.0) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_test_disjoin_deriv_paths() {
+        assert!(!KeyExpression::from_str("@0/<0;1>/*")
+            .unwrap()
+            .is_disjoint(&KeyExpression::from_str("@0/<1;2>/*").unwrap()));
+    }
+}

--- a/src/descriptor/wallet_policy/mod.rs
+++ b/src/descriptor/wallet_policy/mod.rs
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt::{self, Display};
+use core::str::FromStr;
+
+use super::key::XKeyParseError;
+use super::{DerivPaths, DescriptorKeyParseError, Wildcard};
+use crate::{Descriptor, DescriptorPublicKey, String, Translator, Vec};
+
+mod key_expression;
+
+use key_expression::{KeyExpression, KeyIndex};
+
+/// A wallet policy as described in BIP-388
+///
+///```rust
+/// use std::str::FromStr;
+/// use miniscript::{Descriptor, DescriptorPublicKey};
+/// use miniscript::descriptor::WalletPolicy;
+///
+/// // Convert from a `Descriptor<DescriptorPublicKey>`:
+/// let desc_str = "pkh([6738736c/44'/0'/0']xpub6Br37sWxruYfT8ASpCjVHKGwgdnYFEn98DwiN76i2oyY6fgH1LAPmmDcF46xjxJr22gw4jmVjTE2E3URMnRPEPYyo1zoPSUba563ESMXCeb/<0;1>/*)";
+/// let descriptor = Descriptor::<DescriptorPublicKey>::from_str(desc_str).unwrap();
+/// let policy1: WalletPolicy = (&descriptor).try_into().unwrap();
+///
+/// // Convert from a Descriptor<DescriptorPublicKey> string:
+/// let policy2 = WalletPolicy::from_str(desc_str).unwrap();
+/// assert_eq!(policy1, policy2);
+///
+/// // Convert from/to a wallet policy template string:
+/// let from_template = WalletPolicy::from_str("pkh(@0/**)").unwrap();
+/// assert_eq!(from_template.to_string(), "pkh(@0/**)");
+///
+/// // Cannot go back into descriptor if you created from template:
+/// assert!(from_template.into_descriptor().is_err());
+///
+/// // Convert into a full descriptor:
+/// assert_eq!(policy1.into_descriptor().unwrap(), descriptor);
+///```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletPolicy {
+    /// Wallet descriptor template
+    template: Descriptor<KeyExpression>,
+    /// Vector of key information items
+    key_info: Vec<DescriptorPublicKey>,
+}
+
+struct WalletPolicyTranslator {
+    key_info: Vec<DescriptorPublicKey>,
+}
+
+impl Translator<KeyExpression> for WalletPolicyTranslator {
+    type TargetPk = DescriptorPublicKey;
+    type Error = WalletPolicyError;
+
+    fn pk(&mut self, pk: &KeyExpression) -> Result<Self::TargetPk, Self::Error> {
+        let idx = pk.index.0 as usize;
+        self.key_info
+            .get(idx)
+            .cloned()
+            .ok_or(WalletPolicyError::KeyInfoInvalidKeyIndex(idx))
+    }
+
+    translate_hash_fail!(KeyExpression, DescriptorPublicKey, Self::Error);
+}
+
+impl Translator<DescriptorPublicKey> for WalletPolicyTranslator {
+    type TargetPk = KeyExpression;
+    type Error = WalletPolicyError;
+
+    fn pk(&mut self, pk: &DescriptorPublicKey) -> Result<Self::TargetPk, Self::Error> {
+        let ke = KeyExpression {
+            // FIXME: use a BTreeSet here? maybe doesn't really matter
+            index: KeyIndex(self.key_info.iter().position(|p| p == pk).unwrap() as u32),
+            derivation_paths: DerivPaths::new(pk.derivation_paths())
+                .ok_or(WalletPolicyError::TranslatorEmptyDerivationPaths)?,
+            wildcard: pk
+                .wildcard()
+                .ok_or(WalletPolicyError::TranslatorMissingWildcard)?,
+        };
+        Ok(ke)
+    }
+
+    translate_hash_fail!(DescriptorPublicKey, KeyExpression, Self::Error);
+}
+
+impl WalletPolicy {
+    /// Create a new `WalletPolicy` from a
+    /// `Descriptor<DescriptorPublicKey>`. Does not validate the underlying
+    /// template.
+    pub fn from_descriptor_unchecked(
+        descriptor: &Descriptor<DescriptorPublicKey>,
+    ) -> Result<WalletPolicy, WalletPolicyError> {
+        let mut translator = WalletPolicyTranslator { key_info: descriptor.iter_pk().collect() };
+        Ok(WalletPolicy {
+            template: descriptor.translate_pk(&mut translator).map_err(|e| {
+                e.expect_translator_err("converting descriptor to wallet policy template")
+            })?,
+            key_info: translator.key_info,
+        })
+    }
+
+    /// Create a new `WalletPolicy` from a `Descriptor<DescriptorPublicKey>` and
+    /// validates the underyling template.
+    pub fn from_descriptor(
+        descriptor: &Descriptor<DescriptorPublicKey>,
+    ) -> Result<WalletPolicy, WalletPolicyError> {
+        WalletPolicy::from_descriptor_unchecked(descriptor).and_then(WalletPolicy::validate)
+    }
+
+    /// Convert a `WalletPolicy` into a `Descriptor<DescriptorPublicKey>` using
+    /// the underlying template and key information.
+    pub fn into_descriptor(self) -> Result<Descriptor<DescriptorPublicKey>, WalletPolicyError> {
+        self.template
+            .translate_pk(&mut WalletPolicyTranslator { key_info: self.key_info })
+            .map_err(|e| e.expect_translator_err("converting to full descriptor"))
+    }
+
+    /// Sets the key information so that `WalletPolicy::into_descriptor` can be
+    /// called successfully. Errors when there are not enough keys for the template.
+    pub fn set_key_info(&mut self, keys: &[DescriptorPublicKey]) -> Result<(), WalletPolicyError> {
+        if keys.len() != self.template.iter_pk().count() {
+            return Err(WalletPolicyError::WalletPolicyInvalidKeyInfo);
+        }
+        self.key_info = keys.to_vec();
+        Ok(())
+    }
+
+    /// Validates the wallet policy template.
+    #[must_use = "Wallet policy won't be considered valid until this is called"]
+    fn validate(self) -> Result<WalletPolicy, WalletPolicyError> {
+        // HACK: don't know how else to prevent the following invalid cases from
+        // the test vectors while still using the current Descriptor parsing:
+        // skipped or out of order placeholders, repeated placeholds,
+        // non-disjoin multipath expressions
+        let mut prev: Option<KeyExpression> = None;
+        for key in self.template.iter_pk() {
+            if let (Some(prev), curr) = (&prev, &key) {
+                if prev.index.0 > curr.index.0 || prev.index.0 != curr.index.0.saturating_sub(1) {
+                    return Err(WalletPolicyError::TemplateValidationKeyIndexOutOfOrder);
+                } else if prev.index.0 == curr.index.0 && !prev.is_disjoint(curr) {
+                    return Err(WalletPolicyError::TemplateValidationNonDisjointPaths);
+                }
+            }
+            prev = Some(key);
+        }
+        Ok(self)
+    }
+}
+
+impl Display for WalletPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{:#}", self.template) }
+}
+
+impl TryFrom<&Descriptor<DescriptorPublicKey>> for WalletPolicy {
+    type Error = WalletPolicyError;
+
+    fn try_from(desc: &Descriptor<DescriptorPublicKey>) -> Result<Self, Self::Error> {
+        WalletPolicy::from_descriptor(desc)
+    }
+}
+
+impl TryFrom<&str> for WalletPolicy {
+    type Error = WalletPolicyError;
+
+    fn try_from(desc: &str) -> Result<Self, Self::Error> {
+        match Descriptor::<KeyExpression>::from_str(desc) {
+            Ok(template) => Ok(WalletPolicy { template, key_info: vec![] }.validate()?),
+            Err(err1) => match Descriptor::<DescriptorPublicKey>::from_str(desc) {
+                Ok(desc) => Ok(WalletPolicy::from_descriptor(&desc)?),
+                Err(err2) => Err(WalletPolicyError::WalletPolicyParseFromString(format!(
+                    "Couldn't parse from descriptor [{err1}], or wallet policy template: [{err2}]"
+                ))),
+            },
+        }
+    }
+}
+
+impl FromStr for WalletPolicy {
+    type Err = WalletPolicyError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> { s.try_into() }
+}
+
+/// WalletPolicy errors
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum WalletPolicyError {
+    /// A derivation path must be present when parsing a KeyExpression
+    KeyExpressionParseMustHaveDerivPath,
+    /// The derivation path for a KeyExpression is invalid
+    KeyExpressionParseInvalidDerivPath,
+    /// The KeyIndex is missing an '@' sign
+    KeyIndexParseExpectedAtSign(char),
+    /// The KeyIndex is not a valid unsigned integer
+    KeyIndexParseInvalidIndex(String),
+    /// The key info is not found for the given index
+    KeyInfoInvalidKeyIndex(usize),
+    /// The key indexes in the template are out of order
+    TemplateValidationKeyIndexOutOfOrder,
+    /// The key indexes in the template are the same but the paths are non-disjoint
+    TemplateValidationNonDisjointPaths,
+    /// There must be at least one derivation path for a xpub
+    TranslatorEmptyDerivationPaths,
+    /// Missing wildcard on xpub
+    TranslatorMissingWildcard,
+    /// Couldn't parse wallet policy from string
+    WalletPolicyParseFromString(String),
+    /// Couldn't set key info on WalletPolicy
+    WalletPolicyInvalidKeyInfo,
+}
+
+impl From<WalletPolicyError> for DescriptorKeyParseError {
+    fn from(err: WalletPolicyError) -> Self {
+        DescriptorKeyParseError::XKeyParseError(XKeyParseError::Bip388(err))
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for WalletPolicyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> { None }
+}
+
+impl Display for WalletPolicyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            WalletPolicyError::KeyExpressionParseMustHaveDerivPath => {
+                write!(f, "Key expression placeholder must have a derivation path after it")
+            }
+            WalletPolicyError::KeyExpressionParseInvalidDerivPath => {
+                write!(
+                    f,
+                    "Key expression placeholder must be of the format \"/**\" or \"/<NUM;NUM>/*\""
+                )
+            }
+            WalletPolicyError::KeyIndexParseInvalidIndex(index_str) => {
+                write!(f, "Couldn't parse index, got {index_str}")
+            }
+            WalletPolicyError::KeyIndexParseExpectedAtSign(ch) => {
+                write!(f, "Expected KeyIndex '@' sign, got {ch}")
+            }
+            WalletPolicyError::KeyInfoInvalidKeyIndex(idx) => {
+                write!(f, "Invalid index [{idx}] into key info for wallet policy")
+            }
+            WalletPolicyError::TemplateValidationKeyIndexOutOfOrder => {
+                write!(f, "The template has indexes that are out of order")
+            }
+            WalletPolicyError::TemplateValidationNonDisjointPaths => {
+                write!(f, "The template has identical indexes but the paths are non-disjoint")
+            }
+            WalletPolicyError::TranslatorEmptyDerivationPaths => {
+                write!(f, "Expected derivation paths when translating into KeyExpression")
+            }
+            WalletPolicyError::TranslatorMissingWildcard => {
+                write!(f, "Missing wildcard. Not an xpub?")
+            }
+            WalletPolicyError::WalletPolicyParseFromString(msg) => msg.fmt(f),
+            WalletPolicyError::WalletPolicyInvalidKeyInfo => {
+                write!(f, "Invalid key information for WalletPolicy template")
+            }
+        }
+    }
+}
+
+impl From<WalletPolicyError> for XKeyParseError {
+    fn from(err: WalletPolicyError) -> Self { XKeyParseError::Bip388(err) }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::Descriptor;
+
+    const VALID_TEMPLATES: &[(&str, &str)] = &[
+    (
+        "pkh(@0/**)",
+        "pkh([6738736c/44'/0'/0']xpub6Br37sWxruYfT8ASpCjVHKGwgdnYFEn98DwiN76i2oyY6fgH1LAPmmDcF46xjxJr22gw4jmVjTE2E3URMnRPEPYyo1zoPSUba563ESMXCeb/<0;1>/*)"
+    ),
+    (
+        "sh(wpkh(@0/**))",
+        "sh(wpkh([6738736c/49'/0'/1']xpub6Bex1CHWGXNNwGVKHLqNC7kcV348FxkCxpZXyCWp1k27kin8sRPayjZUKDjyQeZzGUdyeAj2emoW5zStFFUAHRgd5w8iVVbLgZ7PmjAKAm9/<0;1>/*))"
+    ),
+    (
+        "wpkh(@0/**)",
+        "wpkh([6738736c/84'/0'/2']xpub6CRQzb8u9dmMcq5XAwwRn9gcoYCjndJkhKgD11WKzbVGd932UmrExWFxCAvRnDN3ez6ZujLmMvmLBaSWdfWVn75L83Qxu1qSX4fJNrJg2Gt/<0;1>/*)"
+    ),
+    (
+        "tr(@0/**)",
+        "tr([6738736c/86'/0'/0']xpub6CryUDWPS28eR2cDyojB8G354izmx294BdjeSvH469Ty3o2E6Tq5VjBJCn8rWBgesvTJnyXNAJ3QpLFGuNwqFXNt3gn612raffLWfdHNkYL/<0;1>/*)"
+    ),
+    (
+        "wsh(sortedmulti(2,@0/**,@1/**))",
+        "wsh(sortedmulti(2,[6738736c/48'/0'/0'/2']xpub6FC1fXFP1GXLX5TKtcjHGT4q89SDRehkQLtbKJ2PzWcvbBHtyDsJPLtpLtkGqYNYZdVVAjRQ5kug9CsapegmmeRutpP7PW4u4wVF9JfkDhw/<0;1>/*,[b2b1f0cf/48'/0'/0'/2']xpub6EWhjpPa6FqrcaPBuGBZRJVjzGJ1ZsMygRF26RwN932Vfkn1gyCiTbECVitBjRCkexEvetLdiqzTcYimmzYxyR1BZ79KNevgt61PDcukmC7/<0;1>/*))"
+    ),
+    (
+        "wsh(thresh(3,pk(@0/**),s:pk(@1/**),s:pk(@2/**),sln:older(12960)))",
+        "wsh(thresh(3,pk([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa/<0;1>/*),s:pk([b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js/<0;1>/*),s:pk([a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2/<0;1>/*),sln:older(12960)))"
+    ),
+    (
+        "wsh(or_d(pk(@0/**),and_v(v:multi(2,@1/**,@2/**,@3/**),older(65535))))",
+        "wsh(or_d(pk([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa/<0;1>/*),and_v(v:multi(2,[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js/<0;1>/*,[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2/<0;1>/*,[bb641298/44'/0'/0'/100']xpub6Dz8PHFmXkYkykQ83ySkruky567XtJb9N69uXScJZqweYiQn6FyieajdiyjCvWzRZ2GoLHMRE1cwDfuJZ6461YvNRGVBJNnLA35cZrQKSRJ/<0;1>/*),older(65535))))"
+    ),
+    (
+       "sh(multi(1,@0/**,@0/<2;3>/*))",
+       "sh(multi(1,xpub6Bex1CHWGXNNwGVKHLqNC7kcV348FxkCxpZXyCWp1k27kin8sRPayjZUKDjyQeZzGUdyeAj2emoW5zStFFUAHRgd5w8iVVbLgZ7PmjAKAm9/<0;1>/*,xpub6Bex1CHWGXNNwGVKHLqNC7kcV348FxkCxpZXyCWp1k27kin8sRPayjZUKDjyQeZzGUdyeAj2emoW5zStFFUAHRgd5w8iVVbLgZ7PmjAKAm9/<2;3>/*))"
+    ),
+    // TODO: uncomment if BIP-390 is ever supported
+    // (
+    //     "tr(@0/**,{sortedmulti_a(1,@0/<2;3>/*,@1/**),or_b(pk(@2/**),s:pk(@3/**))})",
+    //     "tr([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa/<0;1>/*,{sortedmulti_a(1,[6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa/<2;3>/*,xpub6Fc2TRaCWNgfT49nRGG2G78d1dPnjhW66gEXi7oYZML7qEFN8e21b2DLDipTZZnfV6V7ivrMkvh4VbnHY2ChHTS9qM3XVLJiAgcfagYQk6K/<0;1>/*),or_b(pk(xpub6GxHB9kRdFfTqYka8tgtX9Gh3Td3A9XS8uakUGVcJ9NGZ1uLrGZrRVr67DjpMNCHprZmVmceFTY4X4wWfksy8nVwPiNvzJ5pjLxzPtpnfEM/<0;1>/*),s:pk(xpub6GjFUVVYewLj5no5uoNKCWuyWhQ1rKGvV8DgXBG9Uc6DvAKxt2dhrj1EZFrTNB5qxAoBkVW3wF8uCS3q1ri9fueAa6y7heFTcf27Q4gyeh6/<0;1>/*))})"
+    // ),
+    // (
+    //     "tr(musig(@0,@1,@2)/**,{and_v(v:pk(musig(@0,@1)/**),older(12960)),{and_v(v:pk(musig(@0,@2)/**),older(12960)),and_v(v:pk(musig(@1,@2)/**),older(12960))}})",
+    //     "tr(musig([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa,[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js,[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2)/<0;1>/*,{and_v(v:pk(musig([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa,[b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js)/<0;1>/*),older(12960)),{and_v(v:pk(musig([6738736c/48'/0'/0'/100']xpub6FC1fXFP1GXQpyRFfSE1vzzySqs3Vg63bzimYLeqtNUYbzA87kMNTcuy9ubr7MmavGRjW2FRYHP4WGKjwutbf1ghgkUW9H7e3ceaPLRcVwa,[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2)/<0;1>/*),older(12960)),and_v(v:pk(musig([b2b1f0cf/44'/0'/0'/100']xpub6EYajCJHe2CK53RLVXrN14uWoEttZgrRSaRztujsXg7yRhGtHmLBt9ot9Pd5ugfwWEu6eWyJYKSshyvZFKDXiNbBcoK42KRZbxwjRQpm5Js,[a666a867/44'/0'/0'/100']xpub6Dgsze3ujLi1EiHoCtHFMS9VLS1UheVqxrHGfP7sBJ2DBfChEUHV4MDwmxAXR2ayeytpwm3zJEU3H3pjCR6q6U5sP2p2qzAD71x9z5QShK2)/<0;1>/*),older(12960))}})"
+    // ),
+    ];
+
+    const INVALID_TEMPLATES: &[&str] = &[
+    // Key placeholder with no path following it
+    "pkh(@0)",
+
+    // Key placeholder with an explicit path present
+    "pkh(@0/0/**)",
+
+    // Key placeholders out of order
+    "sh(multi(1,@1/**,@0/**))",
+
+    // Skipped key placeholder @1
+    "sh(multi(1,@0/**,@2/**))",
+
+    // Repeated keys with the same path expression
+    "sh(multi(1,@0/**,@0/**))",
+
+    // Non-disjoint multipath expressions (@0/1/* appears twice)
+    "sh(multi(1,@0/<0;1>/*,@0/<1;2>/*))",
+
+    // Expression with a non-KP key present
+    "sh(multi(1,@0/**,xpub6AHA9hZDN11k2ijHMeS5QqHx2KP9aMBRhTDqANMnwVtdyw2TDYRmF8PjpvwUFcL1Et8Hj59S3gTSMcUQ5gAqTz3Wd8EsMTmF3DChhqPQBnU/<0;1>/*))",
+
+    // Allowed cardinality > 2
+    "pkh(@0/<0;1;2>/*)",
+
+    // Derivation before aggregation is not allowed in wallet policies (despite
+        // being allowed in BIP-390)
+        // TODO: uncomment if BIP-390 is ever supported
+    // "tr(musig(@0/**,@1/**))",
+];
+
+    #[test]
+    fn can_parse_valid_wallet_policy_templates() {
+        for (t, desc) in VALID_TEMPLATES {
+            let descriptor = Descriptor::<DescriptorPublicKey>::from_str(desc).unwrap();
+            let policy = WalletPolicy::from_str(desc).expect("invalid descriptor");
+            let template = WalletPolicy::from_str(t).expect("invalid template");
+            assert_eq!(format!("{:#}", template.template), *t);
+            assert_eq!(policy.into_descriptor().unwrap(), descriptor);
+        }
+    }
+
+    #[test]
+    fn can_error_on_invalid_wallet_policy_templates() {
+        for t in INVALID_TEMPLATES {
+            assert!(WalletPolicy::from_str(t).is_err());
+        }
+    }
+
+    #[test]
+    fn can_set_key_info() {
+        let mut template_only =
+            WalletPolicy::from_str("wsh(sortedmulti(2,@0/**,@1/**))").expect("invalid template");
+        assert!(template_only.clone().into_descriptor().is_err());
+        let keys = ["[6738736c/48'/0'/0'/2']xpub6FC1fXFP1GXLX5TKtcjHGT4q89SDRehkQLtbKJ2PzWcvbBHtyDsJPLtpLtkGqYNYZdVVAjRQ5kug9CsapegmmeRutpP7PW4u4wVF9JfkDhw", "[b2b1f0cf/48'/0'/0'/2']xpub6EWhjpPa6FqrcaPBuGBZRJVjzGJ1ZsMygRF26RwN932Vfkn1gyCiTbECVitBjRCkexEvetLdiqzTcYimmzYxyR1BZ79KNevgt61PDcukmC7"]
+            .into_iter()
+            .map(FromStr::from_str)
+            .collect::<Result<Vec<DescriptorPublicKey>, _>>()
+            .unwrap();
+        template_only.set_key_info(&keys).unwrap();
+        assert!(template_only.clone().into_descriptor().is_ok());
+    }
+}

--- a/src/descriptor/wallet_policy/mod.rs
+++ b/src/descriptor/wallet_policy/mod.rs
@@ -3,9 +3,11 @@
 use core::fmt::{self, Display};
 use core::str::FromStr;
 
+use bitcoin::hashes::{hash160, ripemd160, sha256};
+
 use super::key::XKeyParseError;
 use super::{DerivPaths, DescriptorKeyParseError, Wildcard};
-use crate::{BTreeSet, Descriptor, DescriptorPublicKey, String, Translator, Vec};
+use crate::{BTreeSet, Descriptor, DescriptorPublicKey, String, ToString, Translator, Vec};
 
 mod key_expression;
 
@@ -61,7 +63,30 @@ impl Translator<KeyExpression> for WalletPolicyTranslator {
             .ok_or(WalletPolicyError::KeyInfoInvalidKeyIndex(idx))
     }
 
-    translate_hash_fail!(KeyExpression, DescriptorPublicKey, Self::Error);
+    // Hash terminals: KeyExpression stores hashes as hex `String` (for
+    // template round-tripping), DescriptorPublicKey uses the concrete
+    // `bitcoin::hashes::*::Hash` types. Parse the hex string into the
+    // binary form during materialization.
+
+    fn sha256(&mut self, s: &String) -> Result<sha256::Hash, Self::Error> {
+        s.parse::<sha256::Hash>()
+            .map_err(|_| WalletPolicyError::TranslatorInvalidHashHex("sha256", s.clone()))
+    }
+
+    fn hash256(&mut self, s: &String) -> Result<crate::hash256::Hash, Self::Error> {
+        s.parse::<crate::hash256::Hash>()
+            .map_err(|_| WalletPolicyError::TranslatorInvalidHashHex("hash256", s.clone()))
+    }
+
+    fn ripemd160(&mut self, s: &String) -> Result<ripemd160::Hash, Self::Error> {
+        s.parse::<ripemd160::Hash>()
+            .map_err(|_| WalletPolicyError::TranslatorInvalidHashHex("ripemd160", s.clone()))
+    }
+
+    fn hash160(&mut self, s: &String) -> Result<hash160::Hash, Self::Error> {
+        s.parse::<hash160::Hash>()
+            .map_err(|_| WalletPolicyError::TranslatorInvalidHashHex("hash160", s.clone()))
+    }
 }
 
 impl Translator<DescriptorPublicKey> for WalletPolicyTranslator {
@@ -81,7 +106,22 @@ impl Translator<DescriptorPublicKey> for WalletPolicyTranslator {
         Ok(ke)
     }
 
-    translate_hash_fail!(DescriptorPublicKey, KeyExpression, Self::Error);
+    // Hash terminals: DescriptorPublicKey uses concrete Hash types,
+    // KeyExpression stores them as hex `String`. Render to lowercase hex
+    // (the `Display` impl on `bitcoin::hashes::*::Hash`) so the resulting
+    // template prints hashes in their canonical form.
+
+    fn sha256(&mut self, h: &sha256::Hash) -> Result<String, Self::Error> { Ok(h.to_string()) }
+
+    fn hash256(&mut self, h: &crate::hash256::Hash) -> Result<String, Self::Error> {
+        Ok(h.to_string())
+    }
+
+    fn ripemd160(&mut self, h: &ripemd160::Hash) -> Result<String, Self::Error> {
+        Ok(h.to_string())
+    }
+
+    fn hash160(&mut self, h: &hash160::Hash) -> Result<String, Self::Error> { Ok(h.to_string()) }
 }
 
 impl WalletPolicy {
@@ -208,6 +248,8 @@ pub enum WalletPolicyError {
     WalletPolicyParseFromString(String),
     /// Couldn't set key info on WalletPolicy
     WalletPolicyInvalidKeyInfo,
+    /// Hash terminal in template had invalid hex (kind, raw input)
+    TranslatorInvalidHashHex(&'static str, String),
 }
 
 impl From<WalletPolicyError> for DescriptorKeyParseError {
@@ -257,6 +299,9 @@ impl Display for WalletPolicyError {
             WalletPolicyError::WalletPolicyParseFromString(msg) => msg.fmt(f),
             WalletPolicyError::WalletPolicyInvalidKeyInfo => {
                 write!(f, "Invalid key information for WalletPolicy template")
+            }
+            WalletPolicyError::TranslatorInvalidHashHex(kind, raw) => {
+                write!(f, "Invalid hex for {kind} hash terminal: {raw}")
             }
         }
     }
@@ -364,6 +409,68 @@ mod tests {
         for t in INVALID_TEMPLATES {
             assert!(WalletPolicy::from_str(t).is_err());
         }
+    }
+
+    // Hash-terminal round-trip tests. Before this fix the translator used
+    // `translate_hash_fail!` and `into_descriptor` returned an error on any
+    // hash terminal; BIP 388 places no restriction on them.
+
+    // BIP 84 mainnet origin; same xpub as VALID_TEMPLATES.
+    const TEST_XPUB: &str = "[6738736c/84'/0'/0']xpub6CRQzb8u9dmMcq5XAwwRn9gcoYCjndJkhKgD11WKzbVGd932UmrExWFxCAvRnDN3ez6ZujLmMvmLBaSWdfWVn75L83Qxu1qSX4fJNrJg2Gt/<0;1>/*";
+
+    // (kind, lowercase-hex of correct byte length).
+    const HASH_VECTORS: &[(&str, &str)] = &[
+        ("sha256", "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"),
+        ("hash256", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+        ("ripemd160", "1234567890abcdef1234567890abcdef12345678"),
+        ("hash160", "fedcba0987654321fedcba0987654321fedcba09"),
+    ];
+
+    #[test]
+    fn hash_terminals_round_trip() {
+        for &(kind, hex) in HASH_VECTORS {
+            let s = format!("wsh(and_v(v:pk({TEST_XPUB}),{kind}({hex})))");
+            let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&s).unwrap();
+            let policy = WalletPolicy::from_str(&s).unwrap();
+            assert_eq!(policy.into_descriptor().unwrap(), descriptor);
+        }
+    }
+
+    #[test]
+    fn mixed_hash_terminals_round_trip() {
+        // All distinct pairs of hash kinds in one policy. Catches cross-type
+        // dispatch errors, including byte-order quirks specific to hash256.
+        for (i, &(a_kind, a_hex)) in HASH_VECTORS.iter().enumerate() {
+            for &(b_kind, b_hex) in HASH_VECTORS.iter().skip(i + 1) {
+                let s = format!(
+                    "wsh(and_v(v:and_v(v:pk({TEST_XPUB}),{a_kind}({a_hex})),{b_kind}({b_hex})))"
+                );
+                let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&s).unwrap();
+                let policy = WalletPolicy::from_str(&s).unwrap();
+                assert_eq!(policy.into_descriptor().unwrap(), descriptor);
+            }
+        }
+    }
+
+    // The public parser validates hex length up-front, so invalid hex
+    // never reaches the translator through `from_str`. This drives the
+    // translator directly to pin the defensive `TranslatorInvalidHashHex`
+    // variant.
+    #[test]
+    fn translator_invalid_hash_hex_errors() {
+        let mut t = WalletPolicyTranslator { key_info: Vec::new() };
+        let bad = String::from("not_hex");
+
+        macro_rules! assert_bad {
+            ($method:ident, $kind:literal) => {{
+                let err = Translator::<KeyExpression>::$method(&mut t, &bad).unwrap_err();
+                assert!(matches!(err, WalletPolicyError::TranslatorInvalidHashHex($kind, _)));
+            }};
+        }
+        assert_bad!(sha256, "sha256");
+        assert_bad!(hash256, "hash256");
+        assert_bad!(ripemd160, "ripemd160");
+        assert_bad!(hash160, "hash160");
     }
 
     #[test]

--- a/src/descriptor/wallet_policy/mod.rs
+++ b/src/descriptor/wallet_policy/mod.rs
@@ -379,4 +379,27 @@ mod tests {
         template_only.set_key_info(&keys).unwrap();
         assert!(template_only.clone().into_descriptor().is_ok());
     }
+
+    // Regression test for a bug where set_key_info() counted key-expression
+    // occurrences instead of unique placeholder indices. A template reusing @0
+    // with disjoint paths (e.g. @0/**,@0/<2;3>/*) has 2 occurrences but only 1
+    // unique placeholder. The old code accepted 2 keys, silently dropping the
+    // second one during descriptor translation since both @0 resolve to
+    // key_info[0].
+    // Reported by jm@squareup.com
+    #[test]
+    fn set_key_info_rejects_extra_keys_for_repeated_placeholder() {
+        let mut policy = WalletPolicy::from_str("wsh(sortedmulti(2,@0/**,@0/<2;3>/*))").unwrap();
+        let attacker_key: DescriptorPublicKey = "[6738736c/48'/0'/0'/2']xpub6FC1fXFP1GXLX5TKtcjHGT4q89SDRehkQLtbKJ2PzWcvbBHtyDsJPLtpLtkGqYNYZdVVAjRQ5kug9CsapegmmeRutpP7PW4u4wVF9JfkDhw".parse().unwrap();
+        let victim_key: DescriptorPublicKey = "[b2b1f0cf/48'/0'/0'/2']xpub6EWhjpPa6FqrcaPBuGBZRJVjzGJ1ZsMygRF26RwN932Vfkn1gyCiTbECVitBjRCkexEvetLdiqzTcYimmzYxyR1BZ79KNevgt61PDcukmC7".parse().unwrap();
+
+        // Must reject: 2 keys provided but only 1 unique placeholder (@0)
+        assert_eq!(
+            policy.set_key_info(&[attacker_key.clone(), victim_key]),
+            Err(WalletPolicyError::WalletPolicyInvalidKeyInfo),
+        );
+
+        // Must accept: 1 key for 1 unique placeholder
+        assert!(policy.set_key_info(&[attacker_key]).is_ok());
+    }
 }

--- a/src/descriptor/wallet_policy/mod.rs
+++ b/src/descriptor/wallet_policy/mod.rs
@@ -5,7 +5,7 @@ use core::str::FromStr;
 
 use super::key::XKeyParseError;
 use super::{DerivPaths, DescriptorKeyParseError, Wildcard};
-use crate::{Descriptor, DescriptorPublicKey, String, Translator, Vec};
+use crate::{BTreeSet, Descriptor, DescriptorPublicKey, String, Translator, Vec};
 
 mod key_expression;
 
@@ -119,7 +119,9 @@ impl WalletPolicy {
     /// Sets the key information so that `WalletPolicy::into_descriptor` can be
     /// called successfully. Errors when there are not enough keys for the template.
     pub fn set_key_info(&mut self, keys: &[DescriptorPublicKey]) -> Result<(), WalletPolicyError> {
-        if keys.len() != self.template.iter_pk().count() {
+        let unique_placeholders: BTreeSet<u32> =
+            self.template.iter_pk().map(|k| k.index.0).collect();
+        if keys.len() != unique_placeholders.len() {
             return Err(WalletPolicyError::WalletPolicyInvalidKeyInfo);
         }
         self.key_info = keys.to_vec();


### PR DESCRIPTION
Backports PRs by cherry-picking all commits:

- [PR #898](https://github.com/rust-bitcoin/rust-miniscript/pull/898)
- [PR #932](https://github.com/rust-bitcoin/rust-miniscript/pull/932)
- [PR #935](https://github.com/rust-bitcoin/rust-miniscript/pull/935)

For supporting external issue [bhwi #68](https://github.com/wizardsardine/bhwi/issues/68) to move from git commit pinning to a released crate.