### PR TITLE
fix(typecheck): correct d: and hash-fragment witness counting

### DIFF
--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -2206,4 +2206,48 @@ mod tests {
             "The Miniscript corresponding Script cannot be larger than 10000 bytes, but got 10275 bytes."
         );
     }
+    #[test]
+    fn satisfaction_size_matches_template() {
+        // The satisfaction sizes stored in `ExtData` must agree with the
+        // witness template the satisfier produces, whose elements are sized by
+        // `Placeholder::size`.
+        //
+        // A `d:` satisfaction pushes a single `<1>` element, which takes two
+        // bytes on the witness stack (its length prefix plus the byte itself),
+        // and dissatisfying a hash fragment pushes a single 32-byte element.
+        struct HasSigFor(bitcoin::PublicKey);
+
+        impl crate::plan::AssetProvider<bitcoin::PublicKey> for HasSigFor {
+            fn provider_lookup_ecdsa_sig(&self, pk: &bitcoin::PublicKey) -> bool { *pk == self.0 }
+
+            fn check_older(&self, _: bitcoin::relative::LockTime) -> bool { true }
+        }
+
+        let keys = pubkeys(2);
+        let hash = sha256::Hash::hash(&[]);
+
+        for ms_str in [
+            // The `<1>` of the `d:` wrapper is the whole satisfaction.
+            "dv:older(144)".to_owned(),
+            // Only the second key can sign and the preimage is unknown, so the
+            // satisfaction dissatisfies the hash and signs with that key.
+            format!("andor(sha256({}),pk({}),pk({}))", hash, keys[0], keys[1]),
+        ] {
+            let ms = Segwitv0Script::from_str_insane(&ms_str).unwrap();
+            let template = ms.build_template(&HasSigFor(keys[1]));
+            let stack = match template.stack {
+                crate::miniscript::satisfy::Witness::Stack(stack) => stack,
+                _ => panic!("{} should be satisfiable", ms_str),
+            };
+
+            let size: usize = stack.iter().map(crate::util::ItemSize::size).sum();
+            assert_eq!(ms.max_satisfaction_size().unwrap(), size, "{}", ms_str);
+            assert_eq!(
+                ms.max_satisfaction_witness_elements().unwrap(),
+                stack.len() + 1,
+                "{}",
+                ms_str
+            );
+        }
+    }
 }

--- a/src/miniscript/types/extra_props.rs
+++ b/src/miniscript/types/extra_props.rs
@@ -360,8 +360,9 @@ impl ExtData {
                 max_exec_op_count: 0,
             }),
             dissat_data: Some(SatData {
+                // A hash dissatisfaction is a single 32-byte element.
                 max_witness_stack_size: 33,
-                max_witness_stack_count: 2,
+                max_witness_stack_count: 1,
                 max_script_sig_size: 33,
                 max_exec_stack_count: 2, // either size <32> or <sha256> <32 byte>
                 max_exec_op_count: 0,
@@ -385,8 +386,9 @@ impl ExtData {
                 max_exec_op_count: 0,
             }),
             dissat_data: Some(SatData {
+                // A hash dissatisfaction is a single 32-byte element.
                 max_witness_stack_size: 33,
-                max_witness_stack_count: 2,
+                max_witness_stack_count: 1,
                 max_script_sig_size: 33,
                 max_exec_stack_count: 2, // either size <32> or <sha256> <32 byte>
                 max_exec_op_count: 0,
@@ -410,8 +412,9 @@ impl ExtData {
                 max_exec_op_count: 0,
             }),
             dissat_data: Some(SatData {
+                // A hash dissatisfaction is a single 32-byte element.
                 max_witness_stack_size: 33,
-                max_witness_stack_count: 2,
+                max_witness_stack_count: 1,
                 max_script_sig_size: 33,
                 max_exec_stack_count: 2, // either size <32> or <sha256> <32 byte>
                 max_exec_op_count: 0,
@@ -435,8 +438,9 @@ impl ExtData {
                 max_exec_op_count: 0,
             }),
             dissat_data: Some(SatData {
+                // A hash dissatisfaction is a single 32-byte element.
                 max_witness_stack_size: 33,
-                max_witness_stack_count: 2,
+                max_witness_stack_count: 1,
                 max_script_sig_size: 33,
                 max_exec_stack_count: 2, // either size <32> or <sha256> <32 byte>
                 max_exec_op_count: 0,
@@ -542,8 +546,11 @@ impl ExtData {
             has_free_verify: false,
             static_ops: 3 + self.static_ops,
             sat_data: self.sat_data.map(|data| SatData {
-                max_witness_stack_size: data.max_witness_stack_size + 1,
-                max_witness_stack_count: data.max_witness_stack_count + 2,
+                // The satisfaction pushes a single element holding 0x01, which
+                // is two bytes in a witness (its length prefix and the byte
+                // itself) and one byte in a scriptsig (OP_1).
+                max_witness_stack_size: data.max_witness_stack_size + 2,
+                max_witness_stack_count: data.max_witness_stack_count + 1,
                 max_script_sig_size: data.max_script_sig_size + 1,
                 // Note: in practice this cmp::max always evaluates to data.max_exec_stack_count.
                 max_exec_stack_count: cmp::max(1, data.max_exec_stack_count),


### PR DESCRIPTION
Two of the values that #859 (f57cac0 "typeck: pull satisfaction/
dissatisfaction limits into struct") moved into `SatData` ended up in the
wrong field, so `ExtData` no longer agrees with the witness the satisfier
produces:

* `cast_dupif` used to add `(w + 2, s + 1)` to the (witness size,
  scriptsig size) pair and 1 to the element count. It now adds 1 to the
  witness size and 2 to the element count: the witness size took the
  scriptsig's increment and the count took the witness size's. A `d:`
  satisfaction pushes a single element holding `0x01`, which is two bytes
  in a witness (its length prefix and the byte itself) and one byte in a
  scriptsig (`OP_1`), one element either way. `Placeholder::PushOne`
  sizes that element as two, and `or_i`, whose `<1>` selector is the very
  same element, still adds `(2, 1)`.

* The four hash fragments used to have a `stack_elem_count_dissat` of 1
  and now have a `dissat_data.max_witness_stack_count` of 2, which is the
  value of the `exec_stack_elem_count_dissat` that sat next to it.
  Dissatisfying a hash fragment pushes a single 32-byte element, as the
  33-byte `max_witness_stack_size` beside it already says.

The witness size of `d:` is the consequential one, because it is an
under-estimate and `max_satisfaction_size` feeds `max_weight_to_satisfy`
for every descriptor type: a bare, sh, wsh or tr descriptor whose
miniscript contains a `d:` wrapper under-states the weight of its input by
one weight unit per wrapper, so a fee computed from it lands below the
intended feerate. The two element counts are over-estimates, which only
cost their users precision.

Both are in 13.0.0, 13.0.1 and 13.1.0. This area of the same refactor has
needed one follow-up correction already (f3ea32c, the `thresh` execution
stack count).

Found while differential-testing an independent port of this crate, which
disagreed on the witness size of the expressions whose satisfaction goes
through a `d:` wrapper (242 of ~16k) and on the element count of the hash
dissatisfactions.