### PR TITLE
Manual update to rustc nightly-2026-08-21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ members = ["fuzz"]
 exclude = ["embedded", "bitcoind-tests"]
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-07-24"
+nightly = "nightly-2026-08-21"
 stable = "1.95.0"
 
 [workspace.lints.clippy]

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -6,7 +6,7 @@
 //!
 
 use core::num::NonZeroU32;
-use core::{f64, fmt, mem};
+use core::{fmt, mem};
 #[cfg(feature = "std")]
 use std::error;
 


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-miniscript/pull/1012
Supersedes https://github.com/rust-bitcoin/rust-miniscript/pull/1024
Supersedes https://github.com/rust-bitcoin/rust-miniscript/pull/1029

Fix a deprecation lint for `core::f64` failing on nightly.