### PR TITLE
fix(iter): translate_pk to iterate in left-to-right order

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -9,13 +9,72 @@
 
 mod tree;
 
+#[cfg(all(not(feature = "std"), not(test)))]
+use alloc::vec;
+#[cfg(any(feature = "std", test))]
+use std::vec;
+
 pub use tree::{
     PostOrderIter, PostOrderIterItem, PreOrderIter, PreOrderIterItem, Tree, TreeLike,
     VerbosePreOrderIter,
 };
 
+use crate::prelude::*;
 use crate::sync::Arc;
-use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal};
+use crate::{Miniscript, MiniscriptKey, ScriptContext, Terminal, Threshold};
+
+/// Extension trait for the stacks used by algorithms which reconstruct a tree
+/// from a [`TreeLike::post_order_iter`].
+///
+/// Since a post-order iterator yields children left-to-right, the children of
+/// a node appear in that same order at the top of the stack. These methods pop
+/// them off and hand them back in that order, rather than reversed as a bare
+/// sequence of [`Vec::pop`] calls would.
+pub(crate) trait StackExt<T> {
+    /// Pops the top two elements off of the stack and passes them, in
+    /// left-to-right order, to `f`.
+    fn pop2<R>(&mut self, f: impl FnOnce(T, T) -> R) -> R;
+
+    /// Pops the top three elements off of the stack and passes them, in
+    /// left-to-right order, to `f`.
+    fn pop3<R>(&mut self, f: impl FnOnce(T, T, T) -> R) -> R;
+
+    /// Pops the top `n` elements off of the stack, in left-to-right order.
+    fn pop_n(&mut self, n: usize) -> vec::Drain<'_, T>;
+
+    /// Pops the children of `thresh` off of the stack, in left-to-right order,
+    /// and reassembles them into a threshold with the same `k`.
+    fn pop_thresh<U, const MAX: usize>(&mut self, thresh: &Threshold<U, MAX>) -> Threshold<T, MAX>;
+}
+
+impl<T> StackExt<T> for Vec<T> {
+    #[inline]
+    fn pop2<R>(&mut self, f: impl FnOnce(T, T) -> R) -> R {
+        let b = self.pop().unwrap();
+        let a = self.pop().unwrap();
+        f(a, b)
+    }
+
+    #[inline]
+    fn pop3<R>(&mut self, f: impl FnOnce(T, T, T) -> R) -> R {
+        let c = self.pop().unwrap();
+        let b = self.pop().unwrap();
+        let a = self.pop().unwrap();
+        f(a, b, c)
+    }
+
+    #[inline]
+    fn pop_n(&mut self, n: usize) -> vec::Drain<'_, T> {
+        let start = self.len() - n;
+        self.drain(start..)
+    }
+
+    #[inline]
+    fn pop_thresh<U, const MAX: usize>(&mut self, thresh: &Threshold<U, MAX>) -> Threshold<T, MAX> {
+        let mut children = self.pop_n(thresh.n());
+        thresh.map_ref(|_| children.next().unwrap())
+    }
+}
 
 impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> TreeLike for &'a Miniscript<Pk, Ctx> {
     type NaryChildren = &'a [Arc<Miniscript<Pk, Ctx>>];

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -19,7 +19,7 @@ use bitcoin::script;
 use bitcoin::taproot::{LeafVersion, TapLeafHash};
 
 pub use self::context::{BareCtx, Legacy, Segwitv0, Tap};
-use crate::iter::TreeLike;
+use crate::iter::{StackExt as _, TreeLike};
 use crate::prelude::*;
 use crate::{script_num_size, TranslateErr};
 
@@ -55,7 +55,7 @@ mod private {
     use super::limits::{MAX_PUBKEYS_IN_CHECKSIGADD, MAX_PUBKEYS_PER_MULTISIG};
     use super::types::{self, ExtData, Type};
     use super::ScriptContext;
-    use crate::iter::TreeLike as _;
+    use crate::iter::{StackExt as _, TreeLike as _};
     use crate::prelude::sync::Arc;
     use crate::{
         AbsLockTime, Error, MiniscriptKey, RelLockTime, Terminal, ValidationError,
@@ -89,7 +89,7 @@ mod private {
         ///   and they can call `Miniscript::clone`.
         fn clone(&self) -> Self {
             let mut stack = vec![];
-            for item in self.rtl_post_order_iter() {
+            for item in self.post_order_iter() {
                 let new_term = match item.node.node {
                     Terminal::PkK(ref p) => Terminal::PkK(p.clone()),
                     Terminal::PkH(ref p) => Terminal::PkH(p.clone()),
@@ -109,24 +109,14 @@ mod private {
                     Terminal::Verify(..) => Terminal::Verify(stack.pop().unwrap()),
                     Terminal::NonZero(..) => Terminal::NonZero(stack.pop().unwrap()),
                     Terminal::ZeroNotEqual(..) => Terminal::ZeroNotEqual(stack.pop().unwrap()),
-                    Terminal::AndV(..) => {
-                        Terminal::AndV(stack.pop().unwrap(), stack.pop().unwrap())
-                    }
-                    Terminal::AndB(..) => {
-                        Terminal::AndB(stack.pop().unwrap(), stack.pop().unwrap())
-                    }
-                    Terminal::AndOr(..) => Terminal::AndOr(
-                        stack.pop().unwrap(),
-                        stack.pop().unwrap(),
-                        stack.pop().unwrap(),
-                    ),
-                    Terminal::OrB(..) => Terminal::OrB(stack.pop().unwrap(), stack.pop().unwrap()),
-                    Terminal::OrD(..) => Terminal::OrD(stack.pop().unwrap(), stack.pop().unwrap()),
-                    Terminal::OrC(..) => Terminal::OrC(stack.pop().unwrap(), stack.pop().unwrap()),
-                    Terminal::OrI(..) => Terminal::OrI(stack.pop().unwrap(), stack.pop().unwrap()),
-                    Terminal::Thresh(ref thresh) => {
-                        Terminal::Thresh(thresh.map_ref(|_| stack.pop().unwrap()))
-                    }
+                    Terminal::AndV(..) => stack.pop2(Terminal::AndV),
+                    Terminal::AndB(..) => stack.pop2(Terminal::AndB),
+                    Terminal::AndOr(..) => stack.pop3(Terminal::AndOr),
+                    Terminal::OrB(..) => stack.pop2(Terminal::OrB),
+                    Terminal::OrD(..) => stack.pop2(Terminal::OrD),
+                    Terminal::OrC(..) => stack.pop2(Terminal::OrC),
+                    Terminal::OrI(..) => stack.pop2(Terminal::OrI),
+                    Terminal::Thresh(ref thresh) => Terminal::Thresh(stack.pop_thresh(thresh)),
                     Terminal::Multi(ref thresh) => Terminal::Multi(thresh.clone()),
                     Terminal::SortedMulti(ref thresh) => Terminal::SortedMulti(thresh.clone()),
                     Terminal::MultiA(ref thresh) => Terminal::MultiA(thresh.clone()),
@@ -876,7 +866,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
         T: Translator<Pk>,
     {
         let mut translated = vec![];
-        for data in self.rtl_post_order_iter() {
+        for data in self.post_order_iter() {
             let new_term = match data.node.node {
                 Terminal::PkK(ref p) => Terminal::PkK(t.pk(p)?),
                 Terminal::PkH(ref p) => Terminal::PkH(t.pk(p)?),
@@ -896,32 +886,14 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
                 Terminal::Verify(..) => Terminal::Verify(translated.pop().unwrap()),
                 Terminal::NonZero(..) => Terminal::NonZero(translated.pop().unwrap()),
                 Terminal::ZeroNotEqual(..) => Terminal::ZeroNotEqual(translated.pop().unwrap()),
-                Terminal::AndV(..) => {
-                    Terminal::AndV(translated.pop().unwrap(), translated.pop().unwrap())
-                }
-                Terminal::AndB(..) => {
-                    Terminal::AndB(translated.pop().unwrap(), translated.pop().unwrap())
-                }
-                Terminal::AndOr(..) => Terminal::AndOr(
-                    translated.pop().unwrap(),
-                    translated.pop().unwrap(),
-                    translated.pop().unwrap(),
-                ),
-                Terminal::OrB(..) => {
-                    Terminal::OrB(translated.pop().unwrap(), translated.pop().unwrap())
-                }
-                Terminal::OrD(..) => {
-                    Terminal::OrD(translated.pop().unwrap(), translated.pop().unwrap())
-                }
-                Terminal::OrC(..) => {
-                    Terminal::OrC(translated.pop().unwrap(), translated.pop().unwrap())
-                }
-                Terminal::OrI(..) => {
-                    Terminal::OrI(translated.pop().unwrap(), translated.pop().unwrap())
-                }
-                Terminal::Thresh(ref thresh) => {
-                    Terminal::Thresh(thresh.map_ref(|_| translated.pop().unwrap()))
-                }
+                Terminal::AndV(..) => translated.pop2(Terminal::AndV),
+                Terminal::AndB(..) => translated.pop2(Terminal::AndB),
+                Terminal::AndOr(..) => translated.pop3(Terminal::AndOr),
+                Terminal::OrB(..) => translated.pop2(Terminal::OrB),
+                Terminal::OrD(..) => translated.pop2(Terminal::OrD),
+                Terminal::OrC(..) => translated.pop2(Terminal::OrC),
+                Terminal::OrI(..) => translated.pop2(Terminal::OrI),
+                Terminal::Thresh(ref thresh) => Terminal::Thresh(translated.pop_thresh(thresh)),
                 Terminal::Multi(ref thresh) => Terminal::Multi(thresh.translate_ref(|k| t.pk(k))?),
                 Terminal::SortedMulti(ref thresh) => {
                     Terminal::SortedMulti(thresh.translate_ref(|k| t.pk(k))?)
@@ -943,7 +915,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
     /// Substitutes raw public keys hashes with the public keys as provided by map.
     pub fn substitute_raw_pkh(&self, pk_map: &BTreeMap<hash160::Hash, Pk>) -> Self {
         let mut stack = vec![];
-        for item in self.rtl_post_order_iter() {
+        for item in self.post_order_iter() {
             let new_term = match item.node.node {
                 Terminal::PkK(ref p) => Terminal::PkK(p.clone()),
                 Terminal::PkH(ref p) => Terminal::PkH(p.clone()),
@@ -967,20 +939,14 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Miniscript<Pk, Ctx> {
                 Terminal::Verify(..) => Terminal::Verify(stack.pop().unwrap()),
                 Terminal::NonZero(..) => Terminal::NonZero(stack.pop().unwrap()),
                 Terminal::ZeroNotEqual(..) => Terminal::ZeroNotEqual(stack.pop().unwrap()),
-                Terminal::AndV(..) => Terminal::AndV(stack.pop().unwrap(), stack.pop().unwrap()),
-                Terminal::AndB(..) => Terminal::AndB(stack.pop().unwrap(), stack.pop().unwrap()),
-                Terminal::AndOr(..) => Terminal::AndOr(
-                    stack.pop().unwrap(),
-                    stack.pop().unwrap(),
-                    stack.pop().unwrap(),
-                ),
-                Terminal::OrB(..) => Terminal::OrB(stack.pop().unwrap(), stack.pop().unwrap()),
-                Terminal::OrD(..) => Terminal::OrD(stack.pop().unwrap(), stack.pop().unwrap()),
-                Terminal::OrC(..) => Terminal::OrC(stack.pop().unwrap(), stack.pop().unwrap()),
-                Terminal::OrI(..) => Terminal::OrI(stack.pop().unwrap(), stack.pop().unwrap()),
-                Terminal::Thresh(ref thresh) => {
-                    Terminal::Thresh(thresh.map_ref(|_| stack.pop().unwrap()))
-                }
+                Terminal::AndV(..) => stack.pop2(Terminal::AndV),
+                Terminal::AndB(..) => stack.pop2(Terminal::AndB),
+                Terminal::AndOr(..) => stack.pop3(Terminal::AndOr),
+                Terminal::OrB(..) => stack.pop2(Terminal::OrB),
+                Terminal::OrD(..) => stack.pop2(Terminal::OrD),
+                Terminal::OrC(..) => stack.pop2(Terminal::OrC),
+                Terminal::OrI(..) => stack.pop2(Terminal::OrI),
+                Terminal::Thresh(ref thresh) => Terminal::Thresh(stack.pop_thresh(thresh)),
                 Terminal::Multi(ref thresh) => Terminal::Multi(thresh.clone()),
                 Terminal::SortedMulti(ref thresh) => Terminal::SortedMulti(thresh.clone()),
                 Terminal::MultiA(ref thresh) => Terminal::MultiA(thresh.clone()),

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -21,7 +21,7 @@ use {
 };
 
 use crate::expression::{self, FromTree};
-use crate::iter::{Tree, TreeLike};
+use crate::iter::{StackExt as _, Tree, TreeLike};
 use crate::miniscript::types::extra_props::TimelockInfo;
 use crate::prelude::*;
 use crate::sync::Arc;
@@ -710,7 +710,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         use Policy::*;
 
         let mut translated = vec![];
-        for data in self.rtl_post_order_iter() {
+        for data in self.post_order_iter() {
             let new_policy = match data.node {
                 Unsatisfiable => Unsatisfiable,
                 Trivial => Trivial,
@@ -721,12 +721,13 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                 Hash160(ref h) => t.hash160(h).map(Hash160)?,
                 Older(ref n) => Older(*n),
                 After(ref n) => After(*n),
-                And(ref subs) => And((0..subs.len()).map(|_| translated.pop().unwrap()).collect()),
+                And(ref subs) => And(translated.pop_n(subs.len()).collect()),
                 Or(ref subs) => Or(subs
                     .iter()
-                    .map(|(prob, _)| (*prob, translated.pop().unwrap()))
+                    .map(|(prob, _)| *prob)
+                    .zip(translated.pop_n(subs.len()))
                     .collect()),
-                Thresh(ref thresh) => Thresh(thresh.map_ref(|_| translated.pop().unwrap())),
+                Thresh(ref thresh) => Thresh(translated.pop_thresh(thresh)),
             };
             translated.push(Arc::new(new_policy));
         }
@@ -741,17 +742,16 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         use Policy::*;
 
         let mut translated = vec![];
-        for data in Arc::new(self).rtl_post_order_iter() {
+        for data in Arc::new(self).post_order_iter() {
             let new_policy = match data.node.as_ref() {
                 Self::Key(ref k) if k.clone() == *key => Some(Self::Unsatisfiable),
-                And(ref subs) => {
-                    Some(And((0..subs.len()).map(|_| translated.pop().unwrap()).collect()))
-                }
+                And(ref subs) => Some(And(translated.pop_n(subs.len()).collect())),
                 Or(ref subs) => Some(Or(subs
                     .iter()
-                    .map(|(prob, _)| (*prob, translated.pop().unwrap()))
+                    .map(|(prob, _)| *prob)
+                    .zip(translated.pop_n(subs.len()))
                     .collect())),
-                Thresh(ref thresh) => Some(Thresh(thresh.map_ref(|_| translated.pop().unwrap()))),
+                Thresh(ref thresh) => Some(Thresh(translated.pop_thresh(thresh))),
                 _ => None,
             };
             match new_policy {
@@ -829,7 +829,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         use Policy::*;
 
         let mut infos = vec![];
-        for data in self.rtl_post_order_iter() {
+        for data in self.post_order_iter() {
             let info = match data.node {
                 Self::After(ref t) => TimelockInfo {
                     csv_with_height: false,
@@ -846,15 +846,15 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                     contains_combination: false,
                 },
                 And(ref subs) => {
-                    let iter = (0..subs.len()).map(|_| infos.pop().unwrap());
+                    let iter = infos.pop_n(subs.len());
                     TimelockInfo::combine_threshold(subs.len(), iter)
                 }
                 Or(ref subs) => {
-                    let iter = (0..subs.len()).map(|_| infos.pop().unwrap());
+                    let iter = infos.pop_n(subs.len());
                     TimelockInfo::combine_threshold(1, iter)
                 }
                 Thresh(ref thresh) => {
-                    let iter = (0..thresh.n()).map(|_| infos.pop().unwrap());
+                    let iter = infos.pop_n(thresh.n());
                     TimelockInfo::combine_threshold(thresh.k(), iter)
                 }
                 _ => TimelockInfo::default(),
@@ -886,32 +886,32 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         use Policy::*;
 
         let mut acc = vec![];
-        for data in self.rtl_post_order_iter() {
+        for data in self.post_order_iter() {
             let new = match data.node {
                 Unsatisfiable | Trivial | Key(_) => (true, true),
                 Sha256(_) | Hash256(_) | Ripemd160(_) | Hash160(_) | After(_) | Older(_) => {
                     (false, true)
                 }
                 And(ref subs) => {
-                    let (atleast_one_signed, all_non_mall) = (0..subs.len())
-                        .map(|_| acc.pop().unwrap())
+                    let (atleast_one_signed, all_non_mall) = acc
+                        .pop_n(subs.len())
                         .fold((false, true), |acc, x: (bool, bool)| (acc.0 || x.0, acc.1 && x.1));
                     (atleast_one_signed, all_non_mall)
                 }
                 Or(ref subs) => {
-                    let (all_signed, atleast_one_signed, all_non_mall) = (0..subs.len())
-                        .map(|_| acc.pop().unwrap())
-                        .fold((true, false, true), |acc, x| {
+                    let (all_signed, atleast_one_signed, all_non_mall) =
+                        acc.pop_n(subs.len()).fold((true, false, true), |acc, x| {
                             (acc.0 && x.0, acc.1 || x.0, acc.2 && x.1)
                         });
                     (all_signed, atleast_one_signed && all_non_mall)
                 }
                 Thresh(ref thresh) => {
-                    let (signed_count, non_mall_count) = (0..thresh.n())
-                        .map(|_| acc.pop().unwrap())
-                        .fold((0, 0), |(signed_count, non_mall_count), (signed, non_mall)| {
+                    let (signed_count, non_mall_count) = acc.pop_n(thresh.n()).fold(
+                        (0, 0),
+                        |(signed_count, non_mall_count), (signed, non_mall)| {
                             (signed_count + signed as usize, non_mall_count + non_mall as usize)
-                        });
+                        },
+                    );
                     (
                         signed_count >= (thresh.n() - thresh.k() + 1),
                         non_mall_count == thresh.n() && signed_count >= (thresh.n() - thresh.k()),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -21,7 +21,7 @@ pub mod semantic;
 pub use self::concrete::Policy as Concrete;
 pub use self::semantic::Policy as Semantic;
 use crate::descriptor::Descriptor;
-use crate::iter::TreeLike as _;
+use crate::iter::{StackExt as _, TreeLike as _};
 use crate::miniscript::{Miniscript, ScriptContext};
 use crate::sync::Arc;
 #[cfg(all(not(feature = "std"), not(test)))]
@@ -114,7 +114,7 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Miniscript<Pk, Ctx>
         self.lift_check()?;
 
         let mut stack = vec![];
-        for item in self.rtl_post_order_iter() {
+        for item in self.post_order_iter() {
             let new_term = match item.node.node {
                 Terminal::PkK(ref pk) | Terminal::PkH(ref pk) => {
                     Arc::new(Semantic::Key(pk.clone()))
@@ -137,24 +137,20 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Liftable<Pk> for Miniscript<Pk, Ctx>
                 | Terminal::Verify(..)
                 | Terminal::NonZero(..)
                 | Terminal::ZeroNotEqual(..) => stack.pop().unwrap(),
-                Terminal::AndV(..) | Terminal::AndB(..) => Arc::new(Semantic::Thresh(
-                    Threshold::and(stack.pop().unwrap(), stack.pop().unwrap()),
-                )),
-                Terminal::AndOr(..) => Arc::new(Semantic::Thresh(Threshold::or(
-                    Arc::new(Semantic::Thresh(Threshold::and(
-                        stack.pop().unwrap(),
-                        stack.pop().unwrap(),
-                    ))),
-                    stack.pop().unwrap(),
-                ))),
-                Terminal::OrB(..) | Terminal::OrD(..) | Terminal::OrC(..) | Terminal::OrI(..) => {
+                Terminal::AndV(..) | Terminal::AndB(..) => {
+                    stack.pop2(|a, b| Arc::new(Semantic::Thresh(Threshold::and(a, b))))
+                }
+                Terminal::AndOr(..) => stack.pop3(|a, b, c| {
                     Arc::new(Semantic::Thresh(Threshold::or(
-                        stack.pop().unwrap(),
-                        stack.pop().unwrap(),
+                        Arc::new(Semantic::Thresh(Threshold::and(a, b))),
+                        c,
                     )))
+                }),
+                Terminal::OrB(..) | Terminal::OrD(..) | Terminal::OrC(..) | Terminal::OrI(..) => {
+                    stack.pop2(|a, b| Arc::new(Semantic::Thresh(Threshold::or(a, b))))
                 }
                 Terminal::Thresh(ref thresh) => {
-                    Arc::new(Semantic::Thresh(thresh.map_ref(|_| stack.pop().unwrap())))
+                    Arc::new(Semantic::Thresh(stack.pop_thresh(thresh)))
                 }
                 Terminal::Multi(ref thresh) | Terminal::SortedMulti(ref thresh) => {
                     Arc::new(Semantic::Thresh(

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -10,7 +10,7 @@ use core::{cmp, fmt, str};
 use bitcoin::{absolute, relative};
 
 use super::ENTAILMENT_MAX_TERMINALS;
-use crate::iter::{Tree, TreeLike};
+use crate::iter::{StackExt as _, Tree, TreeLike};
 use crate::prelude::*;
 use crate::sync::Arc;
 use crate::{
@@ -152,7 +152,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
         use Policy::*;
 
         let mut translated = vec![];
-        for data in self.rtl_post_order_iter() {
+        for data in self.post_order_iter() {
             let new_policy = match data.node {
                 Unsatisfiable => Unsatisfiable,
                 Trivial => Trivial,
@@ -163,7 +163,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                 Hash160(ref h) => t.hash160(h).map(Hash160)?,
                 Older(ref n) => Older(*n),
                 After(ref n) => After(*n),
-                Thresh(ref thresh) => Thresh(thresh.map_ref(|_| translated.pop().unwrap())),
+                Thresh(ref thresh) => Thresh(translated.pop_thresh(thresh)),
             };
             translated.push(Arc::new(new_policy));
         }
@@ -212,9 +212,9 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     // Helper function to compute the number of constraints in policy.
     fn n_terminals(&self) -> usize {
         let mut n_terminals = vec![];
-        for data in self.rtl_post_order_iter() {
+        for data in self.post_order_iter() {
             let num = match data.node {
-                Self::Thresh(thresh) => (0..thresh.n()).map(|_| n_terminals.pop().unwrap()).sum(),
+                Self::Thresh(thresh) => n_terminals.pop_n(thresh.n()).sum(),
                 Self::Trivial | Self::Unsatisfiable => 0,
                 _leaf => 1,
             };
@@ -928,7 +928,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// that are not satisfied at the given `age`.
     pub fn at_age(self, age: relative::LockTime) -> Self {
         let mut at_age = vec![];
-        for data in Arc::new(self).rtl_post_order_iter() {
+        for data in Arc::new(self).post_order_iter() {
             let new_policy = match data.node.as_ref() {
                 Self::Older(ref t) => {
                     if relative::LockTime::from(*t).is_implied_by(age) {
@@ -937,9 +937,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                         Some(Self::Unsatisfiable)
                     }
                 }
-                Self::Thresh(ref thresh) => {
-                    Some(Self::Thresh(thresh.map_ref(|_| at_age.pop().unwrap())))
-                }
+                Self::Thresh(ref thresh) => Some(Self::Thresh(at_age.pop_thresh(thresh))),
                 _ => None,
             };
             match new_policy {
@@ -958,7 +956,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// that are not satisfied at the given `n` (`n OP_CHECKLOCKTIMEVERIFY`).
     pub fn at_lock_time(self, n: absolute::LockTime) -> Self {
         let mut at_age = vec![];
-        for data in Arc::new(self).rtl_post_order_iter() {
+        for data in Arc::new(self).post_order_iter() {
             let new_policy = match data.node.as_ref() {
                 Self::After(t) => {
                     if absolute::LockTime::from(*t).is_implied_by(n) {
@@ -967,9 +965,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                         Some(Self::Unsatisfiable)
                     }
                 }
-                Self::Thresh(ref thresh) => {
-                    Some(Self::Thresh(thresh.map_ref(|_| at_age.pop().unwrap())))
-                }
+                Self::Thresh(ref thresh) => Some(Self::Thresh(at_age.pop_thresh(thresh))),
                 _ => None,
             };
             match new_policy {
@@ -1000,7 +996,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// Returns `None` if the policy is not satisfiable.
     pub fn minimum_n_keys(&self) -> Option<usize> {
         let mut minimum_n_keys = vec![];
-        for data in self.rtl_post_order_iter() {
+        for data in self.post_order_iter() {
             let minimum_n_key = match data.node {
                 Self::Unsatisfiable => None,
                 Self::Trivial
@@ -1012,8 +1008,9 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
                 | Self::Hash160(..) => Some(0),
                 Self::Key(..) => Some(1),
                 Self::Thresh(ref thresh) => {
-                    let mut sublens = (0..thresh.n())
-                        .filter_map(|_| minimum_n_keys.pop().unwrap())
+                    let mut sublens = minimum_n_keys
+                        .pop_n(thresh.n())
+                        .flatten()
                         .collect::<Vec<usize>>();
                     if sublens.len() < thresh.k() {
                         // Not enough branches are satisfiable
@@ -1039,10 +1036,10 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     /// implemented.
     pub fn sorted(self) -> Self {
         let mut sorted = vec![];
-        for data in Arc::new(self).rtl_post_order_iter() {
+        for data in Arc::new(self).post_order_iter() {
             let new_policy = match data.node.as_ref() {
                 Self::Thresh(ref thresh) => {
-                    let mut new_thresh = thresh.map_ref(|_| sorted.pop().unwrap());
+                    let mut new_thresh = sorted.pop_thresh(thresh);
                     new_thresh.data_mut().sort();
                     Some(Self::Thresh(new_thresh))
                 }


### PR DESCRIPTION
First commit is the actual conversion.

Second commit with the Ext trait can be dropped, but I didn't want to
ruin the readability of Terminal mappings.

Closes #1022