### PR TITLE
Manual weekly update to rustc (to nightly-2026-08-14)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ members = ["fuzz"]
 exclude = ["embedded", "bitcoind-tests"]
 
 [workspace.metadata.rbmt.toolchains]
-nightly = "nightly-2026-07-24"
+nightly = "nightly-2026-08-14"
 stable = "1.95.0"
 
 [workspace.lints.clippy]

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -5,7 +5,7 @@
 //! Optimizing compiler from concrete policies to Miniscript
 //!
 
-use core::{cmp, f64, fmt, hash, mem};
+use core::{cmp, fmt, hash, mem};
 #[cfg(feature = "std")]
 use std::error;
 


### PR DESCRIPTION
Supersedes https://github.com/rust-bitcoin/rust-miniscript/pull/1024

Drops unused core f64 import for rust primitive to fix lint error 