### PR TITLE
12.x: Bump version to 12.3.8

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.7"
+version = "12.3.8"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.7"
+version = "12.3.8"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniscript"
-version = "12.3.7"
+version = "12.3.8"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>, Sanket Kanjalkar <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/rust-bitcoin/rust-miniscript/"


### PR DESCRIPTION
Bumps the 12.x branch version to 12.3.8 for a new release including the fixes #867 and #1011.