### PR TITLE
fix(miniscript): compare thresh k and tree size in Terminal Eq/Ord

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1264,6 +1264,25 @@ mod tests {
     }
 
     #[test]
+    fn descriptor_eq_distinguishes_thresh_policies() {
+        let two_of_two = Descriptor::<String>::from_str("wsh(thresh(2,pk(A),s:pk(B)))").unwrap();
+        let one_of_two = Descriptor::<String>::from_str("wsh(thresh(1,pk(A),s:pk(B)))").unwrap();
+        let two_of_three =
+            Descriptor::<String>::from_str("wsh(thresh(2,pk(A),s:pk(B),s:pk(C)))").unwrap();
+
+        assert_ne!(two_of_two, one_of_two);
+        assert_ne!(two_of_two, two_of_three);
+        assert_ne!(two_of_two.cmp(&one_of_two), core::cmp::Ordering::Equal);
+        assert_ne!(two_of_two.cmp(&two_of_three), core::cmp::Ordering::Equal);
+        assert_eq!(two_of_two, two_of_two.clone());
+
+        let mut sorted = vec![two_of_two, one_of_two, two_of_three];
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), 3);
+    }
+
+    #[test]
     fn desc_rtt_tests() {
         roundtrip_descriptor("c:pk_k()");
         roundtrip_descriptor("wsh(pk())");

--- a/src/miniscript/decode.rs
+++ b/src/miniscript/decode.rs
@@ -232,6 +232,11 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> PartialEq for Terminal<Pk, Ctx> {
                 (Self::Hash256(h1), Self::Hash256(h2)) if h1 != h2 => return false,
                 (Self::Ripemd160(h1), Self::Ripemd160(h2)) if h1 != h2 => return false,
                 (Self::Hash160(h1), Self::Hash160(h2)) if h1 != h2 => return false,
+                (Self::Thresh(th1), Self::Thresh(th2))
+                    if th1.k() != th2.k() || th1.n() != th2.n() =>
+                {
+                    return false
+                }
                 (Self::Multi(th1), Self::Multi(th2)) if th1 != th2 => return false,
                 (Self::SortedMulti(th1), Self::SortedMulti(th2)) if th1 != th2 => return false,
                 (Self::MultiA(th1), Self::MultiA(th2)) if th1 != th2 => return false,

--- a/src/miniscript/display.rs
+++ b/src/miniscript/display.rs
@@ -331,7 +331,18 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext> Ord for Terminal<Pk, Ctx> {
             cmp::Ordering::Less => cmp::Ordering::Less,
             cmp::Ordering::Greater => cmp::Ordering::Greater,
             cmp::Ordering::Equal => {
-                // But if they are equal then we need to iterate
+                // But if they are equal then we need to iterate. Compare node
+                // counts first since `zip` stops at the shorter iterator.
+                let me_count = DisplayNode::Node(Type::FALSE, self)
+                    .pre_order_iter()
+                    .count();
+                let you_count = DisplayNode::Node(Type::FALSE, other)
+                    .pre_order_iter()
+                    .count();
+                match me_count.cmp(&you_count) {
+                    cmp::Ordering::Equal => {}
+                    ordering => return ordering,
+                }
                 for (me, you) in DisplayNode::Node(Type::FALSE, self)
                     .pre_order_iter()
                     .zip(DisplayNode::Node(Type::FALSE, other).pre_order_iter())

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -1955,6 +1955,88 @@ mod tests {
     }
 
     #[test]
+    fn terminal_eq_compares_thresh_k_and_child_count() {
+        let two_of_two =
+            Miniscript::<String, Segwitv0>::from_str("thresh(2,pk(A),s:pk(B))").unwrap();
+        let one_of_two =
+            Miniscript::<String, Segwitv0>::from_str("thresh(1,pk(A),s:pk(B))").unwrap();
+        let two_of_three =
+            Miniscript::<String, Segwitv0>::from_str("thresh(2,pk(A),s:pk(B),s:pk(C))").unwrap();
+
+        assert_ne!(two_of_two, one_of_two);
+        assert_ne!(two_of_two, two_of_three);
+        assert_eq!(two_of_two, two_of_two.clone());
+    }
+
+    #[test]
+    fn terminal_eq_ord_hash_are_mutually_consistent() {
+        fn std_hash<T: std::hash::Hash>(t: &T) -> u64 {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            t.hash(&mut hasher);
+            std::hash::Hasher::finish(&hasher)
+        }
+
+        fn parse(s: &str) -> Miniscript<String, Segwitv0> { Miniscript::from_str(s).unwrap() }
+
+        let strings = [
+            "thresh(1,pk(A),s:pk(B))",
+            "thresh(2,pk(A),s:pk(B))",
+            "thresh(2,pk(A),s:pk(B),s:pk(C))",
+            "thresh(2,pk(A),s:pk(C),s:pk(B))",
+            "multi(1,A,B)",
+            "multi(2,A,B)",
+            "multi(1,A,B,C)",
+            "and_v(v:pk(A),pk(B))",
+            "and_v(v:pk(A),and_v(v:pk(B),pk(C)))",
+            "pk(A)",
+            "pk(C)",
+        ];
+        let scripts = strings.map(parse);
+        let scripts_copy = strings.map(parse);
+
+        for (a, b) in scripts.iter().zip(scripts_copy.iter()) {
+            assert_eq!(a, b, "{} vs {}", a, b);
+            assert_eq!(a.cmp(b), cmp::Ordering::Equal, "{} vs {}", a, b);
+            assert_eq!(std_hash(a), std_hash(b), "{} vs {}", a, b);
+        }
+
+        for (i, a) in scripts.iter().enumerate() {
+            for (j, b) in scripts.iter().enumerate() {
+                assert_eq!(a == b, a.cmp(b) == cmp::Ordering::Equal, "{} vs {}", a, b);
+                assert_eq!(a.cmp(b), b.cmp(a).reverse(), "{} vs {}", a, b);
+                if i != j {
+                    assert_ne!(a, b, "{} vs {}", a, b);
+                    assert_ne!(a.cmp(b), cmp::Ordering::Equal, "{} vs {}", a, b);
+                    assert_ne!(std_hash(a), std_hash(b), "{} vs {}", a, b);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn distinct_miniscripts_survive_sorted_and_hashed_collections() {
+        use std::collections::{BTreeSet, HashSet};
+
+        let distinct = [
+            "thresh(1,pk(A),s:pk(B))",
+            "thresh(2,pk(A),s:pk(B))",
+            "thresh(2,pk(A),s:pk(B),s:pk(C))",
+            "multi(1,A,B)",
+            "multi(1,A,B,C)",
+        ]
+        .map(|s| Miniscript::<String, Segwitv0>::from_str(s).unwrap());
+
+        let mut btree: BTreeSet<_> = distinct.iter().cloned().collect();
+        assert_eq!(btree.len(), distinct.len());
+
+        let mut hash: HashSet<_> = distinct.iter().cloned().collect();
+        assert_eq!(hash.len(), distinct.len());
+
+        assert!(!btree.insert(distinct[0].clone()));
+        assert!(!hash.insert(distinct[0].clone()));
+    }
+
+    #[test]
     fn template_timelocks() {
         use crate::{AbsLockTime, RelLockTime};
         let key_present = bitcoin::PublicKey::from_str(


### PR DESCRIPTION
`Terminal::eq` never compared the `k` threshold or child count of `Thresh` fragments (they fell into the discriminant-only catch-all arm), and both `Terminal::eq` and `Terminal::cmp` zipped the two pre-order iterators without checking that they had the same length. As a result structurally distinct miniscripts could compare equal, and could order `Ordering::Equal`:

```
thresh(2,pk(A),s:pk(B)) == thresh(1,pk(A),s:pk(B))
thresh(2,pk(A),s:pk(B)) == thresh(2,pk(A),s:pk(B),s:pk(C))
```

while hashing differently (`Hash` includes `k` and the child count), violating the Eq/Hash and Eq/Ord contracts for `Miniscript`, `Descriptor` and `TapTree`, which all delegate to these impls, and corrupting sorted and hashed collections of descriptors in downstream users.

**Fix:** compare the number of pre-order nodes up front in both impls (a tree now orders before any tree it is a strict pre-order prefix of), and compare the `Thresh` threshold `k` and child count in `eq`.

**Tests:** regression tests cover `thresh` differing in `k`/child count, mutual Eq/Ord/Hash consistency (including antisymmetry and cross-instance equality) over a list of structurally distinct scripts, survival of distinct scripts in `BTreeSet`/`HashSet`, and descriptor-level equality/sort+dedup. All fail without the fix.
