### PR TITLE
13.x: descriptor: fix taproot tree formatting

### DIFF
--- a/src/descriptor/tr/mod.rs
+++ b/src/descriptor/tr/mod.rs
@@ -528,20 +528,30 @@ mod tests {
 
     use super::*;
 
+    fn strip_ws(desc: &str) -> String { desc.replace(&[' ', '\n'][..], "") }
+
     fn descriptor() -> String {
         let desc = "tr(acc0, {
-            multi_a(3, acc10, acc11, acc12), {
+            {
+              multi_a(3, acc10, acc11, acc12),
               and_v(
                 v:multi_a(2, acc10, acc11, acc12),
                 after(10)
-              ),
-              and_v(
-                v:multi_a(1, acc10, acc11, ac12),
-                after(100)
               )
-            }
+            },
+            and_v(
+              v:multi_a(1, acc10, acc11, ac12),
+              after(100)
+            )
          })";
-        desc.replace(&[' ', '\n'][..], "")
+        strip_ws(desc)
+    }
+
+    fn assert_display_roundtrip(desc: &str) {
+        let desc = strip_ws(desc);
+        let tr = Tr::<String>::from_str(&desc).unwrap();
+        assert_eq!(format!("{:#}", tr), desc);
+        Tr::<String>::from_str(&tr.to_string()).unwrap();
     }
 
     #[test]
@@ -550,6 +560,13 @@ mod tests {
         let tr = Tr::<String>::from_str(&desc).unwrap();
         // Note the last ac12 only has ac and fails the predicate
         assert!(!tr.for_each_key(|k| k.starts_with("acc")));
+    }
+
+    #[test]
+    fn display_roundtrips_unbalanced_taptree() {
+        assert_display_roundtrip(&descriptor());
+        assert_display_roundtrip("tr(acc0,{pk(acc1),{pk(acc2),pk(acc3)}})");
+        assert_display_roundtrip("tr(acc0,{{pk(acc1),pk(acc2)},{pk(acc3),pk(acc4)}})");
     }
 
     #[test]

--- a/src/descriptor/tr/taptree.rs
+++ b/src/descriptor/tr/taptree.rs
@@ -89,27 +89,34 @@ fn fmt_helper<Pk: MiniscriptKey>(
     f: &mut fmt::Formatter,
     mut fmt_ms: impl FnMut(&mut fmt::Formatter, &Miniscript<Pk, Tap>) -> fmt::Result,
 ) -> fmt::Result {
-    let mut last_depth = 0;
+    let mut child_counts = Vec::<u8>::with_capacity(TAPROOT_CONTROL_MAX_NODE_COUNT);
+
     for item in view.leaves() {
-        if last_depth > 0 {
+        let depth = usize::from(item.depth());
+
+        if !child_counts.is_empty() {
             f.write_str(",")?;
         }
 
-        while last_depth < item.depth() {
+        while child_counts.len() < depth {
             f.write_str("{")?;
-            last_depth += 1;
+            child_counts.push(0);
         }
+
         fmt_ms(f, item.miniscript())?;
-        while last_depth > item.depth() {
+
+        if let Some(child_count) = child_counts.last_mut() {
+            *child_count += 1;
+        }
+        while let Some(2) = child_counts.last() {
             f.write_str("}")?;
-            last_depth -= 1;
+            child_counts.pop();
+            if let Some(child_count) = child_counts.last_mut() {
+                *child_count += 1;
+            }
         }
     }
 
-    while last_depth > 0 {
-        f.write_str("}")?;
-        last_depth -= 1;
-    }
     Ok(())
 }
 

--- a/src/descriptor/tr/taptree.rs
+++ b/src/descriptor/tr/taptree.rs
@@ -289,7 +289,10 @@ impl<Pk: MiniscriptKey> TapTreeBuilder<Pk> {
     }
 
     #[inline]
-    pub(super) fn finalize(self) -> TapTree<Pk> { TapTree { depths_leaves: self.depths_leaves } }
+    pub(super) fn finalize(self) -> TapTree<Pk> {
+        assert!(!self.depths_leaves.is_empty(), "TapTreeBuilder must not finalize an empty tree");
+        TapTree { depths_leaves: self.depths_leaves }
+    }
 }
 
 #[cfg(test)]

--- a/src/descriptor/tr/taptree.rs
+++ b/src/descriptor/tr/taptree.rs
@@ -291,3 +291,28 @@ impl<Pk: MiniscriptKey> TapTreeBuilder<Pk> {
     #[inline]
     pub(super) fn finalize(self) -> TapTree<Pk> { TapTree { depths_leaves: self.depths_leaves } }
 }
+
+#[cfg(test)]
+mod tests {
+    use core::str::FromStr;
+
+    use super::*;
+
+    fn leaf(ms: &str) -> TapTree<String> {
+        TapTree::leaf(Arc::new(Miniscript::<String, Tap>::from_str(ms).unwrap()))
+    }
+
+    #[test]
+    fn display_single_leaf_taptree() {
+        let tree = leaf("pk(A)");
+
+        assert_eq!(format!("{}", tree), "pk(A)");
+    }
+
+    #[test]
+    fn debug_binary_taptree() {
+        let tree = TapTree::combine(leaf("pk(A)"), leaf("pk(B)")).unwrap();
+
+        assert_eq!(format!("{:?}", tree), "{[B/onduesm]pk(\"A\"),[B/onduesm]pk(\"B\")}");
+    }
+}


### PR DESCRIPTION
Commit 552e8440 ("tr: flatten TapTree type") changed TapTree from a recursive enum into a depth-preorder leaf list. The formatter only tracked depth changes between adjacent leaves, which loses binary subtree boundaries for some unbalanced trees and can render descriptors that do not parse back.

Format the flat representation with an explicit child-count stack so completed binary subtrees are closed at the right time.

Backport of #953. I literally just `jj duplicate`d the commits without looking at them. May warrant re-review.