### PR TITLE
compiler: reject policy keys invalid in the target script context

### DIFF
--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -12,7 +12,7 @@ use std::error;
 
 use sync::Arc;
 
-use crate::miniscript::context::SigType;
+use crate::miniscript::context::{ScriptContextError, SigType};
 use crate::miniscript::limits::{MAX_PUBKEYS_IN_CHECKSIGADD, MAX_PUBKEYS_PER_MULTISIG};
 use crate::miniscript::types::{self, ErrorKind, Type};
 use crate::miniscript::ScriptContext;
@@ -25,7 +25,7 @@ type PolicyCache<Pk, Ctx> = BTreeMap<
     BTreeMap<CompilationKey, AstElemExt<Pk, Ctx>>,
 >;
 /// Detailed error type for compiler.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum CompilerError {
     /// `And` fragments only support two args.
     NonBinaryArgAnd,
@@ -43,6 +43,9 @@ pub enum CompilerError {
     /// In a Taproot compilation, no "unspendable key" was provided and no in-policy
     /// key could be used as an internal key.
     NoInternalKey,
+    /// A policy key is not valid under the selected script context (e.g. an
+    /// x-only key in Segwit v0 or an uncompressed key in Taproot).
+    ContextError(ScriptContextError),
     /// The selected Taproot internal key is uncompressed.
     UncompressedTaprootInternalKey,
     /// A Huffman merge during Taproot compilation would place a leaf beyond
@@ -79,6 +82,7 @@ impl fmt::Display for CompilerError {
                 "At least one spending path has exceeded the standardness or consensus limits",
             ),
             Self::NoInternalKey => f.write_str("Taproot compilation had no internal key available"),
+            Self::ContextError(ref e) => fmt::Display::fmt(e, f),
             Self::UncompressedTaprootInternalKey => {
                 f.write_str("Taproot compilation selected an uncompressed internal key")
             }
@@ -254,6 +258,7 @@ impl error::Error for CompilerError {
             | TooManyTapleaves { .. }
             | IfFragmentInNativeLeaf { .. } => None,
             PolicyError(e) => Some(e),
+            ContextError(e) => Some(e),
         }
     }
 }
@@ -944,6 +949,10 @@ where
             insert_wrap!(AstElemExt::trivial());
         }
         Concrete::Key(ref pk) => {
+            // The compiler must never produce a Miniscript that is invalid
+            // under the target script context (e.g. an x-only key in Segwit
+            // v0, or an uncompressed key in Taproot).
+            Ctx::check_pk(pk).map_err(CompilerError::ContextError)?;
             insert_wrap!(AstElemExt::pk_h(pk.clone()));
             insert_wrap!(AstElemExt::pk_k(pk.clone()));
         }

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1193,7 +1193,7 @@ mod tests {
     use bitcoin::hashes;
 
     use super::*;
-    use crate::miniscript::{Legacy, Segwitv0, Tap};
+    use crate::miniscript::{BareCtx, Legacy, Segwitv0, Tap};
     use crate::policy::Liftable;
     use crate::{script_num_size, AbsLockTime, RelLockTime, Threshold, ToPublicKey};
 
@@ -1636,5 +1636,42 @@ mod tests {
         );
 
         assert_eq!(miniscript, expected);
+    }
+
+    #[test]
+    fn context_invalid_keys() {
+        // X-only keys are not allowed in Segwitv0, Legacy or Bare contexts;
+        // the compiler must return an error rather than produce an invalid
+        // Miniscript.
+        let x_only_key = "08c0fcf8895f4361b4fc77afe2ad53b0bd27dcebfd863421b2b246dc283d4103";
+        let policy: Concrete<bitcoin::XOnlyPublicKey> = policy_str!("pk({})", x_only_key);
+        assert_eq!(
+            policy.compile::<Segwitv0>(),
+            Err(CompilerError::ContextError(ScriptContextError::XOnlyKeysNotAllowed(
+                x_only_key.to_string(),
+                "Segwitv0"
+            ))),
+        );
+        policy.compile::<Legacy>().unwrap_err();
+        policy.compile::<BareCtx>().unwrap_err();
+        // ..but they are allowed in a Taproot context.
+        policy.compile::<Tap>().unwrap();
+
+        // The same restriction applies to keys compiled into multi fragments.
+        let k2 = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+        let multi_pol: Concrete<bitcoin::XOnlyPublicKey> =
+            policy_str!("thresh(1,pk({}),pk({}))", x_only_key, k2);
+        multi_pol.compile::<Segwitv0>().unwrap_err();
+
+        // Uncompressed keys are not allowed in Segwitv0 or Taproot contexts.
+        let uncompressed = "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8";
+        let policy: Concrete<bitcoin::PublicKey> = policy_str!("pk({})", uncompressed);
+        assert_eq!(
+            policy.compile::<Segwitv0>(),
+            Err(CompilerError::ContextError(ScriptContextError::UncompressedKeysNotAllowed)),
+        );
+        policy.compile::<Tap>().unwrap_err();
+        // ..but they are allowed in a Legacy context.
+        policy.compile::<Legacy>().unwrap();
     }
 }


### PR DESCRIPTION
Supersedes and closes #761.

`Concrete::pk(xonly).compile::<Segwitv0>()` used to panic (`Terminal creation must always succeed`, reported in #761). Since the compiler rewrite (ea221af, part of the recent compiler refactor series), it no longer panics — it **silently returns `Ok`** with a Miniscript that is invalid for the target context, e.g. `wsh(pkh(<32-byte x-only key>))`: a fundable address whose coins can never be spent (a 32-byte key is not a valid segwit-v0 ECDSA pubkey, so `CHECKSIG` can never succeed). Verified end-to-end against Bitcoin Core 26.0 consensus (libbitcoinconsensus): funding succeeds, and the owner's spend with the correct private key and a valid signature is rejected.

The same hole lets uncompressed keys compile under Segwitv0/Tap, and x-only keys under Legacy/Bare.

**Fix:** call `Ctx::check_pk` when compiling `Concrete::Key` fragments — the single point where policy keys become terminals, so `multi`/`multi_a` and all public entry points (`compile`, `compile_to_descriptor`, `compile_tr*`) are covered. Invalid keys now produce `CompilerError::ContextError`, reusing the informative `ScriptContextError` messages from #760. (`CompilerError` loses its `Copy`/`Hash` derives since `ScriptContextError` has neither; nothing in-tree relied on them.)

**Test:** `context_invalid_keys` covers x-only keys under Segwitv0/Legacy/Bare (Err) and Tap (Ok), the `multi` path, and uncompressed keys under Segwitv0/Tap (Err) and Legacy (Ok). Adapted from #761; @shesek is credited as co-author.