### PR TITLE
plan: fix witness size for wsh and sh(wsh), fix scriptSig size of sh(wpkh) and sh(wsh)

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -28,7 +28,7 @@ use crate::descriptor::{self, Descriptor, DescriptorType, KeyMap};
 use crate::miniscript::hash256;
 use crate::miniscript::satisfy::{Placeholder, Satisfier, SchnorrSigType};
 use crate::prelude::*;
-use crate::util::witness_size;
+use crate::util::{varint_len, witness_size};
 use crate::{DefiniteDescriptorKey, DescriptorPublicKey, Error, MiniscriptKey, ToPublicKey};
 
 /// Trait describing a present/missing lookup table for constructing witness templates
@@ -792,10 +792,11 @@ mod test {
         let desc = format!("wsh(t:or_c(pk({}),v:pkh({})))", keys[0], keys[1]);
 
         // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig)
+        // + 1 (witness script len) + 63 (witness script)
         let tests = vec![
             (vec![], vec![], None, None, None),
-            (vec![0], vec![], None, None, Some(4 + 1 + 73)),
-            (vec![0, 1], vec![], None, None, Some(4 + 1 + 73)),
+            (vec![0], vec![], None, None, Some(4 + 1 + 73 + 1 + 63)),
+            (vec![0, 1], vec![], None, None, Some(4 + 1 + 73 + 1 + 63)),
         ];
 
         test_inner(&desc, keys, hashes, tests);
@@ -817,10 +818,11 @@ mod test {
         let desc = format!("wsh(and_v(v:pk({}),pk({})))", keys[0], keys[1]);
 
         // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 2
+        // + 1 (witness script len) + 70 (witness script)
         let tests = vec![
             (vec![], vec![], None, None, None),
             (vec![0], vec![], None, None, None),
-            (vec![0, 1], vec![], None, None, Some(4 + 1 + 73 * 2)),
+            (vec![0, 1], vec![], None, None, Some(4 + 1 + 73 * 2 + 1 + 70)),
         ];
 
         test_inner(&desc, keys, hashes, tests);
@@ -853,7 +855,8 @@ mod test {
             (vec![], vec![], None, None, None),
             (vec![0, 1], vec![], None, None, None),
             // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 3 + 1 (dummy push)
-            (vec![0, 1, 3], vec![], None, None, Some(4 + 1 + 73 * 3 + 1)),
+            // + 1 (witness script len) + 139 (witness script)
+            (vec![0, 1, 3], vec![], None, None, Some(4 + 1 + 73 * 3 + 1 + 1 + 139)),
         ];
 
         test_inner(&desc, keys, hashes, tests);
@@ -887,24 +890,28 @@ mod test {
             ),
             (vec![0], vec![], None, None, None),
             // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) + 1 (OP_0) + 1 (OP_ZERO)
+            // + 1 (witness script len) + 85 (witness script)
             (
                 vec![0],
                 vec![],
                 Some(Sequence(1000).to_relative_lock_time().unwrap()),
                 None,
-                Some(80),
+                Some(166),
             ),
             // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 2 + 2 (OP_PUSHBYTE_1 0x01)
-            (vec![0, 1], vec![], None, None, Some(153)),
+            // + 1 (witness script len) + 85 (witness script)
+            (vec![0, 1], vec![], None, None, Some(239)),
             // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) + 1 (OP_0) + 1 (OP_ZERO)
+            // + 1 (witness script len) + 85 (witness script)
             (
                 vec![0, 1],
                 vec![],
                 Some(Sequence(1000).to_relative_lock_time().unwrap()),
                 None,
-                Some(80),
+                Some(166),
             ),
             // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 2 + 2 (OP_PUSHBYTE_1 0x01)
+            // + 1 (witness script len) + 85 (witness script)
             (
                 vec![0, 1],
                 vec![],
@@ -914,7 +921,7 @@ mod test {
                         .unwrap(),
                 ),
                 None,
-                Some(153),
+                Some(239),
             ), // incompatible timelock
         ];
 
@@ -924,20 +931,22 @@ mod test {
 
         let tests = vec![
             // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) + 1 (OP_0) + 1 (OP_ZERO)
+            // + 1 (witness script len) + 85 (witness script)
             (
                 vec![0],
                 vec![],
                 None,
                 Some(absolute::LockTime::from_height(1000).unwrap()),
-                Some(80),
+                Some(166),
             ),
             // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) * 2 + 2 (OP_PUSHBYTE_1 0x01)
+            // + 1 (witness script len) + 85 (witness script)
             (
                 vec![0, 1],
                 vec![],
                 None,
                 Some(absolute::LockTime::from_time(500_001_000).unwrap()),
-                Some(153),
+                Some(239),
             ), // incompatible timelock
         ];
 
@@ -1081,7 +1090,8 @@ mod test {
             (vec![], vec![0], None, None, None),
             // Key + hash
             // expected weight: 4 (scriptSig len) + 1 (witness len) + 73 (sig) + 1 (OP_PUSH) + 32 (preimage)
-            (vec![0], vec![0], None, None, Some(111)),
+            // + 1 (witness script len) + 62 (witness script)
+            (vec![0], vec![0], None, None, Some(174)),
         ];
 
         test_inner(&desc, keys, hashes, tests);
@@ -1259,5 +1269,70 @@ mod test {
         .unwrap();
 
         assert!(desc.into_plan(&assets).is_err());
+    }
+
+    /// A [`Satisfier`] that knows hash preimages only.
+    ///
+    /// A plan sizes a signature at its 73-byte maximum while a real one varies
+    /// in length, so a spend path that carries no signature is the one whose
+    /// witness has a size a plan can be held to byte for byte.
+    struct Preimages(BTreeMap<sha256::Hash, [u8; 32]>);
+
+    impl Satisfier<DefiniteDescriptorKey> for Preimages {
+        fn lookup_sha256(&self, h: &sha256::Hash) -> Option<[u8; 32]> { self.0.get(h).copied() }
+    }
+
+    #[test]
+    fn sizes_match_satisfaction() {
+        use bitcoin::hashes::Hash as _;
+
+        let preimages = [[1u8; 32], [2u8; 32]];
+        let hashes = preimages.map(|p| sha256::Hash::hash(&p));
+        let satisfier = Preimages(hashes.iter().copied().zip(preimages).collect());
+        let assets = Assets::new().add(hashes[0]).add(hashes[1]);
+
+        // Sigless, so it has to go around the sanity checks of `from_str`.
+        let ms = Miniscript::<DefiniteDescriptorKey, Segwitv0>::from_str_insane(&format!(
+            "and_v(v:sha256({}),sha256({}))",
+            hashes[0], hashes[1]
+        ))
+        .unwrap();
+
+        for desc in [
+            Descriptor::new_wsh(ms.clone()).unwrap(),
+            Descriptor::new_sh_wsh(ms).unwrap(),
+        ] {
+            let max_weight = desc.max_weight_to_satisfy().unwrap().to_wu() as usize;
+            let plan = desc.into_plan(&assets).unwrap();
+            let (witness, script_sig) = plan.satisfy(&satisfier).unwrap();
+
+            // The witness as it goes on the wire: an element count followed by
+            // length-prefixed elements, the witness script among them.
+            let witness = bitcoin::Witness::from_slice(&witness);
+            assert_eq!(plan.witness_size(), bitcoin::consensus::serialize(&witness).len());
+            assert_eq!(plan.scriptsig_size(), varint_len(script_sig.len()) + script_sig.len());
+
+            // `max_weight_to_satisfy` is the weight that satisfying adds to an
+            // input, so it leaves out the scriptSig length byte (4 WU) and the
+            // witness count byte (1 WU) that an unsatisfied input carries too.
+            // The plan reports the absolute size, so it is larger by exactly those.
+            assert_eq!(plan.satisfaction_weight(), max_weight + 4 + 1);
+        }
+
+        // sh(wpkh) needs a signature, whose real size varies, so only what a plan
+        // can be held to exactly is checked: the scriptSig it returns, and the
+        // relation to `max_weight_to_satisfy`, which sizes a signature the way the
+        // plan does.
+        let key = DescriptorPublicKey::from_str(
+            "02c2fd50ceae468857bb7eb32ae9cd4083e6c7e42fbbec179d81134b3e3830586c",
+        )
+        .unwrap();
+        let desc =
+            Descriptor::<DefiniteDescriptorKey>::from_str(&format!("sh(wpkh({}))", key)).unwrap();
+        let max_weight = desc.max_weight_to_satisfy().unwrap().to_wu() as usize;
+        let script_sig = desc.unsigned_script_sig();
+        let plan = desc.into_plan(&Assets::new().add(key)).unwrap();
+        assert_eq!(plan.scriptsig_size(), varint_len(script_sig.len()) + script_sig.len());
+        assert_eq!(plan.satisfaction_weight(), max_weight + 4 + 1);
     }
 }


### PR DESCRIPTION
This fixes two size estimation bugs I found while doing LLM-assisted review on https://github.com/btcsuite/btcd/pull/2568.

Since I'm no Rust developer (though I'm learning a lot recently), the code was written by Claude Fable. But every line is carefully reviewed by myself and the commits have already gone through several revisions locally to make them as clean and easy to review as possible.

## Fix 1: count the witness script in `witness_size` for `wsh` and `sh(wsh)`

This seems to be a bug introduced by #897: the witness script was added to the witness stack, but the count in `witness_size` was not updated.
This leads to serious underestimation of witness size, which in case of large scripts can cause you to run into the minimum relay fee rate limit if you're targeting a very low fee.

## Fix 2: fix the scriptSig size in `scriptsig_size` for `sh(wpkh)` and `sh(wsh)`

This fixes an off-by-one in the `script_size` for the nested segwit p2sh cases. This is a tricky one, since it's two layers of data. The outer one (the payload that is the preimage of the _hash_) and the inner one (which is the output script as it would go into a native witness output).

Here's an attempt to visualize it a bit better:

```text
  sh(wsh(pk(K)))                                  sh(wpkh(K))
  23        var-int: scriptSig is 35 bytes        17        var-int: 23 bytes
    22      OP_PUSHBYTES_34                         16      OP_PUSHBYTES_22
      00    OP_0            (witness version 0)       00    OP_0
      20    OP_PUSHBYTES_32                           14    OP_PUSHBYTES_20
      <32>  SHA256(witnessScript)                     <20>  HASH160(pubkey)
            ──────────────                                  ──────────────
            redeemScript = 34 bytes                         redeemScript = 22 bytes
            content 35, on-wire 36                          content 23, on-wire 24

```

Again, this only affects size (fee) estimation.