### PR TITLE
 ci: consolidate rbmt version configuration and align local workflows

### DIFF
--- a/.github/actions/setup-rbmt/action.yml
+++ b/.github/actions/setup-rbmt/action.yml
@@ -8,10 +8,8 @@ runs:
       shell: bash
       run: |
         cargo install \
-          --git https://git.rust-bitcoin.org/rust-bitcoin/rust-bitcoin-maintainer-tools \
-          --rev "$(cat rbmt-version)" \
-          cargo-rbmt \
-          --locked
+          --locked \
+          "cargo-rbmt@$(grep '^rbmt\.version' Cargo.toml | cut -d'"' -f2)"
 
     - name: "Install Rust toolchains via cargo-rbmt"
       shell: bash

--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install cargo-rbmt
-        run: cargo install --git https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git --rev $(cat rbmt-version) cargo-rbmt --locked
+        run: cargo install --locked "cargo-rbmt@$(grep '^rbmt\.version' Cargo.toml | cut -d'"' -f2)"
       - name: Update nightly toolchain in Cargo.toml
         run: |
           cargo rbmt toolchains --update-nightly

--- a/.github/workflows/cron-weekly-update-rbmt.yml
+++ b/.github/workflows/cron-weekly-update-rbmt.yml
@@ -21,15 +21,14 @@ jobs:
           git clone --filter=blob:none --no-checkout \
             https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git /tmp/rbmt
           LATEST_TAG=$(git -C /tmp/rbmt tag --sort=-version:refname | grep '^cargo-rbmt-' | head -1)
-          LATEST_HASH=$(git -C /tmp/rbmt rev-parse "${LATEST_TAG}^{}")
-          CURRENT_HASH=$(cat rbmt-version)
-          if [ -n "${LATEST_HASH}" ] && [ "${LATEST_HASH}" != "${CURRENT_HASH}" ]; then
-            echo "${LATEST_HASH}" > rbmt-version
-            echo "rbmt_hash=${LATEST_HASH}" >> "${GITHUB_ENV}"
-            echo "rbmt_semver=${LATEST_TAG#cargo-rbmt-}" >> "${GITHUB_ENV}"
+          LATEST_VERSION=${LATEST_TAG#cargo-rbmt-}
+          CURRENT_VERSION=$(grep '^rbmt\.version' Cargo.toml | cut -d'"' -f2)
+          if [ -n "${LATEST_VERSION}" ] && [ "${LATEST_VERSION}" != "${CURRENT_VERSION}" ]; then
+            sed -i "s/^rbmt\.version = .*/rbmt.version = \"${LATEST_VERSION}\"/" Cargo.toml
+            echo "rbmt_semver=${LATEST_VERSION}" >> "${GITHUB_ENV}"
             echo "changes_made=true" >> "${GITHUB_ENV}"
           else
-            echo "rbmt-version is already at the latest release. Not opening any PR."
+            echo "rbmt version is already at the latest release. Not opening any PR."
             echo "changes_made=false" >> "${GITHUB_ENV}"
           fi
       - name: Create Pull Request
@@ -41,6 +40,6 @@ jobs:
           committer: Update RBMT Bot <bot@example.com>
           title: Automated weekly update to cargo-rbmt (to ${{ env.rbmt_semver }})
           body: |
-            Automated update to rbmt-version by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+            Automated update to Cargo.toml workspace metadata by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
           commit-message: Automated update to cargo-rbmt-${{ env.rbmt_semver }}
           branch: create-pull-request/weekly-rbmt-update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,9 @@ workspace = true
 members = ["fuzz"]
 exclude = ["embedded", "bitcoind-tests"]
 
+[workspace.metadata]
+rbmt.version = "0.5.3"
+
 [workspace.metadata.rbmt.toolchains]
 nightly = "nightly-2026-08-21"
 stable = "1.95.0"

--- a/justfile
+++ b/justfile
@@ -15,19 +15,19 @@ lint:
 
 # Run the formatter.
 fmt:
-  cargo +nightly fmt
+  cargo rbmt fmt
 
 # Check the formatting.
 fmt-check:
-  cargo +nightly fmt --check
+  cargo rbmt fmt --check
 
 # Run the benchmark suite.
 bench:
-  RUSTFLAGS='--cfg=bench' cargo +nightly bench benchmarks
+  RUSTFLAGS='--cfg=bench' cargo rbmt run --toolchain nightly -- bench benchmarks
 
 # Build the docs (same as for docs.rs).
 docsrs:
-  RUSTDOCFLAGS="--cfg docsrs" cargo +nightly rustdoc --all-features -- -D rustdoc::broken-intra-doc-links
+  cargo rbmt docs
 
 # Quick and dirty CI useful for pre-push checks.
 sane: fmt-check lint

--- a/rbmt-version
+++ b/rbmt-version
@@ -1,1 +1,0 @@
-1c7c7d9d49addb2e44ec044d337ec5ccb1e14c08


### PR DESCRIPTION
  Closes #945
  
 - Moved the cargo-rbmt version pin into Cargo.toml so rbmt can check that the installed version matches the repository’s configuration.  Update CI installation and weekly automation to read this pin, then remove rbmt-version.

 - Route local formatting, docs and benchmarks through rbmt to use the same pinned toolchain and defaults as CI. Keep the existing lockfile helper because rbmt’s lock command changes dependency-resolution behavior.

-  Validated formatting, docs, benchmark compilation, workflow syntax and updater behavior.

